### PR TITLE
Create sign-in page consistent with loading screen design

### DIFF
--- a/css/signin.css
+++ b/css/signin.css
@@ -1,0 +1,80 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+}
+
+.preloader {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
+  padding: 32px;
+  background-color: #001b41;
+  text-align: center;
+}
+
+.preloader__logo {
+  width: 300px;
+  height: 300px;
+  object-fit: contain;
+}
+
+.preloader__form {
+  width: 100%;
+  max-width: 420px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.preloader__field {
+  width: 100%;
+  height: 64px;
+  padding: 0 24px;
+  border: none;
+  border-radius: 8px;
+  background-color: #ffffff;
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 20px;
+  color: #272b34;
+}
+
+.preloader__field::placeholder {
+  color: #888888;
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 20px;
+}
+
+.preloader__field:focus {
+  outline: 3px solid rgba(0, 106, 255, 0.35);
+  outline-offset: 0;
+}
+
+.preloader__button {
+  width: 100%;
+}
+
+@media (max-width: 480px) {
+  .preloader {
+    padding: 24px;
+  }
+
+  .preloader__form {
+    max-width: none;
+  }
+}
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/signin.html
+++ b/signin.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sign In | Reef Rangers</title>
+    <link rel="stylesheet" href="css/battle-card.css" />
+    <link rel="stylesheet" href="css/signin.css" />
+  </head>
+  <body>
+    <div class="preloader">
+      <img
+        class="preloader__logo"
+        src="images/brand/logo.png"
+        alt="Reef Rangers logo"
+        width="300"
+        height="300"
+      />
+      <form class="preloader__form" action="#" method="post">
+        <label class="visually-hidden" for="signin-email">Email</label>
+        <input
+          class="preloader__field"
+          type="email"
+          id="signin-email"
+          name="email"
+          placeholder="Email"
+          autocomplete="email"
+          required
+        />
+        <label class="visually-hidden" for="signin-password">Password</label>
+        <input
+          class="preloader__field"
+          type="password"
+          id="signin-password"
+          name="password"
+          placeholder="Password"
+          autocomplete="current-password"
+          required
+        />
+        <button class="btn-primary preloader__button" type="submit">Sign In</button>
+      </form>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated `signin.html` page that mirrors the loading screen layout with the Reef Rangers logo
- style the sign-in form inputs and action button to follow the specified sizing and typography while reusing the global primary button style

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb1064c5908329a351eabfc3c238b2