### PR TITLE
Flip hero sprite during battle

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -38,6 +38,8 @@
 #battle-shellfin {
   bottom: 10%;
   right: 55%;
+  transform: translateZ(0) scaleX(-1);
+  transform-origin: center;
 }
 
 #monster-stats {
@@ -162,17 +164,17 @@
 
 @keyframes hero-enter {
   0% {
-    transform: translateX(140%) scale(0.9);
+    transform: translateX(140%) scale(0.9) scaleX(-1);
     opacity: 0;
     filter: blur(16px);
   }
   65% {
-    transform: translateX(-3%) scale(1.04);
+    transform: translateX(-3%) scale(1.04) scaleX(-1);
     opacity: 1;
     filter: blur(0);
   }
   100% {
-    transform: translateX(0) scale(1);
+    transform: translateX(0) scale(1) scaleX(-1);
     opacity: 1;
     filter: blur(0);
   }
@@ -197,9 +199,15 @@
 }
 
 @keyframes hero-attack {
-  0% { transform: translateX(0); }
-  50% { transform: translateX(60px); }
-  100% { transform: translateX(0); }
+  0% {
+    transform: translateX(0) scaleX(-1);
+  }
+  50% {
+    transform: translateX(60px) scaleX(-1);
+  }
+  100% {
+    transform: translateX(0) scaleX(-1);
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- flip the hero battle sprite horizontally so it faces the enemy
- update hero entrance and attack animations to preserve the flipped orientation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cae209cdec8329b8f730c05eac620f