### PR TITLE
Rework landing battle intro animation

### DIFF
--- a/css/battle-card.css
+++ b/css/battle-card.css
@@ -1,57 +1,3 @@
-.battle-panel {
-  display: flex;
-  align-items: flex-start;
-  gap: 24px;
-  width: 420px;
-  box-sizing: border-box;
-  padding: 24px;
-  border-radius: 8px;
-  background: #ffffff;
-  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.25);
-  color: #272b34;
-  text-align: left;
-}
-
-.battle-panel__body {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  min-width: 0;
-}
-
-.battle-panel__eyebrow {
-  margin: 0;
-  font-size: 20px;
-  color: #888888;
-}
-
-.battle-panel__title {
-  margin: 0;
-  font-size: 32px;
-  font-weight: 700;
-  color: #272b34;
-}
-
-.battle-panel__stats {
-  margin-top: 12px;
-}
-
-.battle-panel__enemy {
-  width: 220px;
-  height: auto;
-  transform: translate(60px, -20px);
-}
-
-.battle-panel:focus-visible {
-  outline: 3px solid #006aff;
-  outline-offset: 4px;
-}
-
-.battle-panel--buttony {
-  cursor: pointer;
-}
-
 .battle-card {
   width: 420px;
   background: #ffffff;
@@ -64,7 +10,10 @@
   flex-direction: column;
   align-items: center;
   gap: 24px;
-  animation: pop-in 0.4s ease-out;
+}
+
+.battle-card--pop {
+  animation: pop-in 0.4s ease-out forwards;
 }
 
 .battle-card .battle-info {
@@ -100,8 +49,7 @@
   height: 220px;
 }
 
