### PR TITLE
Fix battle completion modal visibility

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -201,22 +201,26 @@
 }
 
 #complete-message {
-  width: 420px;
-  background: #ffffff;
-  border-radius: 8px;
-  padding: 24px;
-  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.25);
-  text-align: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
   display: flex;
-  flex-direction: column;
   align-items: center;
-  gap: 24px;
-  animation: pop-in 0.4s ease-out;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.3);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  z-index: 50;
 }
 
 #complete-message.show {
   opacity: 1;
   visibility: visible;
+  pointer-events: auto;
 }
 
 #complete-message .btn-primary {

--- a/html/battle.html
+++ b/html/battle.html
@@ -83,7 +83,14 @@
         <button type="button">Submit</button>
       </div>
     </div>
-    <div id="complete-message" role="dialog" aria-modal="true" aria-labelledby="battle-complete-title">
+    <div
+      id="complete-message"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="battle-complete-title"
+      aria-hidden="true"
+      tabindex="-1"
+    >
       <section class="battle-card battle-complete-card">
         <div class="battle-info">
           <p id="battle-complete-title" class="battle-title">Battle Complete</p>

--- a/js/battle.js
+++ b/js/battle.js
@@ -776,6 +776,9 @@ document.addEventListener('DOMContentLoaded', () => {
     if (completeMessage) {
       completeMessage.classList.add('show');
       completeMessage.setAttribute('aria-hidden', 'false');
+      if (typeof completeMessage.focus === 'function') {
+        completeMessage.focus();
+      }
     }
 
     if (win) {


### PR DESCRIPTION
## Summary
- ensure the battle completion dialog overlays the battlefield and only becomes interactive when the battle ends
- add dialog accessibility attributes and focus management when showing the completion modal

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca1049e31c8329a379744812e98e50