### PR TITLE
Style sign-in inputs with brand colors

### DIFF
--- a/css/signin.css
+++ b/css/signin.css
@@ -36,21 +36,26 @@ body {
   padding: 0 24px;
   border: none;
   border-radius: 8px;
-  background-color: #ffffff;
+  background-color: #293f5f;
+  color: #949faf;
   font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
   font-size: 20px;
 }
 
 .preloader__field::placeholder {
-  color: #888888;
+  color: #949faf;
   font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
   font-size: 20px;
 }
 
 .preloader__field:focus {
-  color:#ffffff;
+  color: #ffffff;
   outline: 3px solid rgba(0, 106, 255, 0.35);
   outline-offset: 0;
+}
+
+.preloader__field:focus::placeholder {
+  color: #ffffff;
 }
 
 .preloader__button {


### PR DESCRIPTION
## Summary
- restyle the sign-in form input backgrounds to use the brand navy tone
- set placeholder text to the requested slate tone and show white text while typing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb1963ea448329b625edf4518ef9c3