### PR TITLE
Adjust battle completion card width and title layout

### DIFF
--- a/css/battle-card.css
+++ b/css/battle-card.css
@@ -57,6 +57,7 @@
   background: #ffffff;
   border-radius: 8px;
   padding: 24px;
+  box-sizing: border-box;
   box-shadow: 0 18px 36px rgba(0, 0, 0, 0.25);
   text-align: center;
   display: flex;

--- a/html/battle.html
+++ b/html/battle.html
@@ -93,7 +93,7 @@
     >
       <section class="battle-card battle-complete-card">
         <div class="battle-info">
-          <p id="battle-complete-title" class="battle-title">Battle Complete</p>
+          <p id="battle-complete-title" class="battle-title">Battle<br />Complete</p>
         </div>
         <img
           class="enemy-image"


### PR DESCRIPTION
## Summary
- ensure the battle completion card uses border-box sizing so its 420px width includes padding
- break the "Battle Complete" title into two lines to display each word separately

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca16366ef48329bf1558b26c92110b