### PR TITLE
Add dev log out control to battle

### DIFF
--- a/html/battle.html
+++ b/html/battle.html
@@ -32,6 +32,9 @@
     <button type="button" class="battle-dev-controls__btn" data-dev-reset-level>
       Reset Level 1
     </button>
+    <button type="button" class="battle-dev-controls__btn" data-dev-log-out>
+      Log Out
+    </button>
   </div>
   <div id="battle">
     <img id="battle-monster" src="../images/battle/monster_battle_1.png" alt="Monster" />

--- a/js/battle.js
+++ b/js/battle.js
@@ -81,6 +81,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const setStreakButton = document.querySelector('[data-dev-set-streak]');
   const endBattleButton = document.querySelector('[data-dev-end-battle]');
   const resetLevelButton = document.querySelector('[data-dev-reset-level]');
+  const logOutButton = document.querySelector('[data-dev-log-out]');
   const devControls = document.querySelector('.battle-dev-controls');
   const heroAttackVal = heroStats.querySelector('.attack .value');
   const heroHealthVal = heroStats.querySelector('.health .value');
@@ -681,6 +682,23 @@ document.addEventListener('DOMContentLoaded', () => {
     currentBattleLevel = 1;
     battleLevelAdvanced = false;
     battleGoalsMet = false;
+  });
+
+  logOutButton?.addEventListener('click', async () => {
+    const supabase = window.supabaseClient;
+
+    if (supabase?.auth?.signOut) {
+      try {
+        const { error } = await supabase.auth.signOut();
+        if (error) {
+          console.warn('Supabase sign out failed', error);
+        }
+      } catch (error) {
+        console.warn('Unexpected error during sign out', error);
+      }
+    }
+
+    window.location.replace('../signin.html');
   });
 
   document.addEventListener('answer-submitted', (e) => {


### PR DESCRIPTION
## Summary
- add a log out button to the battle developer controls
- trigger a Supabase sign out (if available) and send the user back to the sign-in screen

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb29c340108329be3826abb02f4b3d