### PR TITLE
Enhance battle intro animations

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -9,14 +9,25 @@
   position: absolute;
   width: 300px;
   max-width: 80vw;
+  opacity: 0;
+  filter: blur(18px);
+  transform: translateZ(0);
+  will-change: transform, opacity, filter;
+}
+
+#battle-monster.battle-ready,
+#battle-shellfin.battle-ready {
+  opacity: 1;
+  filter: blur(0);
 }
 
 #battle-monster.slide-in {
-  animation: monster-enter 1s ease-out forwards;
+  animation: monster-enter 0.9s cubic-bezier(0.22, 1, 0.36, 1) forwards;
 }
 
 #battle-shellfin.slide-in {
-  animation: hero-enter 1s ease-out forwards;
+  animation: hero-enter 0.9s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation-delay: 0.08s;
 }
 
 #battle-monster {
@@ -29,6 +40,18 @@
   right: 55%;
 }
 
+#monster-stats {
+  top: 25%;
+  left: 35%;
+  --stat-delay: 0.65s;
+}
+
+#shellfin-stats {
+  bottom: 25%;
+  right: 35%;
+  --stat-delay: 0.78s;
+}
+
 .stat-box {
   position: absolute;
   display: flex;
@@ -39,16 +62,17 @@
   border-radius: 8px;
   border: 1px solid rgba(255, 255, 255, 0.5);
   backdrop-filter: blur(4px);
+  opacity: 0;
+  transform: translateY(24px) scale(0.95);
+  filter: blur(12px);
+  transition: opacity 0.6s ease, transform 0.6s ease, filter 0.6s ease;
+  transition-delay: var(--stat-delay, 0.6s);
 }
 
-#monster-stats {
-  top: 25%;
-  left: 35%;
-}
-
-#shellfin-stats {
-  bottom: 25%;
-  right: 35%;
+.stat-box.show {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  filter: blur(0);
 }
 
 .stat-box .name {
@@ -137,20 +161,38 @@
 }
 
 @keyframes hero-enter {
-  from {
-    transform: translateX(150%);
+  0% {
+    transform: translateX(140%) scale(0.9);
+    opacity: 0;
+    filter: blur(16px);
   }
-  to {
-    transform: translateX(0);
+  65% {
+    transform: translateX(-3%) scale(1.04);
+    opacity: 1;
+    filter: blur(0);
+  }
+  100% {
+    transform: translateX(0) scale(1);
+    opacity: 1;
+    filter: blur(0);
   }
 }
 
 @keyframes monster-enter {
-  from {
-    transform: translateX(-150%);
+  0% {
+    transform: translateX(-140%) scale(0.9);
+    opacity: 0;
+    filter: blur(16px);
   }
-  to {
-    transform: translateX(0);
+  65% {
+    transform: translateX(3%) scale(1.04);
+    opacity: 1;
+    filter: blur(0);
+  }
+  100% {
+    transform: translateX(0) scale(1);
+    opacity: 1;
+    filter: blur(0);
   }
 }
 
@@ -158,6 +200,22 @@
   0% { transform: translateX(0); }
   50% { transform: translateX(60px); }
   100% { transform: translateX(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #battle-monster,
+  #battle-shellfin {
+    opacity: 1;
+    filter: none;
+    animation: none !important;
+  }
+
+  .stat-box {
+    opacity: 1;
+    transform: none;
+    filter: none;
+    transition: none;
+  }
 }
 
 @keyframes monster-attack {

--- a/js/battle.js
+++ b/js/battle.js
@@ -58,6 +58,9 @@ document.addEventListener('DOMContentLoaded', () => {
   }
   const monsterImg = document.getElementById('battle-monster');
   const heroImg = document.getElementById('battle-shellfin');
+  const prefersReducedMotion = window.matchMedia(
+    '(prefers-reduced-motion: reduce)'
+  ).matches;
   const monsterHpFill = document.querySelector('#monster-stats .hp-fill');
   const heroHpFill = document.querySelector('#shellfin-stats .hp-fill');
   const monsterNameEl = document.querySelector('#monster-stats .name');
@@ -126,21 +129,39 @@ document.addEventListener('DOMContentLoaded', () => {
   const hero = { attack: 1, health: 5, gems: 0, damage: 0, name: 'Hero' };
   const monster = { attack: 1, health: 5, damage: 0, name: 'Monster' };
 
-  heroImg.classList.add('slide-in');
-  monsterImg.classList.add('slide-in');
-  heroStats.classList.add('show');
-  monsterStats.classList.add('show');
+  const markBattleReady = (img) => {
+    if (!img) {
+      return;
+    }
+    img.classList.remove('slide-in');
+    img.classList.add('battle-ready');
+  };
 
-  heroImg.addEventListener(
-    'animationend',
-    () => heroImg.classList.remove('slide-in'),
-    { once: true }
-  );
-  monsterImg.addEventListener(
-    'animationend',
-    () => monsterImg.classList.remove('slide-in'),
-    { once: true }
-  );
+  if (prefersReducedMotion) {
+    markBattleReady(heroImg);
+    markBattleReady(monsterImg);
+  } else {
+    if (heroImg) {
+      heroImg.classList.add('slide-in');
+      heroImg.addEventListener('animationend', () => markBattleReady(heroImg), {
+        once: true,
+      });
+      window.setTimeout(() => markBattleReady(heroImg), 1400);
+    }
+
+    if (monsterImg) {
+      monsterImg.classList.add('slide-in');
+      monsterImg.addEventListener('animationend', () => markBattleReady(monsterImg), {
+        once: true,
+      });
+      window.setTimeout(() => markBattleReady(monsterImg), 1400);
+    }
+  }
+
+  window.requestAnimationFrame(() => {
+    heroStats?.classList.add('show');
+    monsterStats?.classList.add('show');
+  });
 
   function shuffle(arr) {
     for (let i = arr.length - 1; i > 0; i--) {


### PR DESCRIPTION
## Summary
- Smooth hero and monster entrances with eased animations, blur transitions, and accessibility-aware fallbacks
- Added staged stat card reveals to complement the battle overlay intro

## Testing
- Not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68ca188933848329873baff8705f93ce