### PR TITLE
Add comprehensive level question sets

### DIFF
--- a/data/questions/level_1_questions.json
+++ b/data/questions/level_1_questions.json
@@ -2,25 +2,553 @@
   "questions": [
     {
       "id": 1,
-      "question": "Level 1: What is 5 + 8?",
+      "question": "Level 1: What is 5 + 5?",
       "options": [
-        1,
-        13,
+        19,
+        18,
         12,
-        2
+        10
       ],
-      "answer": 13
+      "answer": 10
     },
     {
       "id": 2,
-      "question": "Level 1: What is 7 + 8?",
+      "question": "Level 1: What is 5 + 3?",
+      "options": [
+        4,
+        8,
+        17,
+        3
+      ],
+      "answer": 8
+    },
+    {
+      "id": 3,
+      "question": "Level 1: What is 3 + 5?",
+      "options": [
+        2,
+        8,
+        15,
+        10
+      ],
+      "answer": 8
+    },
+    {
+      "id": 4,
+      "question": "Level 1: What is 4 + 0?",
+      "options": [
+        2,
+        12,
+        4,
+        7
+      ],
+      "answer": 4
+    },
+    {
+      "id": 5,
+      "question": "Level 1: What is 3 + 0?",
+      "options": [
+        11,
+        12,
+        8,
+        3
+      ],
+      "answer": 3
+    },
+    {
+      "id": 6,
+      "question": "Level 1: What is 3 + 5?",
+      "options": [
+        6,
+        1,
+        8,
+        5
+      ],
+      "answer": 8
+    },
+    {
+      "id": 7,
+      "question": "Level 1: What is 4 + 1?",
+      "options": [
+        2,
+        13,
+        5,
+        8
+      ],
+      "answer": 5
+    },
+    {
+      "id": 8,
+      "question": "Level 1: What is 3 + 3?",
+      "options": [
+        6,
+        15,
+        2,
+        16
+      ],
+      "answer": 6
+    },
+    {
+      "id": 9,
+      "question": "Level 1: What is 4 + 4?",
+      "options": [
+        9,
+        1,
+        17,
+        8
+      ],
+      "answer": 8
+    },
+    {
+      "id": 10,
+      "question": "Level 1: What is 4 + 0?",
+      "options": [
+        4,
+        7,
+        11,
+        9
+      ],
+      "answer": 4
+    },
+    {
+      "id": 11,
+      "question": "Level 1: What is 0 + 5?",
+      "options": [
+        15,
+        2,
+        4,
+        5
+      ],
+      "answer": 5
+    },
+    {
+      "id": 12,
+      "question": "Level 1: What is 3 + 0?",
       "options": [
         7,
-        15,
+        3,
         12,
-        18
+        9
       ],
-      "answer": 15
+      "answer": 3
+    },
+    {
+      "id": 13,
+      "question": "Level 1: What is 0 + 2?",
+      "options": [
+        7,
+        10,
+        3,
+        2
+      ],
+      "answer": 2
+    },
+    {
+      "id": 14,
+      "question": "Level 1: What is 0 + 3?",
+      "options": [
+        3,
+        9,
+        12,
+        1
+      ],
+      "answer": 3
+    },
+    {
+      "id": 15,
+      "question": "Level 1: What is 0 + 1?",
+      "options": [
+        1,
+        4,
+        9,
+        6
+      ],
+      "answer": 1
+    },
+    {
+      "id": 16,
+      "question": "Level 1: What is 1 + 3?",
+      "options": [
+        4,
+        6,
+        11,
+        2
+      ],
+      "answer": 4
+    },
+    {
+      "id": 17,
+      "question": "Level 1: What is 3 + 4?",
+      "options": [
+        1,
+        14,
+        7,
+        5
+      ],
+      "answer": 7
+    },
+    {
+      "id": 18,
+      "question": "Level 1: What is 4 + 5?",
+      "options": [
+        8,
+        10,
+        18,
+        9
+      ],
+      "answer": 9
+    },
+    {
+      "id": 19,
+      "question": "Level 1: What is 4 + 2?",
+      "options": [
+        9,
+        6,
+        16,
+        8
+      ],
+      "answer": 6
+    },
+    {
+      "id": 20,
+      "question": "Level 1: What is 2 + 3?",
+      "options": [
+        9,
+        2,
+        5,
+        15
+      ],
+      "answer": 5
+    },
+    {
+      "id": 21,
+      "question": "Level 1: What is 3 + 2?",
+      "options": [
+        5,
+        13,
+        7,
+        8
+      ],
+      "answer": 5
+    },
+    {
+      "id": 22,
+      "question": "Level 1: What is 1 + 5?",
+      "options": [
+        10,
+        1,
+        4,
+        6
+      ],
+      "answer": 6
+    },
+    {
+      "id": 23,
+      "question": "Level 1: What is 5 + 2?",
+      "options": [
+        6,
+        7,
+        12,
+        11
+      ],
+      "answer": 7
+    },
+    {
+      "id": 24,
+      "question": "Level 1: What is 2 + 2?",
+      "options": [
+        14,
+        11,
+        4,
+        6
+      ],
+      "answer": 4
+    },
+    {
+      "id": 25,
+      "question": "Level 1: What is 5 + 4?",
+      "options": [
+        18,
+        5,
+        15,
+        9
+      ],
+      "answer": 9
+    },
+    {
+      "id": 26,
+      "question": "Level 1: What is 3 + 4?",
+      "options": [
+        7,
+        16,
+        17,
+        3
+      ],
+      "answer": 7
+    },
+    {
+      "id": 27,
+      "question": "Level 1: What is 4 + 4?",
+      "options": [
+        10,
+        1,
+        13,
+        8
+      ],
+      "answer": 8
+    },
+    {
+      "id": 28,
+      "question": "Level 1: What is 2 + 3?",
+      "options": [
+        3,
+        15,
+        9,
+        5
+      ],
+      "answer": 5
+    },
+    {
+      "id": 29,
+      "question": "Level 1: What is 5 + 3?",
+      "options": [
+        15,
+        8,
+        4,
+        6
+      ],
+      "answer": 8
+    },
+    {
+      "id": 30,
+      "question": "Level 1: What is 2 + 0?",
+      "options": [
+        2,
+        11,
+        12,
+        7
+      ],
+      "answer": 2
+    },
+    {
+      "id": 31,
+      "question": "Level 1: What is 2 + 2?",
+      "options": [
+        4,
+        6,
+        11,
+        5
+      ],
+      "answer": 4
+    },
+    {
+      "id": 32,
+      "question": "Level 1: What is 1 + 1?",
+      "options": [
+        11,
+        3,
+        10,
+        2
+      ],
+      "answer": 2
+    },
+    {
+      "id": 33,
+      "question": "Level 1: What is 2 + 5?",
+      "options": [
+        14,
+        7,
+        6,
+        1
+      ],
+      "answer": 7
+    },
+    {
+      "id": 34,
+      "question": "Level 1: What is 0 + 1?",
+      "options": [
+        4,
+        3,
+        7,
+        1
+      ],
+      "answer": 1
+    },
+    {
+      "id": 35,
+      "question": "Level 1: What is 1 + 4?",
+      "options": [
+        10,
+        8,
+        5,
+        4
+      ],
+      "answer": 5
+    },
+    {
+      "id": 36,
+      "question": "Level 1: What is 1 + 0?",
+      "options": [
+        1,
+        11,
+        9,
+        3
+      ],
+      "answer": 1
+    },
+    {
+      "id": 37,
+      "question": "Level 1: What is 1 + 2?",
+      "options": [
+        9,
+        5,
+        10,
+        3
+      ],
+      "answer": 3
+    },
+    {
+      "id": 38,
+      "question": "Level 1: What is 0 + 2?",
+      "options": [
+        10,
+        3,
+        5,
+        2
+      ],
+      "answer": 2
+    },
+    {
+      "id": 39,
+      "question": "Level 1: What is 3 + 3?",
+      "options": [
+        2,
+        6,
+        7,
+        9
+      ],
+      "answer": 6
+    },
+    {
+      "id": 40,
+      "question": "Level 1: What is 0 + 4?",
+      "options": [
+        10,
+        8,
+        9,
+        4
+      ],
+      "answer": 4
+    },
+    {
+      "id": 41,
+      "question": "Level 1: What is 4 + 3?",
+      "options": [
+        7,
+        3,
+        16,
+        17
+      ],
+      "answer": 7
+    },
+    {
+      "id": 42,
+      "question": "Level 1: What is 2 + 4?",
+      "options": [
+        6,
+        7,
+        8,
+        10
+      ],
+      "answer": 6
+    },
+    {
+      "id": 43,
+      "question": "Level 1: What is 5 + 1?",
+      "options": [
+        8,
+        16,
+        6,
+        14
+      ],
+      "answer": 6
+    },
+    {
+      "id": 44,
+      "question": "Level 1: What is 1 + 2?",
+      "options": [
+        3,
+        13,
+        8,
+        10
+      ],
+      "answer": 3
+    },
+    {
+      "id": 45,
+      "question": "Level 1: What is 5 + 5?",
+      "options": [
+        1,
+        16,
+        4,
+        10
+      ],
+      "answer": 10
+    },
+    {
+      "id": 46,
+      "question": "Level 1: What is 1 + 0?",
+      "options": [
+        3,
+        9,
+        6,
+        1
+      ],
+      "answer": 1
+    },
+    {
+      "id": 47,
+      "question": "Level 1: What is 1 + 5?",
+      "options": [
+        3,
+        6,
+        10,
+        5
+      ],
+      "answer": 6
+    },
+    {
+      "id": 48,
+      "question": "Level 1: What is 5 + 0?",
+      "options": [
+        5,
+        9,
+        6,
+        15
+      ],
+      "answer": 5
+    },
+    {
+      "id": 49,
+      "question": "Level 1: What is 2 + 1?",
+      "options": [
+        12,
+        9,
+        3,
+        11
+      ],
+      "answer": 3
+    },
+    {
+      "id": 50,
+      "question": "Level 1: What is 3 + 1?",
+      "options": [
+        11,
+        4,
+        3,
+        13
+      ],
+      "answer": 4
     }
   ]
 }

