### PR TITLE
Align battle UI labels and progress

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,12 +77,26 @@
         aria-describedby="battle-overlay-stats"
       >
         <div class="battle-info">
-          <p id="battle-overlay-title" class="battle-title">Battle 1</p>
+          <p
+            id="battle-overlay-math"
+            class="math-type"
+            data-battle-math
+          >
+            Math Mission
+          </p>
+          <p
+            id="battle-overlay-title"
+            class="battle-title"
+            data-battle-title
+          >
+            Battle 1
+          </p>
         </div>
         <img
           class="enemy-image"
           src="images/battle/monster_battle.png"
           alt="Enemy monster ready for battle"
+          data-battle-enemy
         />
         <p class="battle-goals-title">Battle Goals</p>
         <div id="battle-overlay-stats" class="battle-stats" aria-live="polite">

--- a/js/battle.js
+++ b/js/battle.js
@@ -125,6 +125,7 @@ document.addEventListener('DOMContentLoaded', () => {
   let battleEnded = false;
   let currentBattleLevel = null;
   let battleStartTime = null;
+  let battleLevelAdvanced = false;
 
   const hero = { attack: 1, health: 5, gems: 0, damage: 0, name: 'Hero' };
   const monster = { attack: 1, health: 5, damage: 0, name: 'Monster' };
@@ -207,6 +208,29 @@ document.addEventListener('DOMContentLoaded', () => {
     valueEl.classList.add(met ? 'goal-result--met' : 'goal-result--missed');
   }
 
+  function setBattleCompleteTitleLines(...lines) {
+    if (!battleCompleteTitle) {
+      return;
+    }
+
+    const filteredLines = lines
+      .map((line) => (typeof line === 'string' ? line.trim() : ''))
+      .filter((line) => line.length > 0);
+
+    battleCompleteTitle.replaceChildren();
+
+    if (!filteredLines.length) {
+      return;
+    }
+
+    filteredLines.forEach((line, index) => {
+      battleCompleteTitle.appendChild(document.createTextNode(line));
+      if (index < filteredLines.length - 1) {
+        battleCompleteTitle.appendChild(document.createElement('br'));
+      }
+    });
+  }
+
   function persistProgress(update) {
     if (!update || typeof update !== 'object') {
       return;
@@ -249,6 +273,9 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function advanceBattleLevel() {
+    if (battleLevelAdvanced) {
+      return;
+    }
     const baseLevel =
       typeof currentBattleLevel === 'number'
         ? currentBattleLevel
@@ -258,6 +285,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const nextLevel = baseLevel + 1;
     persistProgress({ battleLevel: nextLevel });
     currentBattleLevel = nextLevel;
+    battleLevelAdvanced = true;
   }
 
   function loadData() {
@@ -783,10 +811,14 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     }
 
-    if (battleCompleteTitle) {
-      battleCompleteTitle.textContent = win
-        ? 'Monster Defeated!'
-        : 'Keep Practicing!';
+    if (win) {
+      const monsterName =
+        typeof monster?.name === 'string' ? monster.name.trim() : '';
+      const victoryName = monsterName || 'Monster';
+      setBattleCompleteTitleLines(victoryName, 'Defeated!');
+      advanceBattleLevel();
+    } else {
+      setBattleCompleteTitleLines('Keep Practicing!');
     }
 
     if (nextMissionBtn) {
@@ -801,10 +833,6 @@ document.addEventListener('DOMContentLoaded', () => {
         completeMessage.focus();
       }
     }
-
-    if (win) {
-      advanceBattleLevel();
-    }
   }
 
   if (nextMissionBtn) {
@@ -813,6 +841,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (action === 'retry') {
         window.location.reload();
       } else {
+        advanceBattleLevel();
         window.location.href = '../index.html';
       }
     });
@@ -829,13 +858,12 @@ document.addEventListener('DOMContentLoaded', () => {
     wrongAnswers = 0;
     battleStartTime = null;
     initialTimeRemaining = 0;
+    battleLevelAdvanced = false;
     if (completeMessage) {
       completeMessage.classList.remove('show');
       completeMessage.setAttribute('aria-hidden', 'true');
     }
-    if (battleCompleteTitle) {
-      battleCompleteTitle.textContent = 'Battle Complete';
-    }
+    setBattleCompleteTitleLines('Battle', 'Complete');
     if (nextMissionBtn) {
       nextMissionBtn.textContent = 'Next Mission';
       nextMissionBtn.dataset.action = 'next';

--- a/js/index.js
+++ b/js/index.js
@@ -343,12 +343,9 @@ const initLandingInteractions = (preloadedData = {}) => {
   const messageCard = document.querySelector('.battle-select-card');
   const battleOverlay = document.getElementById('battle-overlay');
   const battleButton = battleOverlay?.querySelector('.battle-btn');
-  const messageTitle = messageCard?.querySelector('[data-battle-math]');
-  const messageSubtitle = messageCard?.querySelector('[data-battle-title]');
-  const messageEnemy = messageCard?.querySelector('[data-battle-enemy]');
-  const overlayMath = battleOverlay?.querySelector('.math-type');
-  const overlayEnemy = battleOverlay?.querySelector('.enemy-image');
-  const overlayBattleTitle = battleOverlay?.querySelector('.battle-title');
+  const battleMathElements = document.querySelectorAll('[data-battle-math]');
+  const battleTitleElements = document.querySelectorAll('[data-battle-title]');
+  const battleEnemyElements = document.querySelectorAll('[data-battle-enemy]');
   const overlayAccuracy = battleOverlay?.querySelector('.accuracy-value');
   const overlayTime = battleOverlay?.querySelector('.time-value');
 
@@ -432,51 +429,44 @@ const initLandingInteractions = (preloadedData = {}) => {
       }
 
       const { battleLevel, name, battle } = activeLevel;
-      const mathLabel =
-        activeLevel.mathType ?? battle?.mathType ?? 'Math Mission';
+      const mathLabelSource =
+        typeof activeLevel.mathType === 'string'
+          ? activeLevel.mathType
+          : typeof battle?.mathType === 'string'
+          ? battle.mathType
+          : 'Math Mission';
+      const mathLabel = mathLabelSource.trim() || 'Math Mission';
       const enemy = battle?.enemy ?? {};
       const enemySprite = typeof enemy.sprite === 'string' ? enemy.sprite : '';
-      const enemyAlt = enemy?.name
-        ? `${enemy.name} ready for battle`
+      const enemyName =
+        typeof enemy?.name === 'string' ? enemy.name.trim() : '';
+      const enemyAlt = enemyName
+        ? `${enemyName} ready for battle`
         : 'Enemy ready for battle';
 
-      if (messageTitle) {
-        messageTitle.textContent = mathLabel;
-      }
+      const levelName = typeof name === 'string' ? name.trim() : '';
+      const battleTitleLabel =
+        levelName ||
+        (typeof battleLevel === 'number'
+          ? `Battle ${battleLevel}`
+          : 'Upcoming Battle');
 
-      if (messageSubtitle) {
-        const label = name ||
-          (typeof battleLevel === 'number'
-            ? `Battle ${battleLevel}`
-            : 'Upcoming Battle');
-        messageSubtitle.textContent = label;
-      }
+      battleMathElements.forEach((element) => {
+        element.textContent = mathLabel;
+      });
 
-      if (messageEnemy) {
-        if (enemySprite) {
-          messageEnemy.src = enemySprite;
+      battleTitleElements.forEach((element) => {
+        element.textContent = battleTitleLabel;
+      });
+
+      battleEnemyElements.forEach((element) => {
+        if (element instanceof HTMLImageElement || element.tagName === 'IMG') {
+          if (enemySprite) {
+            element.src = enemySprite;
+          }
+          element.alt = enemyAlt;
         }
-        messageEnemy.alt = enemyAlt;
-      }
-
-      if (overlayMath) {
-        overlayMath.textContent = mathLabel;
-      }
-
-      if (overlayBattleTitle) {
-        const label = name ||
-          (typeof battleLevel === 'number'
-            ? `Battle ${battleLevel}`
-            : 'Battle');
-        overlayBattleTitle.textContent = label;
-      }
-
-      if (overlayEnemy) {
-        if (enemySprite) {
-          overlayEnemy.src = enemySprite;
-        }
-        overlayEnemy.alt = enemyAlt;
-      }
+      });
 
       const accuracyGoal =
         typeof battle?.accuracyGoal === 'number'


### PR DESCRIPTION
## Summary
- add shared data attributes so the landing panel and battle overlay show the same math type, title, and enemy art
- introduce an eyebrow element on the battle overlay and synchronize its content with the landing panel
- update the battle complete flow to render the monster name over two lines, guard level advancement, and reset the UI between runs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca1dc8ceec83299f6ec147fbc6cbcd