### PR TITLE
Implement Supabase sign-in flow and styling tweaks

### DIFF
--- a/css/signin.css
+++ b/css/signin.css
@@ -27,11 +27,13 @@ body {
   max-width: 420px;
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: 24px;
 }
 
 .preloader__field {
   width: 420px;
+  max-width: 100%;
   height: 64px;
   padding: 0 24px;
   border: none;
@@ -50,16 +52,25 @@ body {
 
 .preloader__field:focus {
   color: #ffffff;
-  outline: 3px solid rgba(0, 106, 255, 0.35);
+  outline: 3px solid rgba(255, 255, 255, 0.5);
   outline-offset: 0;
 }
 
 .preloader__field:focus::placeholder {
-  color: #ffffff;
+  color: transparent;
 }
 
 .preloader__button {
-  width: 100%;
+  width: 420px;
+  max-width: 100%;
+}
+
+.preloader__error {
+  max-width: 420px;
+  margin: 0;
+  color: #ff6b6b;
+  font-size: 16px;
+  text-align: center;
 }
 
 @media (max-width: 480px) {

--- a/index.html
+++ b/index.html
@@ -101,6 +101,8 @@
       </div>
     </div>
   </main>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2" defer></script>
+  <script src="js/supabaseClient.js" defer></script>
   <script src="js/index.js" defer></script>
 </body>
 </html>

--- a/js/index.js
+++ b/js/index.js
@@ -4,6 +4,34 @@ const VISITED_VALUE = 'true';
 const PROGRESS_STORAGE_KEY = 'reefRangersProgress';
 const MIN_PRELOAD_DURATION_MS = 2000;
 
+const redirectToSignIn = () => {
+  window.location.replace('signin.html');
+};
+
+const ensureAuthenticated = async () => {
+  const supabase = window.supabaseClient;
+  if (!supabase) {
+    redirectToSignIn();
+    return;
+  }
+
+  try {
+    const { data, error } = await supabase.auth.getSession();
+    if (error) {
+      console.warn('Authentication session lookup failed', error);
+    }
+
+    if (!data?.session) {
+      redirectToSignIn();
+    }
+  } catch (error) {
+    console.warn('Unexpected authentication error', error);
+    redirectToSignIn();
+  }
+};
+
+ensureAuthenticated();
+
 const getNow = () =>
   typeof performance !== 'undefined' && typeof performance.now === 'function'
     ? performance.now()

--- a/js/signin.js
+++ b/js/signin.js
@@ -1,0 +1,96 @@
+const setElementVisibility = (element, shouldShow) => {
+  if (!element) {
+    return;
+  }
+  element.hidden = !shouldShow;
+};
+
+const setFieldState = (field, isDisabled) => {
+  if (!field) {
+    return;
+  }
+  field.disabled = Boolean(isDisabled);
+};
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const form = document.querySelector('.preloader__form');
+  const emailField = document.getElementById('signin-email');
+  const passwordField = document.getElementById('signin-password');
+  const submitButton = form?.querySelector('button[type="submit"]');
+  const errorMessage = document.querySelector('[data-signin-error]');
+  const supabase = window.supabaseClient;
+
+  const showError = (message) => {
+    if (!errorMessage) {
+      return;
+    }
+    errorMessage.textContent = message;
+    setElementVisibility(errorMessage, Boolean(message));
+  };
+
+  const setLoading = (isLoading) => {
+    setFieldState(emailField, isLoading);
+    setFieldState(passwordField, isLoading);
+    if (submitButton) {
+      submitButton.disabled = Boolean(isLoading);
+      submitButton.textContent = isLoading ? 'Signing In…' : 'Sign In';
+    }
+  };
+
+  if (!form || !emailField || !passwordField) {
+    showError('The sign in form could not be initialized.');
+    return;
+  }
+
+  if (!supabase) {
+    showError('Authentication service is unavailable. Please try again later.');
+    return;
+  }
+
+  try {
+    const { data, error } = await supabase.auth.getSession();
+    if (error) {
+      console.warn('Failed to fetch existing session', error);
+    }
+    if (data?.session) {
+      window.location.replace('index.html');
+      return;
+    }
+  } catch (error) {
+    console.warn('Session lookup failed', error);
+  }
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    showError('');
+
+    const email = emailField.value.trim();
+    const password = passwordField.value;
+
+    if (!email || !password) {
+      showError('Please provide both an email and password.');
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      const { error } = await supabase.auth.signInWithPassword({
+        email,
+        password,
+      });
+
+      if (error) {
+        showError(error.message || 'Unable to sign in. Please try again.');
+        setLoading(false);
+        return;
+      }
+
+      window.location.replace('index.html');
+    } catch (error) {
+      console.error('Unexpected error during sign in', error);
+      showError('An unexpected error occurred. Please try again.');
+      setLoading(false);
+    }
+  });
+});

--- a/signin.html
+++ b/signin.html
@@ -16,7 +16,7 @@
         width="300"
         height="300"
       />
-      <form class="preloader__form" action="#" method="post">
+      <form class="preloader__form" action="#" method="post" novalidate>
         <label class="visually-hidden" for="signin-email">Email</label>
         <input
           class="preloader__field"
@@ -37,8 +37,14 @@
           autocomplete="current-password"
           required
         />
-        <button class="btn-primary preloader__button" type="submit">Sign In</button>
+        <button class="btn-primary preloader__button" type="submit">
+          Sign In
+        </button>
       </form>
+      <p class="preloader__error" data-signin-error role="alert" hidden></p>
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2" defer></script>
+    <script src="js/supabaseClient.js" defer></script>
+    <script src="js/signin.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- update the sign-in layout to enforce 420px wide fields, hide placeholders on focus, and adjust focus outline styling
- add Supabase-powered authentication with a dedicated sign-in script and error handling
- require a valid Supabase session before loading the main index page and reuse existing loading screen after login

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cb1ccb73f4832995d9bcd0d75a8991