--- a/data/questions/level_2_questions.json
+++ b/data/questions/level_2_questions.json
@@ -2,25 +2,553 @@
   "questions": [
     {
       "id": 1,
+      "question": "Level 2: What is 6 + 8?",
+      "options": [
+        14,
+        7,
+        20,
+        13
+      ],
+      "answer": 14
+    },
+    {
+      "id": 2,
+      "question": "Level 2: What is 7 + 7?",
+      "options": [
+        14,
+        18,
+        10,
+        15
+      ],
+      "answer": 14
+    },
+    {
+      "id": 3,
+      "question": "Level 2: What is 9 + 7?",
+      "options": [
+        21,
+        7,
+        14,
+        16
+      ],
+      "answer": 16
+    },
+    {
+      "id": 4,
+      "question": "Level 2: What is 6 + 9?",
+      "options": [
+        25,
+        12,
+        7,
+        15
+      ],
+      "answer": 15
+    },
+    {
+      "id": 5,
+      "question": "Level 2: What is 5 + 6?",
+      "options": [
+        4,
+        5,
+        11,
+        14
+      ],
+      "answer": 11
+    },
+    {
+      "id": 6,
+      "question": "Level 2: What is 6 + 9?",
+      "options": [
+        18,
+        7,
+        8,
+        15
+      ],
+      "answer": 15
+    },
+    {
+      "id": 7,
+      "question": "Level 2: What is 9 + 8?",
+      "options": [
+        17,
+        21,
+        20,
+        7
+      ],
+      "answer": 17
+    },
+    {
+      "id": 8,
+      "question": "Level 2: What is 6 + 6?",
+      "options": [
+        5,
+        13,
+        4,
+        12
+      ],
+      "answer": 12
+    },
+    {
+      "id": 9,
+      "question": "Level 2: What is 8 + 6?",
+      "options": [
+        14,
+        9,
+        15,
+        4
+      ],
+      "answer": 14
+    },
+    {
+      "id": 10,
+      "question": "Level 2: What is 5 + 5?",
+      "options": [
+        19,
+        4,
+        6,
+        10
+      ],
+      "answer": 10
+    },
+    {
+      "id": 11,
+      "question": "Level 2: What is 9 + 5?",
+      "options": [
+        13,
+        15,
+        14,
+        4
+      ],
+      "answer": 14
+    },
+    {
+      "id": 12,
       "question": "Level 2: What is 5 + 8?",
       "options": [
-        1,
+        7,
         13,
-        12,
-        2
+        17,
+        8
       ],
       "answer": 13
     },
     {
-      "id": 2,
+      "id": 13,
+      "question": "Level 2: What is 6 + 5?",
+      "options": [
+        9,
+        5,
+        1,
+        11
+      ],
+      "answer": 11
+    },
+    {
+      "id": 14,
+      "question": "Level 2: What is 9 + 5?",
+      "options": [
+        19,
+        14,
+        21,
+        13
+      ],
+      "answer": 14
+    },
+    {
+      "id": 15,
+      "question": "Level 2: What is 5 + 6?",
+      "options": [
+        4,
+        18,
+        19,
+        11
+      ],
+      "answer": 11
+    },
+    {
+      "id": 16,
+      "question": "Level 2: What is 8 + 8?",
+      "options": [
+        22,
+        13,
+        16,
+        10
+      ],
+      "answer": 16
+    },
+    {
+      "id": 17,
+      "question": "Level 2: What is 7 + 5?",
+      "options": [
+        12,
+        13,
+        15,
+        11
+      ],
+      "answer": 12
+    },
+    {
+      "id": 18,
+      "question": "Level 2: What is 5 + 9?",
+      "options": [
+        16,
+        14,
+        8,
+        6
+      ],
+      "answer": 14
+    },
+    {
+      "id": 19,
+      "question": "Level 2: What is 9 + 8?",
+      "options": [
+        17,
+        11,
+        25,
+        20
+      ],
+      "answer": 17
+    },
+    {
+      "id": 20,
+      "question": "Level 2: What is 7 + 7?",
+      "options": [
+        11,
+        18,
+        6,
+        14
+      ],
+      "answer": 14
+    },
+    {
+      "id": 21,
       "question": "Level 2: What is 7 + 8?",
       "options": [
-        7,
-        15,
-        12,
-        18
+        17,
+        18,
+        5,
+        15
       ],
       "answer": 15
+    },
+    {
+      "id": 22,
+      "question": "Level 2: What is 8 + 6?",
+      "options": [
+        15,
+        18,
+        10,
+        14
+      ],
+      "answer": 14
+    },
+    {
+      "id": 23,
+      "question": "Level 2: What is 7 + 5?",
+      "options": [
+        12,
+        7,
+        5,
+        10
+      ],
+      "answer": 12
+    },
+    {
+      "id": 24,
+      "question": "Level 2: What is 8 + 5?",
+      "options": [
+        13,
+        8,
+        17,
+        15
+      ],
+      "answer": 13
+    },
+    {
+      "id": 25,
+      "question": "Level 2: What is 6 + 6?",
+      "options": [
+        16,
+        18,
+        12,
+        9
+      ],
+      "answer": 12
+    },
+    {
+      "id": 26,
+      "question": "Level 2: What is 9 + 6?",
+      "options": [
+        20,
+        25,
+        15,
+        7
+      ],
+      "answer": 15
+    },
+    {
+      "id": 27,
+      "question": "Level 2: What is 8 + 7?",
+      "options": [
+        5,
+        24,
+        15,
+        19
+      ],
+      "answer": 15
+    },
+    {
+      "id": 28,
+      "question": "Level 2: What is 7 + 6?",
+      "options": [
+        20,
+        13,
+        23,
+        12
+      ],
+      "answer": 13
+    },
+    {
+      "id": 29,
+      "question": "Level 2: What is 6 + 5?",
+      "options": [
+        11,
+        3,
+        16,
+        8
+      ],
+      "answer": 11
+    },
+    {
+      "id": 30,
+      "question": "Level 2: What is 5 + 7?",
+      "options": [
+        5,
+        12,
+        3,
+        10
+      ],
+      "answer": 12
+    },
+    {
+      "id": 31,
+      "question": "Level 2: What is 7 + 8?",
+      "options": [
+        21,
+        23,
+        17,
+        15
+      ],
+      "answer": 15
+    },
+    {
+      "id": 32,
+      "question": "Level 2: What is 6 + 8?",
+      "options": [
+        13,
+        14,
+        15,
+        10
+      ],
+      "answer": 14
+    },
+    {
+      "id": 33,
+      "question": "Level 2: What is 6 + 7?",
+      "options": [
+        11,
+        13,
+        20,
+        12
+      ],
+      "answer": 13
+    },
+    {
+      "id": 34,
+      "question": "Level 2: What is 7 + 9?",
+      "options": [
+        19,
+        16,
+        8,
+        11
+      ],
+      "answer": 16
+    },
+    {
+      "id": 35,
+      "question": "Level 2: What is 8 + 9?",
+      "options": [
+        23,
+        17,
+        25,
+        27
+      ],
+      "answer": 17
+    },
+    {
+      "id": 36,
+      "question": "Level 2: What is 5 + 9?",
+      "options": [
+        24,
+        17,
+        21,
+        14
+      ],
+      "answer": 14
+    },
+    {
+      "id": 37,
+      "question": "Level 2: What is 8 + 9?",
+      "options": [
+        21,
+        18,
+        16,
+        17
+      ],
+      "answer": 17
+    },
+    {
+      "id": 38,
+      "question": "Level 2: What is 8 + 7?",
+      "options": [
+        23,
+        17,
+        8,
+        15
+      ],
+      "answer": 15
+    },
+    {
+      "id": 39,
+      "question": "Level 2: What is 8 + 8?",
+      "options": [
+        26,
+        17,
+        16,
+        21
+      ],
+      "answer": 16
+    },
+    {
+      "id": 40,
+      "question": "Level 2: What is 5 + 5?",
+      "options": [
+        15,
+        20,
+        10,
+        16
+      ],
+      "answer": 10
+    },
+    {
+      "id": 41,
+      "question": "Level 2: What is 6 + 7?",
+      "options": [
+        13,
+        7,
+        18,
+        4
+      ],
+      "answer": 13
+    },
+    {
+      "id": 42,
+      "question": "Level 2: What is 9 + 6?",
+      "options": [
+        20,
+        15,
+        5,
+        17
+      ],
+      "answer": 15
+    },
+    {
+      "id": 43,
+      "question": "Level 2: What is 9 + 9?",
+      "options": [
+        18,
+        19,
+        20,
+        8
+      ],
+      "answer": 18
+    },
+    {
+      "id": 44,
+      "question": "Level 2: What is 9 + 7?",
+      "options": [
+        14,
+        15,
+        16,
+        26
+      ],
+      "answer": 16
+    },
+    {
+      "id": 45,
+      "question": "Level 2: What is 7 + 9?",
+      "options": [
+        16,
+        9,
+        19,
+        12
+      ],
+      "answer": 16
+    },
+    {
+      "id": 46,
+      "question": "Level 2: What is 8 + 5?",
+      "options": [
+        13,
+        16,
+        8,
+        15
+      ],
+      "answer": 13
+    },
+    {
+      "id": 47,
+      "question": "Level 2: What is 5 + 7?",
+      "options": [
+        8,
+        12,
+        6,
+        18
+      ],
+      "answer": 12
+    },
+    {
+      "id": 48,
+      "question": "Level 2: What is 9 + 9?",
+      "options": [
+        20,
+        18,
+        21,
+        23
+      ],
+      "answer": 18
+    },
+    {
+      "id": 49,
+      "question": "Level 2: What is 5 + 8?",
+      "options": [
+        13,
+        17,
+        21,
+        9
+      ],
+      "answer": 13
+    },
+    {
+      "id": 50,
+      "question": "Level 2: What is 7 + 6?",
+      "options": [
+        13,
+        10,
+        23,
+        5
+      ],
+      "answer": 13
     }
   ]
 }

