### PR TITLE
Fix sign-in field width overflow

### DIFF
--- a/css/signin.css
+++ b/css/signin.css
@@ -36,6 +36,7 @@ body {
   max-width: 100%;
   height: 64px;
   padding: 0 24px;
+  box-sizing: border-box;
   border: none;
   border-radius: 8px;
   background-color: #293f5f;
@@ -67,6 +68,7 @@ body {
   gap: 16px;
   width: 420px;
   max-width: 100%;
+  box-sizing: border-box;
 }
 
 .preloader__spinner {


### PR DESCRIPTION
## Summary
- ensure the sign-in form input fields respect the intended 420px maximum width by making their padding part of the box model
- apply the same box-sizing fix to the submit button so it aligns with the fields

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb2544fae0832982696db5c89c9aa6