### PR TITLE
Center sign-in layout and add loading spinner

### DIFF
--- a/css/signin.css
+++ b/css/signin.css
@@ -10,6 +10,7 @@ body {
   display: flex;
   flex-direction: column;
   justify-content: center;
+  align-items: center;
   gap: 24px;
   padding: 32px;
   background-color: #001b41;
@@ -31,6 +32,8 @@ body {
 }
 
 .preloader__field {
+  width: 420px;
+  max-width: 100%;
   height: 64px;
   padding: 0 24px;
   border: none;
@@ -58,8 +61,32 @@ body {
 }
 
 .preloader__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
   width: 420px;
   max-width: 100%;
+}
+
+.preloader__spinner {
+  display: none;
+  width: 24px;
+  height: 24px;
+  border: 3px solid rgba(255, 255, 255, 0.4);
+  border-top-color: #ffffff;
+  border-radius: 50%;
+  animation: preloader-spin 0.8s linear infinite;
+}
+
+.preloader__button.is-loading .preloader__spinner {
+  display: inline-block;
+}
+
+@keyframes preloader-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .preloader__error {

--- a/js/signin.js
+++ b/js/signin.js
@@ -17,6 +17,9 @@ document.addEventListener('DOMContentLoaded', async () => {
   const emailField = document.getElementById('signin-email');
   const passwordField = document.getElementById('signin-password');
   const submitButton = form?.querySelector('button[type="submit"]');
+  const submitButtonLabel = submitButton?.querySelector(
+    '.preloader__button-label'
+  );
   const errorMessage = document.querySelector('[data-signin-error]');
   const supabase = window.supabaseClient;
 
@@ -33,7 +36,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     setFieldState(passwordField, isLoading);
     if (submitButton) {
       submitButton.disabled = Boolean(isLoading);
-      submitButton.textContent = isLoading ? 'Signing In…' : 'Sign In';
+      submitButton.classList.toggle('is-loading', Boolean(isLoading));
+      submitButton.setAttribute('aria-busy', isLoading ? 'true' : 'false');
+      if (submitButtonLabel) {
+        submitButtonLabel.textContent = isLoading ? 'Signing In…' : 'Sign In';
+      }
     }
   };
 

--- a/signin.html
+++ b/signin.html
@@ -38,7 +38,8 @@
           required
         />
         <button class="btn-primary preloader__button" type="submit">
-          Sign In
+          <span class="preloader__button-label">Sign In</span>
+          <span class="preloader__spinner" aria-hidden="true"></span>
         </button>
       </form>
       <p class="preloader__error" data-signin-error role="alert" hidden></p>


### PR DESCRIPTION
## Summary
- center all sign-in page content within the viewport
- set input widths to 420px and keep them responsive on small screens
- add an inline loading spinner and accessible label updates when signing in

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb22f856848329acf7f783f65ed40b