--- a/data/questions/level_3_questions.json
+++ b/data/questions/level_3_questions.json
@@ -2,25 +2,553 @@
   "questions": [
     {
       "id": 1,
-      "question": "Level 3: What is 5 + 8?",
+      "question": "Level 3: What is 2 + 3 + 2?",
       "options": [
-        1,
-        13,
+        4,
+        7,
+        6,
+        14
+      ],
+      "answer": 7
+    },
+    {
+      "id": 2,
+      "question": "Level 3: What is 2 + 2 + 1?",
+      "options": [
+        10,
+        5,
         12,
-        2
+        3
+      ],
+      "answer": 5
+    },
+    {
+      "id": 3,
+      "question": "Level 3: What is 3 + 3 + 1?",
+      "options": [
+        3,
+        6,
+        7,
+        9
+      ],
+      "answer": 7
+    },
+    {
+      "id": 4,
+      "question": "Level 3: What is 5 + 2 + 0?",
+      "options": [
+        4,
+        11,
+        7,
+        5
+      ],
+      "answer": 7
+    },
+    {
+      "id": 5,
+      "question": "Level 3: What is 1 + 0 + 4?",
+      "options": [
+        4,
+        6,
+        5,
+        13
+      ],
+      "answer": 5
+    },
+    {
+      "id": 6,
+      "question": "Level 3: What is 4 + 1 + 3?",
+      "options": [
+        9,
+        18,
+        13,
+        8
+      ],
+      "answer": 8
+    },
+    {
+      "id": 7,
+      "question": "Level 3: What is 1 + 5 + 1?",
+      "options": [
+        17,
+        4,
+        8,
+        7
+      ],
+      "answer": 7
+    },
+    {
+      "id": 8,
+      "question": "Level 3: What is 1 + 3 + 4?",
+      "options": [
+        12,
+        8,
+        2,
+        11
+      ],
+      "answer": 8
+    },
+    {
+      "id": 9,
+      "question": "Level 3: What is 2 + 2 + 4?",
+      "options": [
+        11,
+        18,
+        10,
+        8
+      ],
+      "answer": 8
+    },
+    {
+      "id": 10,
+      "question": "Level 3: What is 2 + 5 + 1?",
+      "options": [
+        15,
+        12,
+        16,
+        8
+      ],
+      "answer": 8
+    },
+    {
+      "id": 11,
+      "question": "Level 3: What is 5 + 4 + 5?",
+      "options": [
+        14,
+        9,
+        20,
+        4
+      ],
+      "answer": 14
+    },
+    {
+      "id": 12,
+      "question": "Level 3: What is 5 + 4 + 4?",
+      "options": [
+        13,
+        10,
+        8,
+        5
       ],
       "answer": 13
     },
     {
-      "id": 2,
-      "question": "Level 3: What is 7 + 8?",
+      "id": 13,
+      "question": "Level 3: What is 3 + 3 + 5?",
       "options": [
-        7,
-        15,
-        12,
+        18,
+        3,
+        11,
+        6
+      ],
+      "answer": 11
+    },
+    {
+      "id": 14,
+      "question": "Level 3: What is 2 + 3 + 4?",
+      "options": [
+        13,
+        9,
+        19,
         18
       ],
-      "answer": 15
+      "answer": 9
+    },
+    {
+      "id": 15,
+      "question": "Level 3: What is 4 + 2 + 2?",
+      "options": [
+        18,
+        6,
+        10,
+        8
+      ],
+      "answer": 8
+    },
+    {
+      "id": 16,
+      "question": "Level 3: What is 2 + 1 + 3?",
+      "options": [
+        10,
+        7,
+        6,
+        5
+      ],
+      "answer": 6
+    },
+    {
+      "id": 17,
+      "question": "Level 3: What is 2 + 0 + 2?",
+      "options": [
+        4,
+        2,
+        9,
+        6
+      ],
+      "answer": 4
+    },
+    {
+      "id": 18,
+      "question": "Level 3: What is 5 + 5 + 2?",
+      "options": [
+        11,
+        18,
+        19,
+        12
+      ],
+      "answer": 12
+    },
+    {
+      "id": 19,
+      "question": "Level 3: What is 5 + 0 + 4?",
+      "options": [
+        9,
+        11,
+        2,
+        13
+      ],
+      "answer": 9
+    },
+    {
+      "id": 20,
+      "question": "Level 3: What is 1 + 0 + 3?",
+      "options": [
+        2,
+        12,
+        4,
+        3
+      ],
+      "answer": 4
+    },
+    {
+      "id": 21,
+      "question": "Level 3: What is 5 + 3 + 5?",
+      "options": [
+        15,
+        11,
+        13,
+        9
+      ],
+      "answer": 13
+    },
+    {
+      "id": 22,
+      "question": "Level 3: What is 3 + 4 + 4?",
+      "options": [
+        19,
+        11,
+        8,
+        18
+      ],
+      "answer": 11
+    },
+    {
+      "id": 23,
+      "question": "Level 3: What is 3 + 0 + 1?",
+      "options": [
+        5,
+        12,
+        3,
+        4
+      ],
+      "answer": 4
+    },
+    {
+      "id": 24,
+      "question": "Level 3: What is 4 + 2 + 3?",
+      "options": [
+        12,
+        11,
+        9,
+        18
+      ],
+      "answer": 9
+    },
+    {
+      "id": 25,
+      "question": "Level 3: What is 1 + 5 + 5?",
+      "options": [
+        11,
+        19,
+        15,
+        2
+      ],
+      "answer": 11
+    },
+    {
+      "id": 26,
+      "question": "Level 3: What is 3 + 5 + 2?",
+      "options": [
+        19,
+        15,
+        8,
+        10
+      ],
+      "answer": 10
+    },
+    {
+      "id": 27,
+      "question": "Level 3: What is 4 + 1 + 5?",
+      "options": [
+        5,
+        10,
+        8,
+        16
+      ],
+      "answer": 10
+    },
+    {
+      "id": 28,
+      "question": "Level 3: What is 5 + 4 + 1?",
+      "options": [
+        3,
+        10,
+        16,
+        18
+      ],
+      "answer": 10
+    },
+    {
+      "id": 29,
+      "question": "Level 3: What is 1 + 5 + 2?",
+      "options": [
+        8,
+        11,
+        7,
+        6
+      ],
+      "answer": 8
+    },
+    {
+      "id": 30,
+      "question": "Level 3: What is 4 + 0 + 2?",
+      "options": [
+        9,
+        6,
+        12,
+        2
+      ],
+      "answer": 6
+    },
+    {
+      "id": 31,
+      "question": "Level 3: What is 3 + 3 + 4?",
+      "options": [
+        10,
+        1,
+        11,
+        14
+      ],
+      "answer": 10
+    },
+    {
+      "id": 32,
+      "question": "Level 3: What is 4 + 5 + 2?",
+      "options": [
+        17,
+        1,
+        12,
+        11
+      ],
+      "answer": 11
+    },
+    {
+      "id": 33,
+      "question": "Level 3: What is 0 + 5 + 3?",
+      "options": [
+        9,
+        13,
+        18,
+        8
+      ],
+      "answer": 8
+    },
+    {
+      "id": 34,
+      "question": "Level 3: What is 3 + 5 + 1?",
+      "options": [
+        17,
+        9,
+        6,
+        7
+      ],
+      "answer": 9
+    },
+    {
+      "id": 35,
+      "question": "Level 3: What is 0 + 1 + 3?",
+      "options": [
+        1,
+        8,
+        4,
+        12
+      ],
+      "answer": 4
+    },
+    {
+      "id": 36,
+      "question": "Level 3: What is 3 + 0 + 5?",
+      "options": [
+        12,
+        4,
+        3,
+        8
+      ],
+      "answer": 8
+    },
+    {
+      "id": 37,
+      "question": "Level 3: What is 1 + 1 + 5?",
+      "options": [
+        7,
+        10,
+        8,
+        5
+      ],
+      "answer": 7
+    },
+    {
+      "id": 38,
+      "question": "Level 3: What is 3 + 0 + 4?",
+      "options": [
+        3,
+        5,
+        12,
+        7
+      ],
+      "answer": 7
+    },
+    {
+      "id": 39,
+      "question": "Level 3: What is 2 + 4 + 4?",
+      "options": [
+        20,
+        1,
+        10,
+        12
+      ],
+      "answer": 10
+    },
+    {
+      "id": 40,
+      "question": "Level 3: What is 5 + 2 + 5?",
+      "options": [
+        12,
+        10,
+        2,
+        20
+      ],
+      "answer": 12
+    },
+    {
+      "id": 41,
+      "question": "Level 3: What is 4 + 0 + 1?",
+      "options": [
+        6,
+        13,
+        5,
+        1
+      ],
+      "answer": 5
+    },
+    {
+      "id": 42,
+      "question": "Level 3: What is 3 + 0 + 0?",
+      "options": [
+        13,
+        1,
+        3,
+        5
+      ],
+      "answer": 3
+    },
+    {
+      "id": 43,
+      "question": "Level 3: What is 2 + 0 + 4?",
+      "options": [
+        5,
+        6,
+        15,
+        8
+      ],
+      "answer": 6
+    },
+    {
+      "id": 44,
+      "question": "Level 3: What is 0 + 0 + 5?",
+      "options": [
+        15,
+        11,
+        5,
+        10
+      ],
+      "answer": 5
+    },
+    {
+      "id": 45,
+      "question": "Level 3: What is 4 + 2 + 5?",
+      "options": [
+        11,
+        12,
+        6,
+        19
+      ],
+      "answer": 11
+    },
+    {
+      "id": 46,
+      "question": "Level 3: What is 2 + 5 + 5?",
+      "options": [
+        18,
+        10,
+        8,
+        12
+      ],
+      "answer": 12
+    },
+    {
+      "id": 47,
+      "question": "Level 3: What is 3 + 3 + 2?",
+      "options": [
+        15,
+        8,
+        18,
+        2
+      ],
+      "answer": 8
+    },
+    {
+      "id": 48,
+      "question": "Level 3: What is 1 + 1 + 1?",
+      "options": [
+        13,
+        3,
+        7,
+        12
+      ],
+      "answer": 3
+    },
+    {
+      "id": 49,
+      "question": "Level 3: What is 5 + 5 + 3?",
+      "options": [
+        7,
+        23,
+        13,
+        18
+      ],
+      "answer": 13
+    },
+    {
+      "id": 50,
+      "question": "Level 3: What is 4 + 3 + 3?",
+      "options": [
+        16,
+        3,
+        10,
+        2
+      ],
+      "answer": 10
     }
   ]
 }