-.battle-card .battle-stats,
-.battle-panel__stats {
+.battle-card .battle-stats {
   width: 100%;
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -110,8 +58,7 @@
   background-color: transparent;
 }
 
-.battle-card .battle-stat,
-.battle-panel__stats .battle-stat {
+.battle-card .battle-stat {
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -123,15 +70,13 @@
   background-color: #F4F6FA;
 }
 
-.battle-card .stat-label,
-.battle-panel__stats .stat-label {
+.battle-card .stat-label {
   font-size: 18px;
   color: #888888;
   font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
 }
 
-.battle-card .stat-value,
-.battle-panel__stats .stat-value {
+.battle-card .stat-value {
   font-size: 24px;
   font-weight: 700;
   color: #006AFF;

--- a/css/index.css
+++ b/css/index.css
@@ -57,24 +57,52 @@ body:not(.is-preloading) main.landing {
   left: 50%;
   max-width: 300px;
   max-height: 300px;
-  transform: translateX(150%);
-  animation: hero-slide 1.35s cubic-bezier(0.22, 0.61, 0.36, 1) forwards,
-    hero-float 3.5s ease-in-out 1.35s infinite;
+  transform: translate(-50%, 0);
+  animation: hero-float 3.5s ease-in-out infinite;
   image-rendering: auto;
   z-index: 2;
   pointer-events: none;
 }
 
-@keyframes hero-slide {
-  0% { transform: translateX(150%); }
-  80% { transform: translateX(-54%); }
-  100% { transform: translateX(-50%); }
+@keyframes hero-float {
+  0%   { transform: translate(-50%, 0) translateY(0); }
+  50%  { transform: translate(-50%, 0) translateY(-32px); }
+  100% { transform: translate(-50%, 0) translateY(0); }
 }
 
-@keyframes hero-float {
-  0%   { transform: translateX(-50%) translateY(0); }
-  50%  { transform: translateX(-50%) translateY(-32px); }
-  100% { transform: translateX(-50%) translateY(0); }
+.battle-splat {
+  position: absolute;
+  bottom: calc(32vh - 16px);
+  left: 50%;
+  width: clamp(220px, 42vw, 420px);
+  max-width: 420px;
+  transform: translate(-50%, 0) scale(0.1);
+  transform-origin: center;
+  opacity: 0;
+  pointer-events: none;
+  z-index: 3;
+}
+
+.battle-splat--active {
+  animation: battle-splat-pop 0.6s cubic-bezier(0.24, 1.4, 0.4, 1) forwards;
+}
+
+@keyframes battle-splat-pop {
+  0% {
+    transform: translate(-50%, 0) scale(0.1) rotate(-4deg);
+    opacity: 0;
+    filter: blur(2px);
+  }
+  60% {
+    transform: translate(-50%, -12px) scale(1.08) rotate(3deg);
+    opacity: 1;
+    filter: blur(0);
+  }
+  100% {
+    transform: translate(-50%, 0) scale(1) rotate(0deg);
+    opacity: 1;
+    filter: blur(0);
+  }
 }
 
 /* Bubble field */
@@ -232,65 +260,6 @@ body:not(.is-preloading) main.landing {
   100% { --rot: 3deg; }
 }
 
-/* Message card & overlay (unchanged) */
-.battle-select-card {
-  position: absolute;
-  left: 50%;
-  bottom: 24px;
-  transform: translate(-50%, 32px) scale(0.92);
-  width: min(420px, calc(100% - 32px));
-  max-height: 120px;
-  overflow: hidden;
-  opacity: 0;
-  visibility: hidden;
-  pointer-events: none;
-  animation: message-pop 0.5s ease-out forwards;
-  animation-delay: var(--battle-select-delay, 2.2s);
-  animation-fill-mode: both;
-  z-index: 3;
-  transition: transform 0.6s ease, opacity 0.6s ease;
-}
-
-.battle-select-card--no-delay {
-  --battle-select-delay: 0s;
-}
-
-/* Prevent rapid re-triggering while the card is animating */
-.battle-select-card--animating {
-  pointer-events: none;
-}
-
-body.message-exiting .battle-select-card {
-  transform: translate(-50%, -40vh) scale(1.2);
-  opacity: 0;
-  pointer-events: none;
-}
-
-@keyframes message-pop {
-  0% {
-    transform: translate(-50%, 32px) scale(0.86);
-    opacity: 0;
-    visibility: hidden;
-    pointer-events: none;
-  }
-  60% {
-    transform: translate(-50%, -8px) scale(1.05);
-    opacity: 1;
-    visibility: visible;
-    pointer-events: auto;
-  }
-  100% {
-    transform: translate(-50%, 0) scale(1);
-    opacity: 1;
-    visibility: visible;
-    pointer-events: auto;
-  }
-}
-
-.battle-select-card:focus-visible { outline: 3px solid #006aff; outline-offset: 4px; }
-.battle-select-card:active { transform: translate(-50%, 4px) scale(0.98); }
-.battle-select-card--hidden { visibility: hidden; pointer-events: none; display: none; }
-
 body.battle-overlay-open { overflow: hidden; }
 
 .battle-overlay {
@@ -311,18 +280,17 @@ body.battle-overlay-open { overflow: hidden; }
 .battle-overlay .battle-overlay-card {
   width: 420px;
   padding: 24px;
+  opacity: 0;
   transform: translateY(24px) scale(0.95);
-  transition: transform 0.6s ease;
-  transition-delay: 0s;
-  animation: none;
 }
 
 .battle-overlay .enemy-image { width: min(220px, 60%); height: auto; }
 
 body.battle-overlay-open .battle-overlay { opacity: 1; pointer-events: auto; }
-body.battle-overlay-open .battle-overlay .battle-overlay-card {
+
+.battle-overlay-card--visible {
+  opacity: 1;
   transform: translateY(0) scale(1);
-  transition-delay: 0.12s;
 }
 
 /* ------------------------------------------------------------------------- */

--- a/html/battle.html
+++ b/html/battle.html
@@ -100,7 +100,7 @@
       aria-hidden="true"
       tabindex="-1"
     >
-      <section class="battle-card battle-complete-card">
+      <section class="battle-card battle-card--pop battle-complete-card">
         <div class="battle-info">
           <p id="battle-complete-title" class="battle-title">Battle<br />Complete</p>
         </div>

--- a/index.html
+++ b/index.html
@@ -34,28 +34,15 @@
     <img
       class="hero"
       src="images/characters/shellfin_level_1.png"
-      alt="Shellfin swimming into view"
+      alt="Shellfin ready for battle"
     />
 
-    <aside
-      class="battle-panel battle-panel--buttony battle-select-card"
-      role="button"
-      tabindex="0"
-      aria-live="polite"
-      aria-controls="battle-overlay"
-      aria-expanded="false"
-    >
-      <div class="battle-panel__body">
-        <p class="battle-panel__eyebrow" data-battle-math>Addition</p>
-        <p class="battle-panel__title" data-battle-title>Battle 1</p>
-      </div>
-      <img
-        class="battle-panel__enemy"
-        src="images/battle/monster_battle_1.png"
-        alt="Enemy monster ready for battle"
-        data-battle-enemy
-      />
-    </aside>
+    <img
+      class="battle-splat"
+      src="images/battle/battle.png"
+      alt=""
+      aria-hidden="true"
+    />
     <div id="battle-overlay" class="battle-overlay" aria-hidden="true">
       <div
         class="battle-card battle-overlay-card"


### PR DESCRIPTION
## Summary
- remove the landing battle panel markup and replace it with a timed battle splat overlay image
- update landing styles to stop the hero slide-in, add the splat animation, and tweak the modal card reveal
- simplify the landing script to auto-trigger the splat and overlay and add a reusable battle card pop animation (applied to the battle completion card)

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cb2f0c71e4832992f865fbdf4590c0