### PR TITLE
Improve battle overlay entrance timing

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -302,9 +302,9 @@ body.battle-overlay-open { overflow: hidden; }
   padding: 24px;
   background: rgba(22, 28, 38, 0.25);
   opacity: 0;
-  transform: translateY(48px);
+  transform: none;
   pointer-events: none;
-  transition: opacity 0.6s ease, transform 0.6s ease;
+  transition: opacity 0.6s ease;
   z-index: 5;
 }
 
@@ -313,13 +313,17 @@ body.battle-overlay-open { overflow: hidden; }
   padding: 24px;
   transform: translateY(24px) scale(0.95);
   transition: transform 0.6s ease;
+  transition-delay: 0s;
   animation: none;
 }
 
 .battle-overlay .enemy-image { width: min(220px, 60%); height: auto; }
 
-body.battle-overlay-open .battle-overlay { opacity: 1; transform: translateY(0); pointer-events: auto; }
-body.battle-overlay-open .battle-overlay .battle-overlay-card { transform: translateY(0) scale(1); }
+body.battle-overlay-open .battle-overlay { opacity: 1; pointer-events: auto; }
+body.battle-overlay-open .battle-overlay .battle-overlay-card {
+  transform: translateY(0) scale(1);
+  transition-delay: 0.12s;
+}
 
 /* ------------------------------------------------------------------------- */
 /* Immersive preload experience ------------------------------------------- */


### PR DESCRIPTION
## Summary
- stop translating the battle overlay backdrop so the dark background fades in smoothly
- delay the overlay card animation to let the backdrop appear first

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ca13b0362c8329bd74ee4cd8031c38