--- a/data/questions/level_4_questions.json
+++ b/data/questions/level_4_questions.json
@@ -2,25 +2,553 @@
   "questions": [
     {
       "id": 1,
-      "question": "Level 4: What is 5 + 8?",
+      "question": "Level 4: What is 76 + 0?",
       "options": [
-        1,
-        13,
+        73,
+        76,
+        85,
+        84
+      ],
+      "answer": 76
+    },
+    {
+      "id": 2,
+      "question": "Level 4: What is 19 + 1?",
+      "options": [
+        20,
+        26,
+        17,
+        25
+      ],
+      "answer": 20
+    },
+    {
+      "id": 3,
+      "question": "Level 4: What is 20 + 5?",
+      "options": [
+        27,
+        22,
+        28,
+        25
+      ],
+      "answer": 25
+    },
+    {
+      "id": 4,
+      "question": "Level 4: What is 90 + 0?",
+      "options": [
+        88,
+        93,
+        82,
+        90
+      ],
+      "answer": 90
+    },
+    {
+      "id": 5,
+      "question": "Level 4: What is 77 + 1?",
+      "options": [
+        79,
+        78,
+        71,
+        73
+      ],
+      "answer": 78
+    },
+    {
+      "id": 6,
+      "question": "Level 4: What is 80 + 2?",
+      "options": [
+        89,
+        82,
+        84,
+        72
+      ],
+      "answer": 82
+    },
+    {
+      "id": 7,
+      "question": "Level 4: What is 83 + 0?",
+      "options": [
+        83,
+        92,
+        75,
+        79
+      ],
+      "answer": 83
+    },
+    {
+      "id": 8,
+      "question": "Level 4: What is 40 + 4?",
+      "options": [
+        44,
+        47,
+        53,
+        50
+      ],
+      "answer": 44
+    },
+    {
+      "id": 9,
+      "question": "Level 4: What is 50 + 0?",
+      "options": [
+        53,
+        52,
+        50,
+        47
+      ],
+      "answer": 50
+    },
+    {
+      "id": 10,
+      "question": "Level 4: What is 47 + 2?",
+      "options": [
+        45,
+        49,
+        40,
+        51
+      ],
+      "answer": 49
+    },
+    {
+      "id": 11,
+      "question": "Level 4: What is 76 + 1?",
+      "options": [
+        87,
+        81,
+        78,
+        77
+      ],
+      "answer": 77
+    },
+    {
+      "id": 12,
+      "question": "Level 4: What is 41 + 1?",
+      "options": [
+        35,
+        40,
+        42,
+        32
+      ],
+      "answer": 42
+    },
+    {
+      "id": 13,
+      "question": "Level 4: What is 25 + 5?",
+      "options": [
+        30,
+        38,
+        32,
+        26
+      ],
+      "answer": 30
+    },
+    {
+      "id": 14,
+      "question": "Level 4: What is 46 + 1?",
+      "options": [
+        47,
+        53,
+        54,
+        40
+      ],
+      "answer": 47
+    },
+    {
+      "id": 15,
+      "question": "Level 4: What is 57 + 5?",
+      "options": [
+        62,
+        68,
+        66,
+        55
+      ],
+      "answer": 62
+    },
+    {
+      "id": 16,
+      "question": "Level 4: What is 60 + 0?",
+      "options": [
+        63,
+        67,
+        60,
+        54
+      ],
+      "answer": 60
+    },
+    {
+      "id": 17,
+      "question": "Level 4: What is 52 + 3?",
+      "options": [
+        63,
+        52,
+        61,
+        55
+      ],
+      "answer": 55
+    },
+    {
+      "id": 18,
+      "question": "Level 4: What is 87 + 0?",
+      "options": [
+        92,
+        90,
+        77,
+        87
+      ],
+      "answer": 87
+    },
+    {
+      "id": 19,
+      "question": "Level 4: What is 54 + 4?",
+      "options": [
+        60,
+        65,
+        62,
+        58
+      ],
+      "answer": 58
+    },
+    {
+      "id": 20,
+      "question": "Level 4: What is 38 + 1?",
+      "options": [
+        33,
+        37,
+        39,
+        44
+      ],
+      "answer": 39
+    },
+    {
+      "id": 21,
+      "question": "Level 4: What is 85 + 0?",
+      "options": [
+        95,
+        90,
+        86,
+        85
+      ],
+      "answer": 85
+    },
+    {
+      "id": 22,
+      "question": "Level 4: What is 10 + 3?",
+      "options": [
+        19,
         12,
-        2
+        13,
+        9
       ],
       "answer": 13
     },
     {
-      "id": 2,
-      "question": "Level 4: What is 7 + 8?",
+      "id": 23,
+      "question": "Level 4: What is 41 + 5?",
       "options": [
-        7,
-        15,
+        46,
+        41,
+        37,
+        55
+      ],
+      "answer": 46
+    },
+    {
+      "id": 24,
+      "question": "Level 4: What is 94 + 1?",
+      "options": [
+        90,
+        91,
+        98,
+        95
+      ],
+      "answer": 95
+    },
+    {
+      "id": 25,
+      "question": "Level 4: What is 59 + 0?",
+      "options": [
+        54,
+        59,
+        65,
+        55
+      ],
+      "answer": 59
+    },
+    {
+      "id": 26,
+      "question": "Level 4: What is 64 + 5?",
+      "options": [
+        77,
+        69,
+        65,
+        78
+      ],
+      "answer": 69
+    },
+    {
+      "id": 27,
+      "question": "Level 4: What is 49 + 5?",
+      "options": [
+        63,
+        54,
+        59,
+        61
+      ],
+      "answer": 54
+    },
+    {
+      "id": 28,
+      "question": "Level 4: What is 70 + 2?",
+      "options": [
+        66,
+        72,
+        69,
+        63
+      ],
+      "answer": 72
+    },
+    {
+      "id": 29,
+      "question": "Level 4: What is 72 + 5?",
+      "options": [
+        80,
+        83,
+        70,
+        77
+      ],
+      "answer": 77
+    },
+    {
+      "id": 30,
+      "question": "Level 4: What is 49 + 4?",
+      "options": [
+        48,
+        49,
+        53,
+        58
+      ],
+      "answer": 53
+    },
+    {
+      "id": 31,
+      "question": "Level 4: What is 28 + 1?",
+      "options": [
+        31,
+        29,
+        33,
+        21
+      ],
+      "answer": 29
+    },
+    {
+      "id": 32,
+      "question": "Level 4: What is 55 + 2?",
+      "options": [
+        61,
+        57,
+        59,
+        51
+      ],
+      "answer": 57
+    },
+    {
+      "id": 33,
+      "question": "Level 4: What is 75 + 3?",
+      "options": [
+        78,
+        68,
+        74,
+        80
+      ],
+      "answer": 78
+    },
+    {
+      "id": 34,
+      "question": "Level 4: What is 58 + 4?",
+      "options": [
+        58,
+        62,
+        69,
+        72
+      ],
+      "answer": 62
+    },
+    {
+      "id": 35,
+      "question": "Level 4: What is 44 + 3?",
+      "options": [
+        47,
+        57,
+        52,
+        53
+      ],
+      "answer": 47
+    },
+    {
+      "id": 36,
+      "question": "Level 4: What is 78 + 4?",
+      "options": [
+        74,
+        91,
+        87,
+        82
+      ],
+      "answer": 82
+    },
+    {
+      "id": 37,
+      "question": "Level 4: What is 64 + 4?",
+      "options": [
+        67,
+        77,
+        68,
+        69
+      ],
+      "answer": 68
+    },
+    {
+      "id": 38,
+      "question": "Level 4: What is 62 + 0?",
+      "options": [
+        71,
+        52,
+        59,
+        62
+      ],
+      "answer": 62
+    },
+    {
+      "id": 39,
+      "question": "Level 4: What is 27 + 0?",
+      "options": [
+        20,
+        25,
+        27,
+        35
+      ],
+      "answer": 27
+    },
+    {
+      "id": 40,
+      "question": "Level 4: What is 73 + 0?",
+      "options": [
+        75,
+        79,
+        73,
+        70
+      ],
+      "answer": 73
+    },
+    {
+      "id": 41,
+      "question": "Level 4: What is 17 + 3?",
+      "options": [
+        14,
+        28,
+        20,
+        30
+      ],
+      "answer": 20
+    },
+    {
+      "id": 42,
+      "question": "Level 4: What is 22 + 2?",
+      "options": [
+        27,
+        14,
+        26,
+        24
+      ],
+      "answer": 24
+    },
+    {
+      "id": 43,
+      "question": "Level 4: What is 57 + 0?",
+      "options": [
+        50,
+        51,
+        57,
+        47
+      ],
+      "answer": 57
+    },
+    {
+      "id": 44,
+      "question": "Level 4: What is 66 + 2?",
+      "options": [
+        78,
+        68,
+        66,
+        70
+      ],
+      "answer": 68
+    },
+    {
+      "id": 45,
+      "question": "Level 4: What is 74 + 1?",
+      "options": [
+        84,
+        75,
+        85,
+        76
+      ],
+      "answer": 75
+    },
+    {
+      "id": 46,
+      "question": "Level 4: What is 55 + 0?",
+      "options": [
+        62,
+        45,
+        55,
+        61
+      ],
+      "answer": 55
+    },
+    {
+      "id": 47,
+      "question": "Level 4: What is 91 + 1?",
+      "options": [
+        86,
+        92,
+        93,
+        90
+      ],
+      "answer": 92
+    },
+    {
+      "id": 48,
+      "question": "Level 4: What is 79 + 1?",
+      "options": [
+        88,
+        78,
+        72,
+        80
+      ],
+      "answer": 80
+    },
+    {
+      "id": 49,
+      "question": "Level 4: What is 18 + 0?",
+      "options": [
+        26,
+        23,
         12,
         18
       ],
-      "answer": 15
+      "answer": 18
+    },
+    {
+      "id": 50,
+      "question": "Level 4: What is 70 + 1?",
+      "options": [
+        71,
+        78,
+        72,
+        64
+      ],
+      "answer": 71
     }
   ]
 }

