### PR TITLE
Include Supabase library on sign-in and landing pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,7 +105,8 @@
     window.SUPABASE_URL = 'https://jxlxpumcoihfapmrsaqd.supabase.co';
     window.SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imp4bHhwdW1jb2loZmFwbXJzYXFkIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTc0MjE3MDcsImV4cCI6MjA3Mjk5NzcwN30.PJiDPZ_Dqli_42isJexeYgsf0ebWbCSOwHtR7lsQTN0';
   </script>
-  <script src="js/supabaseClient.js" defer></script>  
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2" defer></script>
+  <script src="js/supabaseClient.js" defer></script>
   <script src="js/index.js" defer></script>
 </body>
 </html>

--- a/signin.html
+++ b/signin.html
@@ -48,7 +48,8 @@
       window.SUPABASE_URL = 'https://jxlxpumcoihfapmrsaqd.supabase.co';
       window.SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imp4bHhwdW1jb2loZmFwbXJzYXFkIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTc0MjE3MDcsImV4cCI6MjA3Mjk5NzcwN30.PJiDPZ_Dqli_42isJexeYgsf0ebWbCSOwHtR7lsQTN0';
     </script>
-    <script src="js/supabaseClient.js" defer></script>  
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2" defer></script>
+    <script src="js/supabaseClient.js" defer></script>
     <script src="js/signin.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- load the Supabase JavaScript client from the CDN on the sign-in and landing pages
- ensure the custom Supabase client initialization has access to the global Supabase factory

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cb25eda3e0832992a6a6c13c0bb001