--- a/data/questions/level_5_questions.json
+++ b/data/questions/level_5_questions.json
@@ -1,0 +1,554 @@
+{
+  "questions": [
+    {
+      "id": 1,
+      "question": "Level 5: What is 15 + 1 + 0?",
+      "options": [
+        16,
+        10,
+        24,
+        18
+      ],
+      "answer": 16
+    },
+    {
+      "id": 2,
+      "question": "Level 5: What is 91 + 1 + 3?",
+      "options": [
+        89,
+        97,
+        85,
+        95
+      ],
+      "answer": 95
+    },
+    {
+      "id": 3,
+      "question": "Level 5: What is 77 + 2 + 5?",
+      "options": [
+        78,
+        89,
+        83,
+        84
+      ],
+      "answer": 84
+    },
+    {
+      "id": 4,
+      "question": "Level 5: What is 31 + 5 + 4?",
+      "options": [
+        44,
+        40,
+        35,
+        36
+      ],
+      "answer": 40
+    },
+    {
+      "id": 5,
+      "question": "Level 5: What is 73 + 1 + 3?",
+      "options": [
+        80,
+        73,
+        77,
+        83
+      ],
+      "answer": 77
+    },
+    {
+      "id": 6,
+      "question": "Level 5: What is 36 + 3 + 5?",
+      "options": [
+        37,
+        44,
+        42,
+        43
+      ],
+      "answer": 44
+    },
+    {
+      "id": 7,
+      "question": "Level 5: What is 67 + 0 + 1?",
+      "options": [
+        68,
+        63,
+        67,
+        62
+      ],
+      "answer": 68
+    },
+    {
+      "id": 8,
+      "question": "Level 5: What is 89 + 2 + 3?",
+      "options": [
+        88,
+        85,
+        87,
+        94
+      ],
+      "answer": 94
+    },
+    {
+      "id": 9,
+      "question": "Level 5: What is 51 + 2 + 4?",
+      "options": [
+        56,
+        57,
+        52,
+        48
+      ],
+      "answer": 57
+    },
+    {
+      "id": 10,
+      "question": "Level 5: What is 43 + 3 + 2?",
+      "options": [
+        48,
+        41,
+        46,
+        51
+      ],
+      "answer": 48
+    },
+    {
+      "id": 11,
+      "question": "Level 5: What is 48 + 2 + 0?",
+      "options": [
+        41,
+        43,
+        50,
+        57
+      ],
+      "answer": 50
+    },
+    {
+      "id": 12,
+      "question": "Level 5: What is 89 + 0 + 1?",
+      "options": [
+        98,
+        95,
+        90,
+        99
+      ],
+      "answer": 90
+    },
+    {
+      "id": 13,
+      "question": "Level 5: What is 22 + 2 + 1?",
+      "options": [
+        25,
+        28,
+        33,
+        17
+      ],
+      "answer": 25
+    },
+    {
+      "id": 14,
+      "question": "Level 5: What is 45 + 0 + 0?",
+      "options": [
+        35,
+        45,
+        39,
+        36
+      ],
+      "answer": 45
+    },
+    {
+      "id": 15,
+      "question": "Level 5: What is 31 + 1 + 2?",
+      "options": [
+        40,
+        24,
+        34,
+        35
+      ],
+      "answer": 34
+    },
+    {
+      "id": 16,
+      "question": "Level 5: What is 18 + 1 + 5?",
+      "options": [
+        31,
+        33,
+        24,
+        17
+      ],
+      "answer": 24
+    },
+    {
+      "id": 17,
+      "question": "Level 5: What is 57 + 2 + 2?",
+      "options": [
+        71,
+        61,
+        63,
+        68
+      ],
+      "answer": 61
+    },
+    {
+      "id": 18,
+      "question": "Level 5: What is 23 + 4 + 2?",
+      "options": [
+        30,
+        20,
+        39,
+        29
+      ],
+      "answer": 29
+    },
+    {
+      "id": 19,
+      "question": "Level 5: What is 75 + 2 + 4?",
+      "options": [
+        81,
+        77,
+        84,
+        73
+      ],
+      "answer": 81
+    },
+    {
+      "id": 20,
+      "question": "Level 5: What is 31 + 4 + 3?",
+      "options": [
+        33,
+        36,
+        38,
+        35
+      ],
+      "answer": 38
+    },
+    {
+      "id": 21,
+      "question": "Level 5: What is 33 + 4 + 0?",
+      "options": [
+        43,
+        33,
+        27,
+        37
+      ],
+      "answer": 37
+    },
+    {
+      "id": 22,
+      "question": "Level 5: What is 85 + 2 + 0?",
+      "options": [
+        80,
+        96,
+        87,
+        93
+      ],
+      "answer": 87
+    },
+    {
+      "id": 23,
+      "question": "Level 5: What is 21 + 4 + 3?",
+      "options": [
+        26,
+        25,
+        28,
+        34
+      ],
+      "answer": 28
+    },
+    {
+      "id": 24,
+      "question": "Level 5: What is 42 + 2 + 2?",
+      "options": [
+        39,
+        54,
+        37,
+        46
+      ],
+      "answer": 46
+    },
+    {
+      "id": 25,
+      "question": "Level 5: What is 17 + 3 + 3?",
+      "options": [
+        32,
+        23,
+        16,
+        14
+      ],
+      "answer": 23
+    },
+    {
+      "id": 26,
+      "question": "Level 5: What is 73 + 0 + 1?",
+      "options": [
+        82,
+        66,
+        74,
+        73
+      ],
+      "answer": 74
+    },
+    {
+      "id": 27,
+      "question": "Level 5: What is 68 + 2 + 3?",
+      "options": [
+        70,
+        67,
+        73,
+        64
+      ],
+      "answer": 73
+    },
+    {
+      "id": 28,
+      "question": "Level 5: What is 25 + 3 + 5?",
+      "options": [
+        30,
+        36,
+        40,
+        33
+      ],
+      "answer": 33
+    },
+    {
+      "id": 29,
+      "question": "Level 5: What is 83 + 0 + 5?",
+      "options": [
+        83,
+        88,
+        81,
+        87
+      ],
+      "answer": 88
+    },
+    {
+      "id": 30,
+      "question": "Level 5: What is 43 + 0 + 4?",
+      "options": [
+        45,
+        52,
+        57,
+        47
+      ],
+      "answer": 47
+    },
+    {
+      "id": 31,
+      "question": "Level 5: What is 89 + 1 + 0?",
+      "options": [
+        90,
+        85,
+        99,
+        86
+      ],
+      "answer": 90
+    },
+    {
+      "id": 32,
+      "question": "Level 5: What is 67 + 2 + 5?",
+      "options": [
+        72,
+        69,
+        76,
+        74
+      ],
+      "answer": 74
+    },
+    {
+      "id": 33,
+      "question": "Level 5: What is 64 + 5 + 3?",
+      "options": [
+        72,
+        65,
+        81,
+        69
+      ],
+      "answer": 72
+    },
+    {
+      "id": 34,
+      "question": "Level 5: What is 31 + 3 + 3?",
+      "options": [
+        36,
+        41,
+        37,
+        27
+      ],
+      "answer": 37
+    },
+    {
+      "id": 35,
+      "question": "Level 5: What is 42 + 2 + 3?",
+      "options": [
+        47,
+        55,
+        37,
+        46
+      ],
+      "answer": 47
+    },
+    {
+      "id": 36,
+      "question": "Level 5: What is 81 + 4 + 5?",
+      "options": [
+        97,
+        98,
+        90,
+        80
+      ],
+      "answer": 90
+    },
+    {
+      "id": 37,
+      "question": "Level 5: What is 85 + 4 + 2?",
+      "options": [
+        90,
+        82,
+        91,
+        94
+      ],
+      "answer": 91
+    },
+    {
+      "id": 38,
+      "question": "Level 5: What is 93 + 2 + 2?",
+      "options": [
+        99,
+        95,
+        90,
+        97
+      ],
+      "answer": 97
+    },
+    {
+      "id": 39,
+      "question": "Level 5: What is 80 + 4 + 2?",
+      "options": [
+        77,
+        87,
+        86,
+        96
+      ],
+      "answer": 86
+    },
+    {
+      "id": 40,
+      "question": "Level 5: What is 71 + 4 + 4?",
+      "options": [
+        85,
+        89,
+        79,
+        72
+      ],
+      "answer": 79
+    },
+    {
+      "id": 41,
+      "question": "Level 5: What is 43 + 1 + 1?",
+      "options": [
+        43,
+        45,
+        38,
+        40
+      ],
+      "answer": 45
+    },
+    {
+      "id": 42,
+      "question": "Level 5: What is 65 + 2 + 2?",
+      "options": [
+        78,
+        66,
+        74,
+        69
+      ],
+      "answer": 69
+    },
+    {
+      "id": 43,
+      "question": "Level 5: What is 23 + 2 + 4?",
+      "options": [
+        35,
+        20,
+        29,
+        34
+      ],
+      "answer": 29
+    },
+    {
+      "id": 44,
+      "question": "Level 5: What is 65 + 5 + 5?",
+      "options": [
+        79,
+        77,
+        67,
+        75
+      ],
+      "answer": 75
+    },
+    {
+      "id": 45,
+      "question": "Level 5: What is 11 + 5 + 2?",
+      "options": [
+        21,
+        18,
+        12,
+        23
+      ],
+      "answer": 18
+    },
+    {
+      "id": 46,
+      "question": "Level 5: What is 44 + 3 + 5?",
+      "options": [
+        43,
+        54,
+        52,
+        59
+      ],
+      "answer": 52
+    },
+    {
+      "id": 47,
+      "question": "Level 5: What is 21 + 1 + 5?",
+      "options": [
+        35,
+        21,
+        18,
+        27
+      ],
+      "answer": 27
+    },
+    {
+      "id": 48,
+      "question": "Level 5: What is 67 + 0 + 0?",
+      "options": [
+        76,
+        67,
+        71,
+        70
+      ],
+      "answer": 67
+    },
+    {
+      "id": 49,
+      "question": "Level 5: What is 87 + 1 + 1?",
+      "options": [
+        81,
+        88,
+        96,
+        89
+      ],
+      "answer": 89
+    },
+    {
+      "id": 50,
+      "question": "Level 5: What is 80 + 3 + 5?",
+      "options": [
+        88,
+        94,
+        91,
+        85
+      ],
+      "answer": 88
+    }
+  ]
+}

--- a/data/questions/level_6_questions.json
+++ b/data/questions/level_6_questions.json
@@ -1,0 +1,554 @@
+{
+  "questions": [
+    {
+      "id": 1,
+      "question": "Level 6: What is 11 + 12?",
+      "options": [
+        30,
+        23,
+        26,
+        28
+      ],
+      "answer": 23
+    },
+    {
+      "id": 2,
+      "question": "Level 6: What is 13 + 80?",
+      "options": [
+        86,
+        93,
+        92,
+        99
+      ],
+      "answer": 93
+    },
+    {
+      "id": 3,
+      "question": "Level 6: What is 77 + 20?",
+      "options": [
+        97,
+        89,
+        95,
+        88
+      ],
+      "answer": 97
+    },
+    {
+      "id": 4,
+      "question": "Level 6: What is 19 + 66?",
+      "options": [
+        83,
+        81,
+        95,
+        85
+      ],
+      "answer": 85
+    },
+    {
+      "id": 5,
+      "question": "Level 6: What is 47 + 48?",
+      "options": [
+        87,
+        95,
+        92,
+        97
+      ],
+      "answer": 95
+    },
+    {
+      "id": 6,
+      "question": "Level 6: What is 27 + 42?",
+      "options": [
+        68,
+        69,
+        64,
+        71
+      ],
+      "answer": 69
+    },
+    {
+      "id": 7,
+      "question": "Level 6: What is 82 + 10?",
+      "options": [
+        85,
+        92,
+        93,
+        91
+      ],
+      "answer": 92
+    },
+    {
+      "id": 8,
+      "question": "Level 6: What is 34 + 46?",
+      "options": [
+        80,
+        88,
+        85,
+        75
+      ],
+      "answer": 80
+    },
+    {
+      "id": 9,
+      "question": "Level 6: What is 47 + 18?",
+      "options": [
+        73,
+        65,
+        74,
+        60
+      ],
+      "answer": 65
+    },
+    {
+      "id": 10,
+      "question": "Level 6: What is 55 + 22?",
+      "options": [
+        77,
+        84,
+        80,
+        71
+      ],
+      "answer": 77
+    },
+    {
+      "id": 11,
+      "question": "Level 6: What is 26 + 13?",
+      "options": [
+        29,
+        35,
+        41,
+        39
+      ],
+      "answer": 39
+    },
+    {
+      "id": 12,
+      "question": "Level 6: What is 64 + 25?",
+      "options": [
+        89,
+        98,
+        79,
+        88
+      ],
+      "answer": 89
+    },
+    {
+      "id": 13,
+      "question": "Level 6: What is 16 + 23?",
+      "options": [
+        31,
+        39,
+        40,
+        45
+      ],
+      "answer": 39
+    },
+    {
+      "id": 14,
+      "question": "Level 6: What is 47 + 34?",
+      "options": [
+        73,
+        81,
+        72,
+        88
+      ],
+      "answer": 81
+    },
+    {
+      "id": 15,
+      "question": "Level 6: What is 39 + 51?",
+      "options": [
+        98,
+        90,
+        84,
+        91
+      ],
+      "answer": 90
+    },
+    {
+      "id": 16,
+      "question": "Level 6: What is 16 + 12?",
+      "options": [
+        30,
+        35,
+        28,
+        31
+      ],
+      "answer": 28
+    },
+    {
+      "id": 17,
+      "question": "Level 6: What is 36 + 22?",
+      "options": [
+        58,
+        64,
+        62,
+        48
+      ],
+      "answer": 58
+    },
+    {
+      "id": 18,
+      "question": "Level 6: What is 21 + 40?",
+      "options": [
+        66,
+        53,
+        62,
+        61
+      ],
+      "answer": 61
+    },
+    {
+      "id": 19,
+      "question": "Level 6: What is 26 + 20?",
+      "options": [
+        46,
+        53,
+        39,
+        48
+      ],
+      "answer": 46
+    },
+    {
+      "id": 20,
+      "question": "Level 6: What is 17 + 60?",
+      "options": [
+        77,
+        79,
+        87,
+        78
+      ],
+      "answer": 77
+    },
+    {
+      "id": 21,
+      "question": "Level 6: What is 11 + 74?",
+      "options": [
+        80,
+        89,
+        86,
+        85
+      ],
+      "answer": 85
+    },
+    {
+      "id": 22,
+      "question": "Level 6: What is 20 + 74?",
+      "options": [
+        94,
+        95,
+        87,
+        93
+      ],
+      "answer": 94
+    },
+    {
+      "id": 23,
+      "question": "Level 6: What is 17 + 46?",
+      "options": [
+        67,
+        63,
+        66,
+        61
+      ],
+      "answer": 63
+    },
+    {
+      "id": 24,
+      "question": "Level 6: What is 30 + 62?",
+      "options": [
+        92,
+        98,
+        93,
+        89
+      ],
+      "answer": 92
+    },
+    {
+      "id": 25,
+      "question": "Level 6: What is 37 + 59?",
+      "options": [
+        96,
+        91,
+        86,
+        95
+      ],
+      "answer": 96
+    },
+    {
+      "id": 26,
+      "question": "Level 6: What is 32 + 48?",
+      "options": [
+        75,
+        80,
+        89,
+        84
+      ],
+      "answer": 80
+    },
+    {
+      "id": 27,
+      "question": "Level 6: What is 64 + 18?",
+      "options": [
+        80,
+        83,
+        89,
+        82
+      ],
+      "answer": 82
+    },
+    {
+      "id": 28,
+      "question": "Level 6: What is 52 + 29?",
+      "options": [
+        74,
+        77,
+        83,
+        81
+      ],
+      "answer": 81
+    },
+    {
+      "id": 29,
+      "question": "Level 6: What is 61 + 29?",
+      "options": [
+        96,
+        87,
+        95,
+        90
+      ],
+      "answer": 90
+    },
+    {
+      "id": 30,
+      "question": "Level 6: What is 44 + 53?",
+      "options": [
+        97,
+        94,
+        91,
+        90
+      ],
+      "answer": 97
+    },
+    {
+      "id": 31,
+      "question": "Level 6: What is 75 + 20?",
+      "options": [
+        89,
+        86,
+        95,
+        97
+      ],
+      "answer": 95
+    },
+    {
+      "id": 32,
+      "question": "Level 6: What is 36 + 21?",
+      "options": [
+        48,
+        57,
+        55,
+        61
+      ],
+      "answer": 57
+    },
+    {
+      "id": 33,
+      "question": "Level 6: What is 25 + 26?",
+      "options": [
+        54,
+        53,
+        60,
+        51
+      ],
+      "answer": 51
+    },
+    {
+      "id": 34,
+      "question": "Level 6: What is 12 + 11?",
+      "options": [
+        20,
+        22,
+        13,
+        23
+      ],
+      "answer": 23
+    },
+    {
+      "id": 35,
+      "question": "Level 6: What is 24 + 46?",
+      "options": [
+        72,
+        78,
+        70,
+        75
+      ],
+      "answer": 70
+    },
+    {
+      "id": 36,
+      "question": "Level 6: What is 23 + 37?",
+      "options": [
+        61,
+        60,
+        54,
+        69
+      ],
+      "answer": 60
+    },
+    {
+      "id": 37,
+      "question": "Level 6: What is 12 + 82?",
+      "options": [
+        93,
+        94,
+        90,
+        88
+      ],
+      "answer": 94
+    },
+    {
+      "id": 38,
+      "question": "Level 6: What is 19 + 50?",
+      "options": [
+        64,
+        67,
+        62,
+        69
+      ],
+      "answer": 69
+    },
+    {
+      "id": 39,
+      "question": "Level 6: What is 29 + 19?",
+      "options": [
+        48,
+        39,
+        55,
+        56
+      ],
+      "answer": 48
+    },
+    {
+      "id": 40,
+      "question": "Level 6: What is 27 + 50?",
+      "options": [
+        87,
+        75,
+        77,
+        73
+      ],
+      "answer": 77
+    },
+    {
+      "id": 41,
+      "question": "Level 6: What is 19 + 79?",
+      "options": [
+        94,
+        98,
+        91,
+        88
+      ],
+      "answer": 98
+    },
+    {
+      "id": 42,
+      "question": "Level 6: What is 53 + 28?",
+      "options": [
+        81,
+        89,
+        72,
+        83
+      ],
+      "answer": 81
+    },
+    {
+      "id": 43,
+      "question": "Level 6: What is 52 + 32?",
+      "options": [
+        77,
+        85,
+        84,
+        91
+      ],
+      "answer": 84
+    },
+    {
+      "id": 44,
+      "question": "Level 6: What is 31 + 46?",
+      "options": [
+        77,
+        80,
+        87,
+        83
+      ],
+      "answer": 77
+    },
+    {
+      "id": 45,
+      "question": "Level 6: What is 30 + 16?",
+      "options": [
+        38,
+        46,
+        44,
+        36
+      ],
+      "answer": 46
+    },
+    {
+      "id": 46,
+      "question": "Level 6: What is 42 + 18?",
+      "options": [
+        60,
+        63,
+        61,
+        51
+      ],
+      "answer": 60
+    },
+    {
+      "id": 47,
+      "question": "Level 6: What is 17 + 20?",
+      "options": [
+        46,
+        37,
+        33,
+        27
+      ],
+      "answer": 37
+    },
+    {
+      "id": 48,
+      "question": "Level 6: What is 42 + 13?",
+      "options": [
+        65,
+        57,
+        61,
+        55
+      ],
+      "answer": 55
+    },
+    {
+      "id": 49,
+      "question": "Level 6: What is 70 + 21?",
+      "options": [
+        84,
+        91,
+        88,
+        83
+      ],
+      "answer": 91
+    },
+    {
+      "id": 50,
+      "question": "Level 6: What is 10 + 57?",
+      "options": [
+        67,
+        76,
+        73,
+        72
+      ],
+      "answer": 67
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- refresh level 1-4 addition question banks with 50 compliant problems each
- add new level 5 and level 6 question files covering specified operand ranges
- ensure all answer options stay between 1 and 99 and each question lists four choices

## Testing
- python validation script to confirm question and option constraints

------
https://chatgpt.com/codex/tasks/task_e_68cb68d39948832984d877dfc447a82f