### PR TITLE
Remove duplicated binary assets from PWA test app

### DIFF
--- a/pwa-app/css/battle-card.css
+++ b/pwa-app/css/battle-card.css
@@ -1,0 +1,132 @@
+.battle-card {
+  width: 420px;
+  background: #ffffff;
+  border-radius: 8px;
+  padding: 24px;
+  box-sizing: border-box;
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.25);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+}
+
+.battle-card--pop {
+  animation: pop-in 0.4s ease-out forwards;
+}
+
+.battle-card .battle-info {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.battle-card .battle-goals-title {
+  margin: 0;
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 20px;
+  color: #272b34;
+}
+
+.battle-card .math-type {
+  margin: 0;
+  font-size: 20px;
+  color: #778099;
+}
+
+.battle-card .battle-title {
+  margin: 0;
+  font-size: 32px;
+  font-weight: 700;
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  color: #272b34;
+}
+
+.battle-card .enemy-image {
+  width: 220px;
+  height: 220px;
+}
+
+.battle-card .battle-stats {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px 16px;
+  border-radius: 8px;
+  background-color: transparent;
+}
+
+.battle-card .battle-stat {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  padding: 16px 16px;
+  border-radius: 8px;
+  background-color: #F4F6FA;
+}
+
+.battle-card .stat-label {
+  font-size: 18px;
+  color: #888888;
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+}
+
+.battle-card .stat-value {
+  font-size: 24px;
+  font-weight: 700;
+  color: #006AFF;
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+}
+
+.battle-card .stat-value {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.battle-card .stat-value.goal-result--met {
+  color: #00B600;
+}
+
+.battle-card .stat-value.goal-result--missed {
+  color: #E20000;
+}
+
+.battle-card .stat-value .goal-result-icon {
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+}
+
+.btn-primary {
+  width: 100%;
+  height: 64px;
+  background: #006aff;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 20px;
+  cursor: pointer;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+@keyframes pop-in {
+  0% {
+    transform: scale(0.88);
+    opacity: 0;
+  }
+  80% {
+    transform: scale(1.04);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}

--- a/pwa-app/css/battle.css
+++ b/pwa-app/css/battle.css
@@ -1,0 +1,371 @@
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  min-height: 100%;
+  overflow: hidden;
+  background: url('../images/background/background.png') no-repeat center/cover;
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+}
+
+#battle {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+#battle-monster,
+#battle-shellfin {
+  position: absolute;
+  width: 300px;
+  max-width: 80vw;
+  opacity: 0;
+  filter: blur(18px);
+  transform: translateZ(0);
+  will-change: transform, opacity, filter;
+}
+
+#battle-monster.battle-ready,
+#battle-shellfin.battle-ready {
+  opacity: 1;
+  filter: blur(0);
+}
+
+#battle-monster.slide-in {
+  animation: monster-enter 0.9s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+#battle-shellfin.slide-in {
+  animation: hero-enter 0.9s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation-delay: 0.08s;
+}
+
+#battle-monster {
+  top: 10%;
+  left: 55%;
+}
+
+#battle-shellfin {
+  bottom: 10%;
+  right: 55%;
+  transform: translateZ(0) scaleX(-1);
+  transform-origin: center;
+}
+
+#monster-stats {
+  top: 25%;
+  left: 35%;
+  --stat-delay: 0.65s;
+}
+
+#shellfin-stats {
+  bottom: 25%;
+  right: 35%;
+  --stat-delay: 0.78s;
+}
+
+.stat-box {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 16px;
+  gap: 16px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  backdrop-filter: blur(4px);
+  opacity: 0;
+  transform: translateY(24px) scale(0.95);
+  filter: blur(12px);
+  transition: opacity 0.6s ease, transform 0.6s ease, filter 0.6s ease;
+  transition-delay: var(--stat-delay, 0.6s);
+}
+
+.stat-box.show {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  filter: blur(0);
+}
+
+.stat-box .name {
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 20px;
+  color: #fff;
+}
+
+.stat-box .stats {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+}
+
+.stat-box .stat {
+  position: relative;
+  display: flex;
+  align-items: center;
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 20px;
+  color: #fff;
+}
+
+.stat-box .stat img {
+  width: 20px;
+  height: 20px;
+  margin-right: 4px;
+}
+
+.stat-box .stat .increase {
+  position: absolute;
+  top: -7px;
+  right: -5px;
+  font-size: 20px;
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  background: #00B600;
+  color: #FFFFFF;
+  border-radius: 8px;
+  padding: 6px 12px;
+  opacity: 0;
+  transform: scale(0);
+  pointer-events: none;
+}
+
+.stat-box .stat .increase.show {
+  animation: increase-pop 0.6s forwards;
+}
+
+@keyframes increase-pop {
+  0% {
+    opacity: 0;
+    transform: scale(0);
+  }
+  60% {
+    opacity: 1;
+    transform: scale(1.3);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.hp-bar {
+  width: 130px;
+  height: 12px;
+  border: 1px solid #fff;
+  border-radius: 4px;
+  margin-top: 4px;
+  overflow: hidden;
+}
+
+.hp-fill {
+  background: #FFBB00;
+  height: 100%;
+  width: 100%;
+  transition: width 0.5s ease-in-out;
+}
+
+#battle-shellfin.attack {
+  animation: hero-attack 0.8s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+#battle-monster.attack {
+  animation: monster-attack 0.8s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+@keyframes hero-enter {
+  0% {
+    transform: translateX(140%) scale(0.9) scaleX(-1);
+    opacity: 0;
+    filter: blur(16px);
+  }
+  65% {
+    transform: translateX(-3%) scale(1.04) scaleX(-1);
+    opacity: 1;
+    filter: blur(0);
+  }
+  100% {
+    transform: translateX(0) scale(1) scaleX(-1);
+    opacity: 1;
+    filter: blur(0);
+  }
+}
+
+@keyframes monster-enter {
+  0% {
+    transform: translateX(-140%) scale(0.9);
+    opacity: 0;
+    filter: blur(16px);
+  }
+  65% {
+    transform: translateX(3%) scale(1.04);
+    opacity: 1;
+    filter: blur(0);
+  }
+  100% {
+    transform: translateX(0) scale(1);
+    opacity: 1;
+    filter: blur(0);
+  }
+}
+
+@keyframes hero-attack {
+  0% {
+    transform: translateX(0) scaleX(-1);
+  }
+  50% {
+    transform: translateX(60px) scaleX(-1);
+  }
+  100% {
+    transform: translateX(0) scaleX(-1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #battle-monster,
+  #battle-shellfin {
+    opacity: 1;
+    filter: none;
+    animation: none !important;
+  }
+
+  .stat-box {
+    opacity: 1;
+    transform: none;
+    filter: none;
+    transition: none;
+  }
+}
+
+@keyframes monster-attack {
+  0% { transform: translateX(0); }
+  50% { transform: translateX(-60px); }
+  100% { transform: translateX(0); }
+}
+
+#battle-message {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.3);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease;
+  z-index: 30;
+}
+
+#battle-message.show {
+  opacity: 1;
+  visibility: visible;
+}
+
+#battle-message .content {
+  background: #fff;
+  padding: 24px;
+  border-radius: 8px;
+  text-align: center;
+}
+
+#battle-message .content p {
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 24px;
+  margin: 0 0 16px;
+}
+
+#complete-message {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.3);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  z-index: 50;
+}
+
+#complete-message.show {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+#complete-message .btn-primary {
+  width: 100%;
+  margin-top: 0;
+}
+
+.battle-stat-banner {
+  margin: 40px auto 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 48px;
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+}
+
+.battle-stat-banner .stat {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.battle-stat-banner .label {
+  font-size: 18px;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.battle-stat-banner .value {
+  font-size: 18px;
+  color: #ffffff;
+  text-transform: none;
+}
+
+.battle-dev-controls {
+  position: fixed;
+  top: 12px;
+  right: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 0;
+  background: none;
+  border: none;
+  box-shadow: none;
+  z-index: 60;
+}
+
+.battle-dev-controls--hidden {
+  display: none;
+}
+
+.battle-dev-controls__btn {
+  border: 1px solid #b9c1ce;
+  background: #ffffff;
+  color: #1d2433;
+  border-radius: 0;
+  padding: 6px 10px;
+  font: inherit;
+  font-size: 14px;
+  line-height: 1.2;
+  cursor: pointer;
+  box-shadow: none;
+  text-transform: none;
+}
+
+.battle-dev-controls__btn:focus-visible {
+  outline: 2px solid #1d2433;
+  outline-offset: 2px;
+}

--- a/pwa-app/css/index.css
+++ b/pwa-app/css/index.css
@@ -1,0 +1,436 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  color: #272B34;
+  background: url('../images/background/background.png') no-repeat center/cover;
+  position: relative;
+  overflow: hidden;
+}
+
+main.landing {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  opacity: 1;
+  transform: translate3d(0, 0, 0);
+  filter: none;
+  transition: opacity 0.6s ease, transform 0.6s ease, filter 0.6s ease;
+  will-change: opacity, transform, filter;
+}
+
+body.is-preloading {
+  overflow: hidden;
+}
+
+body.is-preloading main.landing {
+  opacity: 0;
+  transform: translate3d(0, 24px, 0) scale(0.98);
+  filter: blur(6px);
+  pointer-events: none;
+}
+
+body:not(.is-preloading) main.landing {
+  opacity: 1;
+  transform: translate3d(0, 0, 0) scale(1);
+  filter: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  main.landing {
+    transition: none;
+  }
+
+  body.is-preloading main.landing {
+    transform: none;
+    filter: none;
+  }
+}
+
+.hero {
+  position: absolute;
+  bottom: 32vh;
+  left: 50%;
+  max-width: 300px;
+  max-height: 300px;
+  transform: translate(-50%, 0);
+  animation: hero-float 3.5s ease-in-out infinite;
+  image-rendering: auto;
+  z-index: 2;
+  pointer-events: none;
+}
+
+@keyframes hero-float {
+  0%   { transform: translate(-50%, 0) translateY(0); }
+  50%  { transform: translate(-50%, 0) translateY(-32px); }
+  100% { transform: translate(-50%, 0) translateY(0); }
+}
+
+.battle-splat {
+  position: absolute;
+  bottom: calc(32vh - 16px);
+  left: 50%;
+  width: 300px;
+  height: 300px;
+  transform: translate(-50%, 0) scale(0.1);
+  transform-origin: center;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  z-index: 6;
+}
+
+.battle-splat--active {
+  visibility: visible;
+  animation: battle-splat-pop 0.6s cubic-bezier(0.24, 1.4, 0.4, 1) forwards;
+}
+
+@keyframes battle-splat-pop {
+  0% {
+    transform: translate(-50%, 0) scale(0.1) rotate(-4deg);
+    opacity: 0;
+    filter: blur(2px);
+  }
+  60% {
+    transform: translate(-50%, -12px) scale(1.08) rotate(3deg);
+    opacity: 1;
+    filter: blur(0);
+  }
+  100% {
+    transform: translate(-50%, 0) scale(1) rotate(0deg);
+    opacity: 1;
+    filter: blur(0);
+  }
+}
+
+/* Bubble field */
+.bubbles {
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  gap: clamp(24px, 8vw, 72px);
+  width: min(720px, 100%);
+  padding: 0 16px clamp(120px, 22vh, 200px);
+  overflow: visible;
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* ---- Realistic bubbles ----
+   Using animatable custom properties so multiple animations can
+   combine without fighting over 'transform'.
+*/
+@property --tx { syntax: '<length>'; initial-value: 0px; inherits: false; }
+@property --ty { syntax: '<length>'; initial-value: 0px; inherits: false; }
+@property --sx { syntax: '<number>'; initial-value: 1;   inherits: false; }
+@property --sy { syntax: '<number>'; initial-value: 1;   inherits: false; }
+@property --rot { syntax: '<angle>';  initial-value: 0deg; inherits: false; }
+
+/* SUPER-realistic, clear “water glass” bubbles */
+.bubble {
+  --drift: 0px;
+  position: relative;
+  bottom: -80px;
+  flex: 0 0 auto;
+  width: var(--size);
+  height: var(--size);
+  border-radius: 50%;
+  opacity: 0;
+
+  /* Base: faint tint so it reads against any BG */
+  background: radial-gradient(circle at 50% 45%,
+    rgba(255,255,255,0.10) 0%,
+    rgba(255,255,255,0.05) 40%,
+    rgba(255,255,255,0.02) 65%,
+    rgba(255,255,255,0.00) 100%);
+
+  /* Subtle inner/outside glow for depth */
+  box-shadow:
+    inset 0 0 10px rgba(255,255,255,0.18),
+    0 2px 12px rgba(120,170,220,0.12);
+
+  /* Transform pipeline driven by variables (kept from your version) */
+  transform: translate3d(var(--tx), var(--ty), 0) rotate(var(--rot)) scale(var(--sx), var(--sy));
+  will-change: transform, opacity;
+
+  animation:
+    bubble-rise var(--duration) cubic-bezier(.22,.61,.36,1) infinite,
+    bubble-drift calc(var(--duration) * 0.45) ease-in-out infinite alternate,
+    bubble-wobble calc(var(--duration) * 0.38) ease-in-out infinite,
+    bubble-spin   calc(var(--duration) * 0.9)  ease-in-out infinite alternate;
+  animation-delay:
+    var(--delay, 0s),
+    var(--delay, 0s),
+    var(--delay, 0s),
+    var(--delay, 0s);
+
+  /* Let highlights lift color beneath (gives glass pop) */
+  mix-blend-mode: screen; /* harmless if BG is light; looks great on dark/colored scenes */
+}
+
+/* High-end refraction: only if supported (graceful fallback above) */
+@supports ((-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))) {
+  .bubble {
+    /* Clear glass feel: blur/saturate/brighten background seen through bubble */
+    background: rgba(255,255,255,0.04); /* nearly clear */
+    -webkit-backdrop-filter: blur(6px) saturate(130%) brightness(1.06);
+            backdrop-filter: blur(6px) saturate(130%) brightness(1.06);
+  }
+}
+
+/* RIM: crisp thin edge using a mask so center stays clear */
+.bubble::before,
+.bubble::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  pointer-events: none;
+}
+
+/* Thin luminous rim + micro-rainbow sheen */
+.bubble::before {
+  /* ring drawn by mask; shows only the outer band */
+  background:
+    conic-gradient(from 210deg,
+      rgba(255,255,255,0.35) 0deg,
+      rgba(255,255,255,0.18) 120deg,
+      rgba(200,230,255,0.20) 180deg,
+      rgba(255,255,255,0.28) 270deg,
+      rgba(255,255,255,0.35) 360deg);
+  -webkit-mask: radial-gradient(closest-side,
+      transparent calc(100% - 2.5px), /* ring thickness */
+      #000 calc(100% - 2.0px));
+          mask: radial-gradient(closest-side,
+      transparent calc(100% - 2.5px),
+      #000 calc(100% - 2.0px));
+  filter: blur(0.6px);         /* soften rim a hair */
+  opacity: 0.9;
+  mix-blend-mode: screen;
+}
+
+/* SPECULAR HIGHLIGHTS: small bright dot + soft lens inside */
+.bubble::after {
+  /* two-layer highlight packed into one pseudo for perf */
+  background:
+    radial-gradient(20% 20% at 30% 28%, rgba(255,255,255,0.88) 0%, rgba(255,255,255,0.0) 100%),
+    radial-gradient(60% 50% at 55% 45%, rgba(255,255,255,0.20) 0%, rgba(255,255,255,0.06) 60%, rgba(255,255,255,0.0) 100%);
+  filter: blur(2.2px);
+  opacity: 0.85;
+  mix-blend-mode: screen;
+}
+
+/* Keep your gentle drift bias without time staggering */
+.bubble:nth-of-type(odd) { --drift: 12px; }
+.bubble:nth-of-type(3n)  { --drift: -10px; }
+
+
+/* Rise: non-linear opacity + slight pressure expansion as it ascends */
+@keyframes bubble-rise {
+  0%   { --ty: 0px;                 --sx: 0.95; --sy: 0.95; opacity: 0; }
+  10%  {                            --sx: 0.98; --sy: 0.98; opacity: 0.45; }
+  40%  {                            --sx: 1.02; --sy: 1.02; opacity: 0.92; }
+  100% { --ty: -110vh;              --sx: 1.06; --sy: 1.06; opacity: 0; }
+}
+
+/* Organic horizontal meander tied to --drift */
+@keyframes bubble-drift {
+  0%   { --tx: calc(var(--drift) * -1); }
+  100% { --tx: calc(var(--drift)); }
+}
+
+/* Water wobble: subtle squash & stretch out of phase */
+@keyframes bubble-wobble {
+  0%   { --sx: calc(var(--sx));   --sy: calc(var(--sy)); }
+  25%  { --sx: calc(var(--sx) * 0.985); --sy: calc(var(--sy) * 1.015); }
+  50%  { --sx: calc(var(--sx) * 1.01);  --sy: calc(var(--sy) * 0.99); }
+  75%  { --sx: calc(var(--sx) * 0.99);  --sy: calc(var(--sy) * 1.01); }
+  100% { --sx: calc(var(--sx));   --sy: calc(var(--sy)); }
+}
+
+/* Tiny spin for parallax sparkle */
+@keyframes bubble-spin {
+  0%   { --rot: -2deg; }
+  100% { --rot: 3deg; }
+}
+
+body.battle-overlay-open { overflow: hidden; }
+
+.battle-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(22, 28, 38, 0.25);
+  opacity: 0;
+  transform: none;
+  pointer-events: none;
+  transition: opacity 0.6s ease;
+  z-index: 10;
+}
+
+.battle-overlay .battle-overlay-card {
+  width: 420px;
+  padding: 24px;
+  opacity: 0;
+  transform: translateY(24px) scale(0.95);
+}
+
+.battle-overlay .enemy-image { width: min(220px, 60%); height: auto; }
+
+body.battle-overlay-open .battle-overlay { opacity: 1; pointer-events: auto; }
+
+.battle-overlay-card--visible {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+/* ------------------------------------------------------------------------- */
+/* Simple preload experience ---------------------------------------------- */
+
+.preloader {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
+  padding: 32px;
+  background-color: #001b41;
+  z-index: 10;
+  text-align: center;
+  transition: opacity 0.4s ease;
+}
+
+.preloader__logo {
+  width: 300px;
+  height: 300px;
+  object-fit: contain;
+}
+
+.preloader__text {
+  margin: 0;
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 32px;
+  color: #ffffff;
+}
+
+.preloader__spinner {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: 6px solid rgba(255, 255, 255, 0.2);
+  border-top-color: #ffffff;
+  animation: preloader-spin 1s linear infinite;
+}
+
+.preloader--hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .preloader {
+    transition: none;
+  }
+
+  .preloader__spinner {
+    animation-duration: 0s;
+  }
+}
+
+@keyframes preloader-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+
+.pwa-install {
+  position: relative;
+  z-index: 7;
+  margin: clamp(16px, 4vw, 32px) auto clamp(40px, 8vh, 96px);
+  padding: clamp(16px, 4vw, 32px);
+  max-width: min(420px, 90%);
+  border-radius: 28px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 18px 48px rgba(14, 57, 93, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  text-align: center;
+  color: #0a3d62;
+  backdrop-filter: blur(6px);
+}
+
+@supports not ((backdrop-filter: blur(6px))) {
+  .pwa-install {
+    background: rgba(255, 255, 255, 0.98);
+  }
+}
+
+.pwa-install__title {
+  margin: 0;
+  font-size: clamp(1.25rem, 2vw, 1.6rem);
+  letter-spacing: 0.03em;
+}
+
+.pwa-install__message {
+  margin: 0;
+  font-size: clamp(0.95rem, 1.8vw, 1.05rem);
+  line-height: 1.5;
+  color: rgba(10, 61, 98, 0.85);
+}
+
+.pwa-install__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: center;
+}
+
+.pwa-install__button {
+  width: min(260px, 100%);
+}
+
+.pwa-install__link {
+  color: #0a3d62;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.pwa-install__link:hover,
+.pwa-install__link:focus {
+  text-decoration: underline;
+}
+
+@media (min-width: 768px) {
+  .pwa-install {
+    position: absolute;
+    bottom: clamp(32px, 5vh, 72px);
+    right: clamp(32px, 6vw, 96px);
+    margin: 0;
+    text-align: left;
+    align-items: flex-start;
+  }
+
+  .pwa-install__actions {
+    flex-direction: row;
+    justify-content: flex-start;
+  }
+
+  .pwa-install__link {
+    font-size: 0.95rem;
+  }
+}

--- a/pwa-app/css/question.css
+++ b/pwa-app/css/question.css
@@ -1,0 +1,227 @@
+#question {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.3);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease;
+  z-index: 20;
+}
+
+#question.show {
+  opacity: 1;
+  visibility: visible;
+}
+
+#question .content {
+  background: #fff;
+  box-sizing: border-box;
+  padding: 24px;
+  border-radius: 8px;
+  text-align: center;
+  width: 420px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  position: relative;
+  gap: 40px;
+}
+
+#question h1 {
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 16px;
+  color: #888888;
+}
+
+#question .question-text {
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 24px;
+  margin: 0;
+  padding: 0;
+  color: #272B34;
+  width: 100%;
+  padding-top: 16px;
+}
+
+#question button {
+  width: 100%;
+  height: 64px;
+  background: #006AFF;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 20px;
+}
+
+#question button:disabled {
+  background: #D2D8E2;
+  color: #272B34;
+}
+
+#question .top-bar {
+  width: 100%;
+  align-items: center;
+  display: none;
+  visibility: hidden;
+  opacity: 0;
+  transform: translateY(10px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+#question .top-bar.show {
+  display: flex;
+  visibility: visible;
+  opacity: 1;
+  transform: translateY(0);
+}
+
+#question .top-bar.show + .question-text {
+  padding-top: 0;
+}
+
+#question .progress-wrap {
+  flex: 1;
+  position: relative;
+}
+
+#question .progress-bar {
+  width: 100%;
+  height: 16px;
+  background: #F4F6FA;
+  border-radius: 4px;
+  overflow: hidden;
+  margin-bottom: 0;
+  margin-right: 0;
+}
+
+#question .progress-bar.with-label {
+  margin-right: 0px;
+}
+
+#question .progress-fill {
+  width: 0%;
+  height: 100%;
+  background: #006AFF;
+  transition: width 0.5s ease-in-out;
+}
+
+#question .streak-label {
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 20px;
+  color: #006AFF;
+  opacity: 1;
+  transform: scale(1);
+  white-space: nowrap;
+  display: block;
+  padding-bottom: 16px;
+}
+
+#question .streak-label.show {
+  animation: streak-pop 0.6s forwards;
+}
+
+#question .streak-icon {
+  width: 56px;
+  height: 56px;
+  position: absolute;
+  top: -45px;
+  left: 174px;
+  opacity: 0;
+  transform: scale(0);
+  z-index: 1;
+  display: block;
+}
+
+#question .streak-icon.show {
+  animation: streak-pop-icon 0.6s forwards;
+}
+
+@keyframes streak-pop {
+  0% { opacity: 0; transform: scale(0); }
+  50% { opacity: 1; transform: scale(1.2); }
+  100% { opacity: 1; transform: scale(1); }
+}
+
+@keyframes streak-pop-icon {
+  0% { opacity: 0; transform: scale(0.8); }
+  50% { opacity: 1; transform: scale(2.8); }
+  100% { opacity: 1; transform: scale(2.5); }
+}
+
+#question .choices {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+  width: 100%;
+}
+
+#question .choice {
+  background: #F4F6FA;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  border: 3px solid transparent;
+  cursor: pointer;
+  padding: 16px;
+  box-sizing: border-box;
+  height: 64px;
+}
+
+#question .choice.selected {
+  background: #EBF3FF;
+  border-color: #006AFF;
+}
+
+#question .choice.correct-choice {
+  border-color: #00B600;
+  background: rgba(0, 182, 0, 0.08);
+}
+
+#question .choice.wrong-choice {
+  border-color: #E20000;
+  background: rgba(226, 0, 0, 0.08);
+}
+
+#question .choice img {
+  width: 50%;
+  height: auto;
+  object-fit: contain;
+}
+
+#question .choice p {
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 24px;
+  color: #272B34;
+  margin: 0;
+  text-align: center;
+}
+
+#question button.result {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #ffffff;
+  transition: background 0.3s;
+}
+
+#question button.result img {
+  margin-right: 8px;
+}
+
+#question button.correct {
+  background: #00AC06;
+}
+
+#question button.incorrect {
+  background: #E20000;
+}

--- a/pwa-app/css/signin.css
+++ b/pwa-app/css/signin.css
@@ -1,0 +1,121 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+}
+
+.preloader {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 24px;
+  padding: 32px;
+  background-color: #001b41;
+  text-align: center;
+}
+
+.preloader__logo {
+  width: 300px;
+  height: 300px;
+  object-fit: contain;
+}
+
+.preloader__form {
+  max-width: 420px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+}
+
+.preloader__field {
+  width: 420px;
+  max-width: 100%;
+  height: 64px;
+  padding: 0 24px;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 8px;
+  background-color: #293f5f;
+  color: #949faf;
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 20px;
+}
+
+.preloader__field::placeholder {
+  color: #949faf;
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 20px;
+}
+
+.preloader__field:focus {
+  color: #ffffff;
+  outline: 3px solid rgba(255, 255, 255, 0.5);
+  outline-offset: 0;
+}
+
+.preloader__field:focus::placeholder {
+  color: transparent;
+}
+
+.preloader__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  width: 420px;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+.preloader__spinner {
+  display: none;
+  width: 24px;
+  height: 24px;
+  border: 3px solid rgba(255, 255, 255, 0.4);
+  border-top-color: #ffffff;
+  border-radius: 50%;
+  animation: preloader-spin 0.8s linear infinite;
+}
+
+.preloader__button.is-loading .preloader__spinner {
+  display: inline-block;
+}
+
+@keyframes preloader-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.preloader__error {
+  max-width: 420px;
+  margin: 0;
+  color: #ff6b6b;
+  font-size: 16px;
+  text-align: center;
+}
+
+@media (max-width: 480px) {
+  .preloader {
+    padding: 24px;
+  }
+
+  .preloader__form {
+    max-width: none;
+  }
+}
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/pwa-app/data/levels.json
+++ b/pwa-app/data/levels.json
@@ -1,0 +1,120 @@
+{
+  "levels": [
+    {
+      "battleLevel": 1,
+      "name": "Level 1",
+      "mathType": "Addition",
+      "battle": {
+        "questionReference": {
+          "file": "questions/level_1_questions.json"
+        },
+        "accuracyGoal": 0.8,
+        "timeGoalSeconds": 120,
+        "streakGoal": 3,
+        "hero": {
+          "id": "shellfin",
+          "sprite": "../images/characters/shellfin_level_1.png",
+          "name": "Shellfin",
+          "attack": 1,
+          "health": 3,
+          "damage": 0
+        },
+        "enemy": {
+          "id": "octomurk",
+          "sprite": "../images/battle/monster_battle_1.png",
+          "name": "Octomurk",
+          "attack": 1,
+          "health": 20,
+          "damage": 0
+        }
+      }
+    },
+    {
+      "battleLevel": 2,
+      "name": "Level 2",
+      "mathType": "Addition",
+      "battle": {
+        "questionReference": {
+          "file": "questions/level_2_questions.json"
+        },
+        "accuracyGoal": 0.8,
+        "timeGoalSeconds": 90,
+        "streakGoal": 4,
+        "hero": {
+          "id": "shellfin",
+          "sprite": "../images/characters/shellfin_level_2.png",
+          "name": "Shellfin",
+          "attack": 2,
+          "health": 6,
+          "damage": 0
+        },
+        "enemy": {
+          "id": "octomurk",
+          "sprite": "../images/battle/monster_battle_2.png",
+          "name": "Octomurk",
+          "attack": 2,
+          "health": 40,
+          "damage": 0
+        }
+      }
+    },
+    {
+      "battleLevel": 3,
+      "name": "Level 3",
+      "mathType": "Addition",
+      "battle": {
+        "questionReference": {
+          "file": "questions/level_3_questions.json"
+        },
+        "accuracyGoal": 0.8,
+        "timeGoalSeconds": 90,
+        "streakGoal": 4,
+        "hero": {
+          "id": "shellfin",
+          "sprite": "../images/characters/shellfin_level_2.png",
+          "name": "Shellfin",
+          "attack": 2,
+          "health": 6,
+          "damage": 0
+        },
+        "enemy": {
+          "id": "octomurk",
+          "sprite": "../images/battle/monster_battle_2.png",
+          "name": "Octomurk",
+          "attack": 2,
+          "health": 40,
+          "damage": 0
+        }
+      }
+    },
+    {
+      "battleLevel": 4,
+      "name": "Level 4",
+      "mathType": "Addition",
+      "battle": {
+        "questionReference": {
+          "file": "questions/level_4_questions.json"
+        },
+        "accuracyGoal": 0.8,
+        "timeGoalSeconds": 90,
+        "streakGoal": 4,
+        "hero": {
+          "id": "shellfin",
+          "sprite": "../images/characters/shellfin_level_2.png",
+          "name": "Shellfin",
+          "attack": 2,
+          "health": 6,
+          "damage": 0
+        },
+        "enemy": {
+          "id": "octomurk",
+          "sprite": "../images/battle/monster_battle_2.png",
+          "name": "Octomurk",
+          "attack": 2,
+          "health": 40,
+          "damage": 0
+        }
+      }
+    }
+  ]
+}

--- a/pwa-app/data/questions/level_1_questions.json
+++ b/pwa-app/data/questions/level_1_questions.json
@@ -1,0 +1,554 @@
+{
+  "questions": [
+    {
+      "id": 1,
+      "question": "Level 1: What is 5 + 5?",
+      "options": [
+        19,
+        18,
+        12,
+        10
+      ],
+      "answer": 10
+    },
+    {
+      "id": 2,
+      "question": "Level 1: What is 5 + 3?",
+      "options": [
+        4,
+        8,
+        17,
+        3
+      ],
+      "answer": 8
+    },
+    {
+      "id": 3,
+      "question": "Level 1: What is 3 + 5?",
+      "options": [
+        2,
+        8,
+        15,
+        10
+      ],
+      "answer": 8
+    },
+    {
+      "id": 4,
+      "question": "Level 1: What is 4 + 0?",
+      "options": [
+        2,
+        12,
+        4,
+        7
+      ],
+      "answer": 4
+    },
+    {
+      "id": 5,
+      "question": "Level 1: What is 3 + 0?",
+      "options": [
+        11,
+        12,
+        8,
+        3
+      ],
+      "answer": 3
+    },
+    {
+      "id": 6,
+      "question": "Level 1: What is 3 + 5?",
+      "options": [
+        6,
+        1,
+        8,
+        5
+      ],
+      "answer": 8
+    },
+    {
+      "id": 7,
+      "question": "Level 1: What is 4 + 1?",
+      "options": [
+        2,
+        13,
+        5,
+        8
+      ],
+      "answer": 5
+    },
+    {
+      "id": 8,
+      "question": "Level 1: What is 3 + 3?",
+      "options": [
+        6,
+        15,
+        2,
+        16
+      ],
+      "answer": 6
+    },
+    {
+      "id": 9,
+      "question": "Level 1: What is 4 + 4?",
+      "options": [
+        9,
+        1,
+        17,
+        8
+      ],
+      "answer": 8
+    },
+    {
+      "id": 10,
+      "question": "Level 1: What is 4 + 0?",
+      "options": [
+        4,
+        7,
+        11,
+        9
+      ],
+      "answer": 4
+    },
+    {
+      "id": 11,
+      "question": "Level 1: What is 0 + 5?",
+      "options": [
+        15,
+        2,
+        4,
+        5
+      ],
+      "answer": 5
+    },
+    {
+      "id": 12,
+      "question": "Level 1: What is 3 + 0?",
+      "options": [
+        7,
+        3,
+        12,
+        9
+      ],
+      "answer": 3
+    },
+    {
+      "id": 13,
+      "question": "Level 1: What is 0 + 2?",
+      "options": [
+        7,
+        10,
+        3,
+        2
+      ],
+      "answer": 2
+    },
+    {
+      "id": 14,
+      "question": "Level 1: What is 0 + 3?",
+      "options": [
+        3,
+        9,
+        12,
+        1
+      ],
+      "answer": 3
+    },
+    {
+      "id": 15,
+      "question": "Level 1: What is 0 + 1?",
+      "options": [
+        1,
+        4,
+        9,
+        6
+      ],
+      "answer": 1
+    },
+    {
+      "id": 16,
+      "question": "Level 1: What is 1 + 3?",
+      "options": [
+        4,
+        6,
+        11,
+        2
+      ],
+      "answer": 4
+    },
+    {
+      "id": 17,
+      "question": "Level 1: What is 3 + 4?",
+      "options": [
+        1,
+        14,
+        7,
+        5
+      ],
+      "answer": 7
+    },
+    {
+      "id": 18,
+      "question": "Level 1: What is 4 + 5?",
+      "options": [
+        8,
+        10,
+        18,
+        9
+      ],
+      "answer": 9
+    },
+    {
+      "id": 19,
+      "question": "Level 1: What is 4 + 2?",
+      "options": [
+        9,
+        6,
+        16,
+        8
+      ],
+      "answer": 6
+    },
+    {
+      "id": 20,
+      "question": "Level 1: What is 2 + 3?",
+      "options": [
+        9,
+        2,
+        5,
+        15
+      ],
+      "answer": 5
+    },
+    {
+      "id": 21,
+      "question": "Level 1: What is 3 + 2?",
+      "options": [
+        5,
+        13,
+        7,
+        8
+      ],
+      "answer": 5
+    },
+    {
+      "id": 22,
+      "question": "Level 1: What is 1 + 5?",
+      "options": [
+        10,
+        1,
+        4,
+        6
+      ],
+      "answer": 6
+    },
+    {
+      "id": 23,
+      "question": "Level 1: What is 5 + 2?",
+      "options": [
+        6,
+        7,
+        12,
+        11
+      ],
+      "answer": 7
+    },
+    {
+      "id": 24,
+      "question": "Level 1: What is 2 + 2?",
+      "options": [
+        14,
+        11,
+        4,
+        6
+      ],
+      "answer": 4
+    },
+    {
+      "id": 25,
+      "question": "Level 1: What is 5 + 4?",
+      "options": [
+        18,
+        5,
+        15,
+        9
+      ],
+      "answer": 9
+    },
+    {
+      "id": 26,
+      "question": "Level 1: What is 3 + 4?",
+      "options": [
+        7,
+        16,
+        17,
+        3
+      ],
+      "answer": 7
+    },
+    {
+      "id": 27,
+      "question": "Level 1: What is 4 + 4?",
+      "options": [
+        10,
+        1,
+        13,
+        8
+      ],
+      "answer": 8
+    },
+    {
+      "id": 28,
+      "question": "Level 1: What is 2 + 3?",
+      "options": [
+        3,
+        15,
+        9,
+        5
+      ],
+      "answer": 5
+    },
+    {
+      "id": 29,
+      "question": "Level 1: What is 5 + 3?",
+      "options": [
+        15,
+        8,
+        4,
+        6
+      ],
+      "answer": 8
+    },
+    {
+      "id": 30,
+      "question": "Level 1: What is 2 + 0?",
+      "options": [
+        2,
+        11,
+        12,
+        7
+      ],
+      "answer": 2
+    },
+    {
+      "id": 31,
+      "question": "Level 1: What is 2 + 2?",
+      "options": [
+        4,
+        6,
+        11,
+        5
+      ],
+      "answer": 4
+    },
+    {
+      "id": 32,
+      "question": "Level 1: What is 1 + 1?",
+      "options": [
+        11,
+        3,
+        10,
+        2
+      ],
+      "answer": 2
+    },
+    {
+      "id": 33,
+      "question": "Level 1: What is 2 + 5?",
+      "options": [
+        14,
+        7,
+        6,
+        1
+      ],
+      "answer": 7
+    },
+    {
+      "id": 34,
+      "question": "Level 1: What is 0 + 1?",
+      "options": [
+        4,
+        3,
+        7,
+        1
+      ],
+      "answer": 1
+    },
+    {
+      "id": 35,
+      "question": "Level 1: What is 1 + 4?",
+      "options": [
+        10,
+        8,
+        5,
+        4
+      ],
+      "answer": 5
+    },
+    {
+      "id": 36,
+      "question": "Level 1: What is 1 + 0?",
+      "options": [
+        1,
+        11,
+        9,
+        3
+      ],
+      "answer": 1
+    },
+    {
+      "id": 37,
+      "question": "Level 1: What is 1 + 2?",
+      "options": [
+        9,
+        5,
+        10,
+        3
+      ],
+      "answer": 3
+    },
+    {
+      "id": 38,
+      "question": "Level 1: What is 0 + 2?",
+      "options": [
+        10,
+        3,
+        5,
+        2
+      ],
+      "answer": 2
+    },
+    {
+      "id": 39,
+      "question": "Level 1: What is 3 + 3?",
+      "options": [
+        2,
+        6,
+        7,
+        9
+      ],
+      "answer": 6
+    },
+    {
+      "id": 40,
+      "question": "Level 1: What is 0 + 4?",
+      "options": [
+        10,
+        8,
+        9,
+        4
+      ],
+      "answer": 4
+    },
+    {
+      "id": 41,
+      "question": "Level 1: What is 4 + 3?",
+      "options": [
+        7,
+        3,
+        16,
+        17
+      ],
+      "answer": 7
+    },
+    {
+      "id": 42,
+      "question": "Level 1: What is 2 + 4?",
+      "options": [
+        6,
+        7,
+        8,
+        10
+      ],
+      "answer": 6
+    },
+    {
+      "id": 43,
+      "question": "Level 1: What is 5 + 1?",
+      "options": [
+        8,
+        16,
+        6,
+        14
+      ],
+      "answer": 6
+    },
+    {
+      "id": 44,
+      "question": "Level 1: What is 1 + 2?",
+      "options": [
+        3,
+        13,
+        8,
+        10
+      ],
+      "answer": 3
+    },
+    {
+      "id": 45,
+      "question": "Level 1: What is 5 + 5?",
+      "options": [
+        1,
+        16,
+        4,
+        10
+      ],
+      "answer": 10
+    },
+    {
+      "id": 46,
+      "question": "Level 1: What is 1 + 0?",
+      "options": [
+        3,
+        9,
+        6,
+        1
+      ],
+      "answer": 1
+    },
+    {
+      "id": 47,
+      "question": "Level 1: What is 1 + 5?",
+      "options": [
+        3,
+        6,
+        10,
+        5
+      ],
+      "answer": 6
+    },
+    {
+      "id": 48,
+      "question": "Level 1: What is 5 + 0?",
+      "options": [
+        5,
+        9,
+        6,
+        15
+      ],
+      "answer": 5
+    },
+    {
+      "id": 49,
+      "question": "Level 1: What is 2 + 1?",
+      "options": [
+        12,
+        9,
+        3,
+        11
+      ],
+      "answer": 3
+    },
+    {
+      "id": 50,
+      "question": "Level 1: What is 3 + 1?",
+      "options": [
+        11,
+        4,
+        3,
+        13
+      ],
+      "answer": 4
+    }
+  ]
+}

--- a/pwa-app/data/questions/level_2_questions.json
+++ b/pwa-app/data/questions/level_2_questions.json
@@ -1,0 +1,554 @@
+{
+  "questions": [
+    {
+      "id": 1,
+      "question": "Level 2: What is 6 + 8?",
+      "options": [
+        14,
+        7,
+        20,
+        13
+      ],
+      "answer": 14
+    },
+    {
+      "id": 2,
+      "question": "Level 2: What is 7 + 7?",
+      "options": [
+        14,
+        18,
+        10,
+        15
+      ],
+      "answer": 14
+    },
+    {
+      "id": 3,
+      "question": "Level 2: What is 9 + 7?",
+      "options": [
+        21,
+        7,
+        14,
+        16
+      ],
+      "answer": 16
+    },
+    {
+      "id": 4,
+      "question": "Level 2: What is 6 + 9?",
+      "options": [
+        25,
+        12,
+        7,
+        15
+      ],
+      "answer": 15
+    },
+    {
+      "id": 5,
+      "question": "Level 2: What is 5 + 6?",
+      "options": [
+        4,
+        5,
+        11,
+        14
+      ],
+      "answer": 11
+    },
+    {
+      "id": 6,
+      "question": "Level 2: What is 6 + 9?",
+      "options": [
+        18,
+        7,
+        8,
+        15
+      ],
+      "answer": 15
+    },
+    {
+      "id": 7,
+      "question": "Level 2: What is 9 + 8?",
+      "options": [
+        17,
+        21,
+        20,
+        7
+      ],
+      "answer": 17
+    },
+    {
+      "id": 8,
+      "question": "Level 2: What is 6 + 6?",
+      "options": [
+        5,
+        13,
+        4,
+        12
+      ],
+      "answer": 12
+    },
+    {
+      "id": 9,
+      "question": "Level 2: What is 8 + 6?",
+      "options": [
+        14,
+        9,
+        15,
+        4
+      ],
+      "answer": 14
+    },
+    {
+      "id": 10,
+      "question": "Level 2: What is 5 + 5?",
+      "options": [
+        19,
+        4,
+        6,
+        10
+      ],
+      "answer": 10
+    },
+    {
+      "id": 11,
+      "question": "Level 2: What is 9 + 5?",
+      "options": [
+        13,
+        15,
+        14,
+        4
+      ],
+      "answer": 14
+    },
+    {
+      "id": 12,
+      "question": "Level 2: What is 5 + 8?",
+      "options": [
+        7,
+        13,
+        17,
+        8
+      ],
+      "answer": 13
+    },
+    {
+      "id": 13,
+      "question": "Level 2: What is 6 + 5?",
+      "options": [
+        9,
+        5,
+        1,
+        11
+      ],
+      "answer": 11
+    },
+    {
+      "id": 14,
+      "question": "Level 2: What is 9 + 5?",
+      "options": [
+        19,
+        14,
+        21,
+        13
+      ],
+      "answer": 14
+    },
+    {
+      "id": 15,
+      "question": "Level 2: What is 5 + 6?",
+      "options": [
+        4,
+        18,
+        19,
+        11
+      ],
+      "answer": 11
+    },
+    {
+      "id": 16,
+      "question": "Level 2: What is 8 + 8?",
+      "options": [
+        22,
+        13,
+        16,
+        10
+      ],
+      "answer": 16
+    },
+    {
+      "id": 17,
+      "question": "Level 2: What is 7 + 5?",
+      "options": [
+        12,
+        13,
+        15,
+        11
+      ],
+      "answer": 12
+    },
+    {
+      "id": 18,
+      "question": "Level 2: What is 5 + 9?",
+      "options": [
+        16,
+        14,
+        8,
+        6
+      ],
+      "answer": 14
+    },
+    {
+      "id": 19,
+      "question": "Level 2: What is 9 + 8?",
+      "options": [
+        17,
+        11,
+        25,
+        20
+      ],
+      "answer": 17
+    },
+    {
+      "id": 20,
+      "question": "Level 2: What is 7 + 7?",
+      "options": [
+        11,
+        18,
+        6,
+        14
+      ],
+      "answer": 14
+    },
+    {
+      "id": 21,
+      "question": "Level 2: What is 7 + 8?",
+      "options": [
+        17,
+        18,
+        5,
+        15
+      ],
+      "answer": 15
+    },
+    {
+      "id": 22,
+      "question": "Level 2: What is 8 + 6?",
+      "options": [
+        15,
+        18,
+        10,
+        14
+      ],
+      "answer": 14
+    },
+    {
+      "id": 23,
+      "question": "Level 2: What is 7 + 5?",
+      "options": [
+        12,
+        7,
+        5,
+        10
+      ],
+      "answer": 12
+    },
+    {
+      "id": 24,
+      "question": "Level 2: What is 8 + 5?",
+      "options": [
+        13,
+        8,
+        17,
+        15
+      ],
+      "answer": 13
+    },
+    {
+      "id": 25,
+      "question": "Level 2: What is 6 + 6?",
+      "options": [
+        16,
+        18,
+        12,
+        9
+      ],
+      "answer": 12
+    },
+    {
+      "id": 26,
+      "question": "Level 2: What is 9 + 6?",
+      "options": [
+        20,
+        25,
+        15,
+        7
+      ],
+      "answer": 15
+    },
+    {
+      "id": 27,
+      "question": "Level 2: What is 8 + 7?",
+      "options": [
+        5,
+        24,
+        15,
+        19
+      ],
+      "answer": 15
+    },
+    {
+      "id": 28,
+      "question": "Level 2: What is 7 + 6?",
+      "options": [
+        20,
+        13,
+        23,
+        12
+      ],
+      "answer": 13
+    },
+    {
+      "id": 29,
+      "question": "Level 2: What is 6 + 5?",
+      "options": [
+        11,
+        3,
+        16,
+        8
+      ],
+      "answer": 11
+    },
+    {
+      "id": 30,
+      "question": "Level 2: What is 5 + 7?",
+      "options": [
+        5,
+        12,
+        3,
+        10
+      ],
+      "answer": 12
+    },
+    {
+      "id": 31,
+      "question": "Level 2: What is 7 + 8?",
+      "options": [
+        21,
+        23,
+        17,
+        15
+      ],
+      "answer": 15
+    },
+    {
+      "id": 32,
+      "question": "Level 2: What is 6 + 8?",
+      "options": [
+        13,
+        14,
+        15,
+        10
+      ],
+      "answer": 14
+    },
+    {
+      "id": 33,
+      "question": "Level 2: What is 6 + 7?",
+      "options": [
+        11,
+        13,
+        20,
+        12
+      ],
+      "answer": 13
+    },
+    {
+      "id": 34,
+      "question": "Level 2: What is 7 + 9?",
+      "options": [
+        19,
+        16,
+        8,
+        11
+      ],
+      "answer": 16
+    },
+    {
+      "id": 35,
+      "question": "Level 2: What is 8 + 9?",
+      "options": [
+        23,
+        17,
+        25,
+        27
+      ],
+      "answer": 17
+    },
+    {
+      "id": 36,
+      "question": "Level 2: What is 5 + 9?",
+      "options": [
+        24,
+        17,
+        21,
+        14
+      ],
+      "answer": 14
+    },
+    {
+      "id": 37,
+      "question": "Level 2: What is 8 + 9?",
+      "options": [
+        21,
+        18,
+        16,
+        17
+      ],
+      "answer": 17
+    },
+    {
+      "id": 38,
+      "question": "Level 2: What is 8 + 7?",
+      "options": [
+        23,
+        17,
+        8,
+        15
+      ],
+      "answer": 15
+    },
+    {
+      "id": 39,
+      "question": "Level 2: What is 8 + 8?",
+      "options": [
+        26,
+        17,
+        16,
+        21
+      ],
+      "answer": 16
+    },
+    {
+      "id": 40,
+      "question": "Level 2: What is 5 + 5?",
+      "options": [
+        15,
+        20,
+        10,
+        16
+      ],
+      "answer": 10
+    },
+    {
+      "id": 41,
+      "question": "Level 2: What is 6 + 7?",
+      "options": [
+        13,
+        7,
+        18,
+        4
+      ],
+      "answer": 13
+    },
+    {
+      "id": 42,
+      "question": "Level 2: What is 9 + 6?",
+      "options": [
+        20,
+        15,
+        5,
+        17
+      ],
+      "answer": 15
+    },
+    {
+      "id": 43,
+      "question": "Level 2: What is 9 + 9?",
+      "options": [
+        18,
+        19,
+        20,
+        8
+      ],
+      "answer": 18
+    },
+    {
+      "id": 44,
+      "question": "Level 2: What is 9 + 7?",
+      "options": [
+        14,
+        15,
+        16,
+        26
+      ],
+      "answer": 16
+    },
+    {
+      "id": 45,
+      "question": "Level 2: What is 7 + 9?",
+      "options": [
+        16,
+        9,
+        19,
+        12
+      ],
+      "answer": 16
+    },
+    {
+      "id": 46,
+      "question": "Level 2: What is 8 + 5?",
+      "options": [
+        13,
+        16,
+        8,
+        15
+      ],
+      "answer": 13
+    },
+    {
+      "id": 47,
+      "question": "Level 2: What is 5 + 7?",
+      "options": [
+        8,
+        12,
+        6,
+        18
+      ],
+      "answer": 12
+    },
+    {
+      "id": 48,
+      "question": "Level 2: What is 9 + 9?",
+      "options": [
+        20,
+        18,
+        21,
+        23
+      ],
+      "answer": 18
+    },
+    {
+      "id": 49,
+      "question": "Level 2: What is 5 + 8?",
+      "options": [
+        13,
+        17,
+        21,
+        9
+      ],
+      "answer": 13
+    },
+    {
+      "id": 50,
+      "question": "Level 2: What is 7 + 6?",
+      "options": [
+        13,
+        10,
+        23,
+        5
+      ],
+      "answer": 13
+    }
+  ]
+}

--- a/pwa-app/data/questions/level_3_questions.json
+++ b/pwa-app/data/questions/level_3_questions.json
@@ -1,0 +1,554 @@
+{
+  "questions": [
+    {
+      "id": 1,
+      "question": "Level 3: What is 2 + 3 + 2?",
+      "options": [
+        4,
+        7,
+        6,
+        14
+      ],
+      "answer": 7
+    },
+    {
+      "id": 2,
+      "question": "Level 3: What is 2 + 2 + 1?",
+      "options": [
+        10,
+        5,
+        12,
+        3
+      ],
+      "answer": 5
+    },
+    {
+      "id": 3,
+      "question": "Level 3: What is 3 + 3 + 1?",
+      "options": [
+        3,
+        6,
+        7,
+        9
+      ],
+      "answer": 7
+    },
+    {
+      "id": 4,
+      "question": "Level 3: What is 5 + 2 + 0?",
+      "options": [
+        4,
+        11,
+        7,
+        5
+      ],
+      "answer": 7
+    },
+    {
+      "id": 5,
+      "question": "Level 3: What is 1 + 0 + 4?",
+      "options": [
+        4,
+        6,
+        5,
+        13
+      ],
+      "answer": 5
+    },
+    {
+      "id": 6,
+      "question": "Level 3: What is 4 + 1 + 3?",
+      "options": [
+        9,
+        18,
+        13,
+        8
+      ],
+      "answer": 8
+    },
+    {
+      "id": 7,
+      "question": "Level 3: What is 1 + 5 + 1?",
+      "options": [
+        17,
+        4,
+        8,
+        7
+      ],
+      "answer": 7
+    },
+    {
+      "id": 8,
+      "question": "Level 3: What is 1 + 3 + 4?",
+      "options": [
+        12,
+        8,
+        2,
+        11
+      ],
+      "answer": 8
+    },
+    {
+      "id": 9,
+      "question": "Level 3: What is 2 + 2 + 4?",
+      "options": [
+        11,
+        18,
+        10,
+        8
+      ],
+      "answer": 8
+    },
+    {
+      "id": 10,
+      "question": "Level 3: What is 2 + 5 + 1?",
+      "options": [
+        15,
+        12,
+        16,
+        8
+      ],
+      "answer": 8
+    },
+    {
+      "id": 11,
+      "question": "Level 3: What is 5 + 4 + 5?",
+      "options": [
+        14,
+        9,
+        20,
+        4
+      ],
+      "answer": 14
+    },
+    {
+      "id": 12,
+      "question": "Level 3: What is 5 + 4 + 4?",
+      "options": [
+        13,
+        10,
+        8,
+        5
+      ],
+      "answer": 13
+    },
+    {
+      "id": 13,
+      "question": "Level 3: What is 3 + 3 + 5?",
+      "options": [
+        18,
+        3,
+        11,
+        6
+      ],
+      "answer": 11
+    },
+    {
+      "id": 14,
+      "question": "Level 3: What is 2 + 3 + 4?",
+      "options": [
+        13,
+        9,
+        19,
+        18
+      ],
+      "answer": 9
+    },
+    {
+      "id": 15,
+      "question": "Level 3: What is 4 + 2 + 2?",
+      "options": [
+        18,
+        6,
+        10,
+        8
+      ],
+      "answer": 8
+    },
+    {
+      "id": 16,
+      "question": "Level 3: What is 2 + 1 + 3?",
+      "options": [
+        10,
+        7,
+        6,
+        5
+      ],
+      "answer": 6
+    },
+    {
+      "id": 17,
+      "question": "Level 3: What is 2 + 0 + 2?",
+      "options": [
+        4,
+        2,
+        9,
+        6
+      ],
+      "answer": 4
+    },
+    {
+      "id": 18,
+      "question": "Level 3: What is 5 + 5 + 2?",
+      "options": [
+        11,
+        18,
+        19,
+        12
+      ],
+      "answer": 12
+    },
+    {
+      "id": 19,
+      "question": "Level 3: What is 5 + 0 + 4?",
+      "options": [
+        9,
+        11,
+        2,
+        13
+      ],
+      "answer": 9
+    },
+    {
+      "id": 20,
+      "question": "Level 3: What is 1 + 0 + 3?",
+      "options": [
+        2,
+        12,
+        4,
+        3
+      ],
+      "answer": 4
+    },
+    {
+      "id": 21,
+      "question": "Level 3: What is 5 + 3 + 5?",
+      "options": [
+        15,
+        11,
+        13,
+        9
+      ],
+      "answer": 13
+    },
+    {
+      "id": 22,
+      "question": "Level 3: What is 3 + 4 + 4?",
+      "options": [
+        19,
+        11,
+        8,
+        18
+      ],
+      "answer": 11
+    },
+    {
+      "id": 23,
+      "question": "Level 3: What is 3 + 0 + 1?",
+      "options": [
+        5,
+        12,
+        3,
+        4
+      ],
+      "answer": 4
+    },
+    {
+      "id": 24,
+      "question": "Level 3: What is 4 + 2 + 3?",
+      "options": [
+        12,
+        11,
+        9,
+        18
+      ],
+      "answer": 9
+    },
+    {
+      "id": 25,
+      "question": "Level 3: What is 1 + 5 + 5?",
+      "options": [
+        11,
+        19,
+        15,
+        2
+      ],
+      "answer": 11
+    },
+    {
+      "id": 26,
+      "question": "Level 3: What is 3 + 5 + 2?",
+      "options": [
+        19,
+        15,
+        8,
+        10
+      ],
+      "answer": 10
+    },
+    {
+      "id": 27,
+      "question": "Level 3: What is 4 + 1 + 5?",
+      "options": [
+        5,
+        10,
+        8,
+        16
+      ],
+      "answer": 10
+    },
+    {
+      "id": 28,
+      "question": "Level 3: What is 5 + 4 + 1?",
+      "options": [
+        3,
+        10,
+        16,
+        18
+      ],
+      "answer": 10
+    },
+    {
+      "id": 29,
+      "question": "Level 3: What is 1 + 5 + 2?",
+      "options": [
+        8,
+        11,
+        7,
+        6
+      ],
+      "answer": 8
+    },
+    {
+      "id": 30,
+      "question": "Level 3: What is 4 + 0 + 2?",
+      "options": [
+        9,
+        6,
+        12,
+        2
+      ],
+      "answer": 6
+    },
+    {
+      "id": 31,
+      "question": "Level 3: What is 3 + 3 + 4?",
+      "options": [
+        10,
+        1,
+        11,
+        14
+      ],
+      "answer": 10
+    },
+    {
+      "id": 32,
+      "question": "Level 3: What is 4 + 5 + 2?",
+      "options": [
+        17,
+        1,
+        12,
+        11
+      ],
+      "answer": 11
+    },
+    {
+      "id": 33,
+      "question": "Level 3: What is 0 + 5 + 3?",
+      "options": [
+        9,
+        13,
+        18,
+        8
+      ],
+      "answer": 8
+    },
+    {
+      "id": 34,
+      "question": "Level 3: What is 3 + 5 + 1?",
+      "options": [
+        17,
+        9,
+        6,
+        7
+      ],
+      "answer": 9
+    },
+    {
+      "id": 35,
+      "question": "Level 3: What is 0 + 1 + 3?",
+      "options": [
+        1,
+        8,
+        4,
+        12
+      ],
+      "answer": 4
+    },
+    {
+      "id": 36,
+      "question": "Level 3: What is 3 + 0 + 5?",
+      "options": [
+        12,
+        4,
+        3,
+        8
+      ],
+      "answer": 8
+    },
+    {
+      "id": 37,
+      "question": "Level 3: What is 1 + 1 + 5?",
+      "options": [
+        7,
+        10,
+        8,
+        5
+      ],
+      "answer": 7
+    },
+    {
+      "id": 38,
+      "question": "Level 3: What is 3 + 0 + 4?",
+      "options": [
+        3,
+        5,
+        12,
+        7
+      ],
+      "answer": 7
+    },
+    {
+      "id": 39,
+      "question": "Level 3: What is 2 + 4 + 4?",
+      "options": [
+        20,
+        1,
+        10,
+        12
+      ],
+      "answer": 10
+    },
+    {
+      "id": 40,
+      "question": "Level 3: What is 5 + 2 + 5?",
+      "options": [
+        12,
+        10,
+        2,
+        20
+      ],
+      "answer": 12
+    },
+    {
+      "id": 41,
+      "question": "Level 3: What is 4 + 0 + 1?",
+      "options": [
+        6,
+        13,
+        5,
+        1
+      ],
+      "answer": 5
+    },
+    {
+      "id": 42,
+      "question": "Level 3: What is 3 + 0 + 0?",
+      "options": [
+        13,
+        1,
+        3,
+        5
+      ],
+      "answer": 3
+    },
+    {
+      "id": 43,
+      "question": "Level 3: What is 2 + 0 + 4?",
+      "options": [
+        5,
+        6,
+        15,
+        8
+      ],
+      "answer": 6
+    },
+    {
+      "id": 44,
+      "question": "Level 3: What is 0 + 0 + 5?",
+      "options": [
+        15,
+        11,
+        5,
+        10
+      ],
+      "answer": 5
+    },
+    {
+      "id": 45,
+      "question": "Level 3: What is 4 + 2 + 5?",
+      "options": [
+        11,
+        12,
+        6,
+        19
+      ],
+      "answer": 11
+    },
+    {
+      "id": 46,
+      "question": "Level 3: What is 2 + 5 + 5?",
+      "options": [
+        18,
+        10,
+        8,
+        12
+      ],
+      "answer": 12
+    },
+    {
+      "id": 47,
+      "question": "Level 3: What is 3 + 3 + 2?",
+      "options": [
+        15,
+        8,
+        18,
+        2
+      ],
+      "answer": 8
+    },
+    {
+      "id": 48,
+      "question": "Level 3: What is 1 + 1 + 1?",
+      "options": [
+        13,
+        3,
+        7,
+        12
+      ],
+      "answer": 3
+    },
+    {
+      "id": 49,
+      "question": "Level 3: What is 5 + 5 + 3?",
+      "options": [
+        7,
+        23,
+        13,
+        18
+      ],
+      "answer": 13
+    },
+    {
+      "id": 50,
+      "question": "Level 3: What is 4 + 3 + 3?",
+      "options": [
+        16,
+        3,
+        10,
+        2
+      ],
+      "answer": 10
+    }
+  ]
+}

--- a/pwa-app/data/questions/level_4_questions.json
+++ b/pwa-app/data/questions/level_4_questions.json
@@ -1,0 +1,554 @@
+{
+  "questions": [
+    {
+      "id": 1,
+      "question": "Level 4: What is 76 + 0?",
+      "options": [
+        73,
+        76,
+        85,
+        84
+      ],
+      "answer": 76
+    },
+    {
+      "id": 2,
+      "question": "Level 4: What is 19 + 1?",
+      "options": [
+        20,
+        26,
+        17,
+        25
+      ],
+      "answer": 20
+    },
+    {
+      "id": 3,
+      "question": "Level 4: What is 20 + 5?",
+      "options": [
+        27,
+        22,
+        28,
+        25
+      ],
+      "answer": 25
+    },
+    {
+      "id": 4,
+      "question": "Level 4: What is 90 + 0?",
+      "options": [
+        88,
+        93,
+        82,
+        90
+      ],
+      "answer": 90
+    },
+    {
+      "id": 5,
+      "question": "Level 4: What is 77 + 1?",
+      "options": [
+        79,
+        78,
+        71,
+        73
+      ],
+      "answer": 78
+    },
+    {
+      "id": 6,
+      "question": "Level 4: What is 80 + 2?",
+      "options": [
+        89,
+        82,
+        84,
+        72
+      ],
+      "answer": 82
+    },
+    {
+      "id": 7,
+      "question": "Level 4: What is 83 + 0?",
+      "options": [
+        83,
+        92,
+        75,
+        79
+      ],
+      "answer": 83
+    },
+    {
+      "id": 8,
+      "question": "Level 4: What is 40 + 4?",
+      "options": [
+        44,
+        47,
+        53,
+        50
+      ],
+      "answer": 44
+    },
+    {
+      "id": 9,
+      "question": "Level 4: What is 50 + 0?",
+      "options": [
+        53,
+        52,
+        50,
+        47
+      ],
+      "answer": 50
+    },
+    {
+      "id": 10,
+      "question": "Level 4: What is 47 + 2?",
+      "options": [
+        45,
+        49,
+        40,
+        51
+      ],
+      "answer": 49
+    },
+    {
+      "id": 11,
+      "question": "Level 4: What is 76 + 1?",
+      "options": [
+        87,
+        81,
+        78,
+        77
+      ],
+      "answer": 77
+    },
+    {
+      "id": 12,
+      "question": "Level 4: What is 41 + 1?",
+      "options": [
+        35,
+        40,
+        42,
+        32
+      ],
+      "answer": 42
+    },
+    {
+      "id": 13,
+      "question": "Level 4: What is 25 + 5?",
+      "options": [
+        30,
+        38,
+        32,
+        26
+      ],
+      "answer": 30
+    },
+    {
+      "id": 14,
+      "question": "Level 4: What is 46 + 1?",
+      "options": [
+        47,
+        53,
+        54,
+        40
+      ],
+      "answer": 47
+    },
+    {
+      "id": 15,
+      "question": "Level 4: What is 57 + 5?",
+      "options": [
+        62,
+        68,
+        66,
+        55
+      ],
+      "answer": 62
+    },
+    {
+      "id": 16,
+      "question": "Level 4: What is 60 + 0?",
+      "options": [
+        63,
+        67,
+        60,
+        54
+      ],
+      "answer": 60
+    },
+    {
+      "id": 17,
+      "question": "Level 4: What is 52 + 3?",
+      "options": [
+        63,
+        52,
+        61,
+        55
+      ],
+      "answer": 55
+    },
+    {
+      "id": 18,
+      "question": "Level 4: What is 87 + 0?",
+      "options": [
+        92,
+        90,
+        77,
+        87
+      ],
+      "answer": 87
+    },
+    {
+      "id": 19,
+      "question": "Level 4: What is 54 + 4?",
+      "options": [
+        60,
+        65,
+        62,
+        58
+      ],
+      "answer": 58
+    },
+    {
+      "id": 20,
+      "question": "Level 4: What is 38 + 1?",
+      "options": [
+        33,
+        37,
+        39,
+        44
+      ],
+      "answer": 39
+    },
+    {
+      "id": 21,
+      "question": "Level 4: What is 85 + 0?",
+      "options": [
+        95,
+        90,
+        86,
+        85
+      ],
+      "answer": 85
+    },
+    {
+      "id": 22,
+      "question": "Level 4: What is 10 + 3?",
+      "options": [
+        19,
+        12,
+        13,
+        9
+      ],
+      "answer": 13
+    },
+    {
+      "id": 23,
+      "question": "Level 4: What is 41 + 5?",
+      "options": [
+        46,
+        41,
+        37,
+        55
+      ],
+      "answer": 46
+    },
+    {
+      "id": 24,
+      "question": "Level 4: What is 94 + 1?",
+      "options": [
+        90,
+        91,
+        98,
+        95
+      ],
+      "answer": 95
+    },
+    {
+      "id": 25,
+      "question": "Level 4: What is 59 + 0?",
+      "options": [
+        54,
+        59,
+        65,
+        55
+      ],
+      "answer": 59
+    },
+    {
+      "id": 26,
+      "question": "Level 4: What is 64 + 5?",
+      "options": [
+        77,
+        69,
+        65,
+        78
+      ],
+      "answer": 69
+    },
+    {
+      "id": 27,
+      "question": "Level 4: What is 49 + 5?",
+      "options": [
+        63,
+        54,
+        59,
+        61
+      ],
+      "answer": 54
+    },
+    {
+      "id": 28,
+      "question": "Level 4: What is 70 + 2?",
+      "options": [
+        66,
+        72,
+        69,
+        63
+      ],
+      "answer": 72
+    },
+    {
+      "id": 29,
+      "question": "Level 4: What is 72 + 5?",
+      "options": [
+        80,
+        83,
+        70,
+        77
+      ],
+      "answer": 77
+    },
+    {
+      "id": 30,
+      "question": "Level 4: What is 49 + 4?",
+      "options": [
+        48,
+        49,
+        53,
+        58
+      ],
+      "answer": 53
+    },
+    {
+      "id": 31,
+      "question": "Level 4: What is 28 + 1?",
+      "options": [
+        31,
+        29,
+        33,
+        21
+      ],
+      "answer": 29
+    },
+    {
+      "id": 32,
+      "question": "Level 4: What is 55 + 2?",
+      "options": [
+        61,
+        57,
+        59,
+        51
+      ],
+      "answer": 57
+    },
+    {
+      "id": 33,
+      "question": "Level 4: What is 75 + 3?",
+      "options": [
+        78,
+        68,
+        74,
+        80
+      ],
+      "answer": 78
+    },
+    {
+      "id": 34,
+      "question": "Level 4: What is 58 + 4?",
+      "options": [
+        58,
+        62,
+        69,
+        72
+      ],
+      "answer": 62
+    },
+    {
+      "id": 35,
+      "question": "Level 4: What is 44 + 3?",
+      "options": [
+        47,
+        57,
+        52,
+        53
+      ],
+      "answer": 47
+    },
+    {
+      "id": 36,
+      "question": "Level 4: What is 78 + 4?",
+      "options": [
+        74,
+        91,
+        87,
+        82
+      ],
+      "answer": 82
+    },
+    {
+      "id": 37,
+      "question": "Level 4: What is 64 + 4?",
+      "options": [
+        67,
+        77,
+        68,
+        69
+      ],
+      "answer": 68
+    },
+    {
+      "id": 38,
+      "question": "Level 4: What is 62 + 0?",
+      "options": [
+        71,
+        52,
+        59,
+        62
+      ],
+      "answer": 62
+    },
+    {
+      "id": 39,
+      "question": "Level 4: What is 27 + 0?",
+      "options": [
+        20,
+        25,
+        27,
+        35
+      ],
+      "answer": 27
+    },
+    {
+      "id": 40,
+      "question": "Level 4: What is 73 + 0?",
+      "options": [
+        75,
+        79,
+        73,
+        70
+      ],
+      "answer": 73
+    },
+    {
+      "id": 41,
+      "question": "Level 4: What is 17 + 3?",
+      "options": [
+        14,
+        28,
+        20,
+        30
+      ],
+      "answer": 20
+    },
+    {
+      "id": 42,
+      "question": "Level 4: What is 22 + 2?",
+      "options": [
+        27,
+        14,
+        26,
+        24
+      ],
+      "answer": 24
+    },
+    {
+      "id": 43,
+      "question": "Level 4: What is 57 + 0?",
+      "options": [
+        50,
+        51,
+        57,
+        47
+      ],
+      "answer": 57
+    },
+    {
+      "id": 44,
+      "question": "Level 4: What is 66 + 2?",
+      "options": [
+        78,
+        68,
+        66,
+        70
+      ],
+      "answer": 68
+    },
+    {
+      "id": 45,
+      "question": "Level 4: What is 74 + 1?",
+      "options": [
+        84,
+        75,
+        85,
+        76
+      ],
+      "answer": 75
+    },
+    {
+      "id": 46,
+      "question": "Level 4: What is 55 + 0?",
+      "options": [
+        62,
+        45,
+        55,
+        61
+      ],
+      "answer": 55
+    },
+    {
+      "id": 47,
+      "question": "Level 4: What is 91 + 1?",
+      "options": [
+        86,
+        92,
+        93,
+        90
+      ],
+      "answer": 92
+    },
+    {
+      "id": 48,
+      "question": "Level 4: What is 79 + 1?",
+      "options": [
+        88,
+        78,
+        72,
+        80
+      ],
+      "answer": 80
+    },
+    {
+      "id": 49,
+      "question": "Level 4: What is 18 + 0?",
+      "options": [
+        26,
+        23,
+        12,
+        18
+      ],
+      "answer": 18
+    },
+    {
+      "id": 50,
+      "question": "Level 4: What is 70 + 1?",
+      "options": [
+        71,
+        78,
+        72,
+        64
+      ],
+      "answer": 71
+    }
+  ]
+}

--- a/pwa-app/data/questions/level_5_questions.json
+++ b/pwa-app/data/questions/level_5_questions.json
@@ -1,0 +1,554 @@
+{
+  "questions": [
+    {
+      "id": 1,
+      "question": "Level 5: What is 15 + 1 + 0?",
+      "options": [
+        16,
+        10,
+        24,
+        18
+      ],
+      "answer": 16
+    },
+    {
+      "id": 2,
+      "question": "Level 5: What is 91 + 1 + 3?",
+      "options": [
+        89,
+        97,
+        85,
+        95
+      ],
+      "answer": 95
+    },
+    {
+      "id": 3,
+      "question": "Level 5: What is 77 + 2 + 5?",
+      "options": [
+        78,
+        89,
+        83,
+        84
+      ],
+      "answer": 84
+    },
+    {
+      "id": 4,
+      "question": "Level 5: What is 31 + 5 + 4?",
+      "options": [
+        44,
+        40,
+        35,
+        36
+      ],
+      "answer": 40
+    },
+    {
+      "id": 5,
+      "question": "Level 5: What is 73 + 1 + 3?",
+      "options": [
+        80,
+        73,
+        77,
+        83
+      ],
+      "answer": 77
+    },
+    {
+      "id": 6,
+      "question": "Level 5: What is 36 + 3 + 5?",
+      "options": [
+        37,
+        44,
+        42,
+        43
+      ],
+      "answer": 44
+    },
+    {
+      "id": 7,
+      "question": "Level 5: What is 67 + 0 + 1?",
+      "options": [
+        68,
+        63,
+        67,
+        62
+      ],
+      "answer": 68
+    },
+    {
+      "id": 8,
+      "question": "Level 5: What is 89 + 2 + 3?",
+      "options": [
+        88,
+        85,
+        87,
+        94
+      ],
+      "answer": 94
+    },
+    {
+      "id": 9,
+      "question": "Level 5: What is 51 + 2 + 4?",
+      "options": [
+        56,
+        57,
+        52,
+        48
+      ],
+      "answer": 57
+    },
+    {
+      "id": 10,
+      "question": "Level 5: What is 43 + 3 + 2?",
+      "options": [
+        48,
+        41,
+        46,
+        51
+      ],
+      "answer": 48
+    },
+    {
+      "id": 11,
+      "question": "Level 5: What is 48 + 2 + 0?",
+      "options": [
+        41,
+        43,
+        50,
+        57
+      ],
+      "answer": 50
+    },
+    {
+      "id": 12,
+      "question": "Level 5: What is 89 + 0 + 1?",
+      "options": [
+        98,
+        95,
+        90,
+        99
+      ],
+      "answer": 90
+    },
+    {
+      "id": 13,
+      "question": "Level 5: What is 22 + 2 + 1?",
+      "options": [
+        25,
+        28,
+        33,
+        17
+      ],
+      "answer": 25
+    },
+    {
+      "id": 14,
+      "question": "Level 5: What is 45 + 0 + 0?",
+      "options": [
+        35,
+        45,
+        39,
+        36
+      ],
+      "answer": 45
+    },
+    {
+      "id": 15,
+      "question": "Level 5: What is 31 + 1 + 2?",
+      "options": [
+        40,
+        24,
+        34,
+        35
+      ],
+      "answer": 34
+    },
+    {
+      "id": 16,
+      "question": "Level 5: What is 18 + 1 + 5?",
+      "options": [
+        31,
+        33,
+        24,
+        17
+      ],
+      "answer": 24
+    },
+    {
+      "id": 17,
+      "question": "Level 5: What is 57 + 2 + 2?",
+      "options": [
+        71,
+        61,
+        63,
+        68
+      ],
+      "answer": 61
+    },
+    {
+      "id": 18,
+      "question": "Level 5: What is 23 + 4 + 2?",
+      "options": [
+        30,
+        20,
+        39,
+        29
+      ],
+      "answer": 29
+    },
+    {
+      "id": 19,
+      "question": "Level 5: What is 75 + 2 + 4?",
+      "options": [
+        81,
+        77,
+        84,
+        73
+      ],
+      "answer": 81
+    },
+    {
+      "id": 20,
+      "question": "Level 5: What is 31 + 4 + 3?",
+      "options": [
+        33,
+        36,
+        38,
+        35
+      ],
+      "answer": 38
+    },
+    {
+      "id": 21,
+      "question": "Level 5: What is 33 + 4 + 0?",
+      "options": [
+        43,
+        33,
+        27,
+        37
+      ],
+      "answer": 37
+    },
+    {
+      "id": 22,
+      "question": "Level 5: What is 85 + 2 + 0?",
+      "options": [
+        80,
+        96,
+        87,
+        93
+      ],
+      "answer": 87
+    },
+    {
+      "id": 23,
+      "question": "Level 5: What is 21 + 4 + 3?",
+      "options": [
+        26,
+        25,
+        28,
+        34
+      ],
+      "answer": 28
+    },
+    {
+      "id": 24,
+      "question": "Level 5: What is 42 + 2 + 2?",
+      "options": [
+        39,
+        54,
+        37,
+        46
+      ],
+      "answer": 46
+    },
+    {
+      "id": 25,
+      "question": "Level 5: What is 17 + 3 + 3?",
+      "options": [
+        32,
+        23,
+        16,
+        14
+      ],
+      "answer": 23
+    },
+    {
+      "id": 26,
+      "question": "Level 5: What is 73 + 0 + 1?",
+      "options": [
+        82,
+        66,
+        74,
+        73
+      ],
+      "answer": 74
+    },
+    {
+      "id": 27,
+      "question": "Level 5: What is 68 + 2 + 3?",
+      "options": [
+        70,
+        67,
+        73,
+        64
+      ],
+      "answer": 73
+    },
+    {
+      "id": 28,
+      "question": "Level 5: What is 25 + 3 + 5?",
+      "options": [
+        30,
+        36,
+        40,
+        33
+      ],
+      "answer": 33
+    },
+    {
+      "id": 29,
+      "question": "Level 5: What is 83 + 0 + 5?",
+      "options": [
+        83,
+        88,
+        81,
+        87
+      ],
+      "answer": 88
+    },
+    {
+      "id": 30,
+      "question": "Level 5: What is 43 + 0 + 4?",
+      "options": [
+        45,
+        52,
+        57,
+        47
+      ],
+      "answer": 47
+    },
+    {
+      "id": 31,
+      "question": "Level 5: What is 89 + 1 + 0?",
+      "options": [
+        90,
+        85,
+        99,
+        86
+      ],
+      "answer": 90
+    },
+    {
+      "id": 32,
+      "question": "Level 5: What is 67 + 2 + 5?",
+      "options": [
+        72,
+        69,
+        76,
+        74
+      ],
+      "answer": 74
+    },
+    {
+      "id": 33,
+      "question": "Level 5: What is 64 + 5 + 3?",
+      "options": [
+        72,
+        65,
+        81,
+        69
+      ],
+      "answer": 72
+    },
+    {
+      "id": 34,
+      "question": "Level 5: What is 31 + 3 + 3?",
+      "options": [
+        36,
+        41,
+        37,
+        27
+      ],
+      "answer": 37
+    },
+    {
+      "id": 35,
+      "question": "Level 5: What is 42 + 2 + 3?",
+      "options": [
+        47,
+        55,
+        37,
+        46
+      ],
+      "answer": 47
+    },
+    {
+      "id": 36,
+      "question": "Level 5: What is 81 + 4 + 5?",
+      "options": [
+        97,
+        98,
+        90,
+        80
+      ],
+      "answer": 90
+    },
+    {
+      "id": 37,
+      "question": "Level 5: What is 85 + 4 + 2?",
+      "options": [
+        90,
+        82,
+        91,
+        94
+      ],
+      "answer": 91
+    },
+    {
+      "id": 38,
+      "question": "Level 5: What is 93 + 2 + 2?",
+      "options": [
+        99,
+        95,
+        90,
+        97
+      ],
+      "answer": 97
+    },
+    {
+      "id": 39,
+      "question": "Level 5: What is 80 + 4 + 2?",
+      "options": [
+        77,
+        87,
+        86,
+        96
+      ],
+      "answer": 86
+    },
+    {
+      "id": 40,
+      "question": "Level 5: What is 71 + 4 + 4?",
+      "options": [
+        85,
+        89,
+        79,
+        72
+      ],
+      "answer": 79
+    },
+    {
+      "id": 41,
+      "question": "Level 5: What is 43 + 1 + 1?",
+      "options": [
+        43,
+        45,
+        38,
+        40
+      ],
+      "answer": 45
+    },
+    {
+      "id": 42,
+      "question": "Level 5: What is 65 + 2 + 2?",
+      "options": [
+        78,
+        66,
+        74,
+        69
+      ],
+      "answer": 69
+    },
+    {
+      "id": 43,
+      "question": "Level 5: What is 23 + 2 + 4?",
+      "options": [
+        35,
+        20,
+        29,
+        34
+      ],
+      "answer": 29
+    },
+    {
+      "id": 44,
+      "question": "Level 5: What is 65 + 5 + 5?",
+      "options": [
+        79,
+        77,
+        67,
+        75
+      ],
+      "answer": 75
+    },
+    {
+      "id": 45,
+      "question": "Level 5: What is 11 + 5 + 2?",
+      "options": [
+        21,
+        18,
+        12,
+        23
+      ],
+      "answer": 18
+    },
+    {
+      "id": 46,
+      "question": "Level 5: What is 44 + 3 + 5?",
+      "options": [
+        43,
+        54,
+        52,
+        59
+      ],
+      "answer": 52
+    },
+    {
+      "id": 47,
+      "question": "Level 5: What is 21 + 1 + 5?",
+      "options": [
+        35,
+        21,
+        18,
+        27
+      ],
+      "answer": 27
+    },
+    {
+      "id": 48,
+      "question": "Level 5: What is 67 + 0 + 0?",
+      "options": [
+        76,
+        67,
+        71,
+        70
+      ],
+      "answer": 67
+    },
+    {
+      "id": 49,
+      "question": "Level 5: What is 87 + 1 + 1?",
+      "options": [
+        81,
+        88,
+        96,
+        89
+      ],
+      "answer": 89
+    },
+    {
+      "id": 50,
+      "question": "Level 5: What is 80 + 3 + 5?",
+      "options": [
+        88,
+        94,
+        91,
+        85
+      ],
+      "answer": 88
+    }
+  ]
+}

--- a/pwa-app/data/questions/level_6_questions.json
+++ b/pwa-app/data/questions/level_6_questions.json
@@ -1,0 +1,554 @@
+{
+  "questions": [
+    {
+      "id": 1,
+      "question": "Level 6: What is 11 + 12?",
+      "options": [
+        30,
+        23,
+        26,
+        28
+      ],
+      "answer": 23
+    },
+    {
+      "id": 2,
+      "question": "Level 6: What is 13 + 80?",
+      "options": [
+        86,
+        93,
+        92,
+        99
+      ],
+      "answer": 93
+    },
+    {
+      "id": 3,
+      "question": "Level 6: What is 77 + 20?",
+      "options": [
+        97,
+        89,
+        95,
+        88
+      ],
+      "answer": 97
+    },
+    {
+      "id": 4,
+      "question": "Level 6: What is 19 + 66?",
+      "options": [
+        83,
+        81,
+        95,
+        85
+      ],
+      "answer": 85
+    },
+    {
+      "id": 5,
+      "question": "Level 6: What is 47 + 48?",
+      "options": [
+        87,
+        95,
+        92,
+        97
+      ],
+      "answer": 95
+    },
+    {
+      "id": 6,
+      "question": "Level 6: What is 27 + 42?",
+      "options": [
+        68,
+        69,
+        64,
+        71
+      ],
+      "answer": 69
+    },
+    {
+      "id": 7,
+      "question": "Level 6: What is 82 + 10?",
+      "options": [
+        85,
+        92,
+        93,
+        91
+      ],
+      "answer": 92
+    },
+    {
+      "id": 8,
+      "question": "Level 6: What is 34 + 46?",
+      "options": [
+        80,
+        88,
+        85,
+        75
+      ],
+      "answer": 80
+    },
+    {
+      "id": 9,
+      "question": "Level 6: What is 47 + 18?",
+      "options": [
+        73,
+        65,
+        74,
+        60
+      ],
+      "answer": 65
+    },
+    {
+      "id": 10,
+      "question": "Level 6: What is 55 + 22?",
+      "options": [
+        77,
+        84,
+        80,
+        71
+      ],
+      "answer": 77
+    },
+    {
+      "id": 11,
+      "question": "Level 6: What is 26 + 13?",
+      "options": [
+        29,
+        35,
+        41,
+        39
+      ],
+      "answer": 39
+    },
+    {
+      "id": 12,
+      "question": "Level 6: What is 64 + 25?",
+      "options": [
+        89,
+        98,
+        79,
+        88
+      ],
+      "answer": 89
+    },
+    {
+      "id": 13,
+      "question": "Level 6: What is 16 + 23?",
+      "options": [
+        31,
+        39,
+        40,
+        45
+      ],
+      "answer": 39
+    },
+    {
+      "id": 14,
+      "question": "Level 6: What is 47 + 34?",
+      "options": [
+        73,
+        81,
+        72,
+        88
+      ],
+      "answer": 81
+    },
+    {
+      "id": 15,
+      "question": "Level 6: What is 39 + 51?",
+      "options": [
+        98,
+        90,
+        84,
+        91
+      ],
+      "answer": 90
+    },
+    {
+      "id": 16,
+      "question": "Level 6: What is 16 + 12?",
+      "options": [
+        30,
+        35,
+        28,
+        31
+      ],
+      "answer": 28
+    },
+    {
+      "id": 17,
+      "question": "Level 6: What is 36 + 22?",
+      "options": [
+        58,
+        64,
+        62,
+        48
+      ],
+      "answer": 58
+    },
+    {
+      "id": 18,
+      "question": "Level 6: What is 21 + 40?",
+      "options": [
+        66,
+        53,
+        62,
+        61
+      ],
+      "answer": 61
+    },
+    {
+      "id": 19,
+      "question": "Level 6: What is 26 + 20?",
+      "options": [
+        46,
+        53,
+        39,
+        48
+      ],
+      "answer": 46
+    },
+    {
+      "id": 20,
+      "question": "Level 6: What is 17 + 60?",
+      "options": [
+        77,
+        79,
+        87,
+        78
+      ],
+      "answer": 77
+    },
+    {
+      "id": 21,
+      "question": "Level 6: What is 11 + 74?",
+      "options": [
+        80,
+        89,
+        86,
+        85
+      ],
+      "answer": 85
+    },
+    {
+      "id": 22,
+      "question": "Level 6: What is 20 + 74?",
+      "options": [
+        94,
+        95,
+        87,
+        93
+      ],
+      "answer": 94
+    },
+    {
+      "id": 23,
+      "question": "Level 6: What is 17 + 46?",
+      "options": [
+        67,
+        63,
+        66,
+        61
+      ],
+      "answer": 63
+    },
+    {
+      "id": 24,
+      "question": "Level 6: What is 30 + 62?",
+      "options": [
+        92,
+        98,
+        93,
+        89
+      ],
+      "answer": 92
+    },
+    {
+      "id": 25,
+      "question": "Level 6: What is 37 + 59?",
+      "options": [
+        96,
+        91,
+        86,
+        95
+      ],
+      "answer": 96
+    },
+    {
+      "id": 26,
+      "question": "Level 6: What is 32 + 48?",
+      "options": [
+        75,
+        80,
+        89,
+        84
+      ],
+      "answer": 80
+    },
+    {
+      "id": 27,
+      "question": "Level 6: What is 64 + 18?",
+      "options": [
+        80,
+        83,
+        89,
+        82
+      ],
+      "answer": 82
+    },
+    {
+      "id": 28,
+      "question": "Level 6: What is 52 + 29?",
+      "options": [
+        74,
+        77,
+        83,
+        81
+      ],
+      "answer": 81
+    },
+    {
+      "id": 29,
+      "question": "Level 6: What is 61 + 29?",
+      "options": [
+        96,
+        87,
+        95,
+        90
+      ],
+      "answer": 90
+    },
+    {
+      "id": 30,
+      "question": "Level 6: What is 44 + 53?",
+      "options": [
+        97,
+        94,
+        91,
+        90
+      ],
+      "answer": 97
+    },
+    {
+      "id": 31,
+      "question": "Level 6: What is 75 + 20?",
+      "options": [
+        89,
+        86,
+        95,
+        97
+      ],
+      "answer": 95
+    },
+    {
+      "id": 32,
+      "question": "Level 6: What is 36 + 21?",
+      "options": [
+        48,
+        57,
+        55,
+        61
+      ],
+      "answer": 57
+    },
+    {
+      "id": 33,
+      "question": "Level 6: What is 25 + 26?",
+      "options": [
+        54,
+        53,
+        60,
+        51
+      ],
+      "answer": 51
+    },
+    {
+      "id": 34,
+      "question": "Level 6: What is 12 + 11?",
+      "options": [
+        20,
+        22,
+        13,
+        23
+      ],
+      "answer": 23
+    },
+    {
+      "id": 35,
+      "question": "Level 6: What is 24 + 46?",
+      "options": [
+        72,
+        78,
+        70,
+        75
+      ],
+      "answer": 70
+    },
+    {
+      "id": 36,
+      "question": "Level 6: What is 23 + 37?",
+      "options": [
+        61,
+        60,
+        54,
+        69
+      ],
+      "answer": 60
+    },
+    {
+      "id": 37,
+      "question": "Level 6: What is 12 + 82?",
+      "options": [
+        93,
+        94,
+        90,
+        88
+      ],
+      "answer": 94
+    },
+    {
+      "id": 38,
+      "question": "Level 6: What is 19 + 50?",
+      "options": [
+        64,
+        67,
+        62,
+        69
+      ],
+      "answer": 69
+    },
+    {
+      "id": 39,
+      "question": "Level 6: What is 29 + 19?",
+      "options": [
+        48,
+        39,
+        55,
+        56
+      ],
+      "answer": 48
+    },
+    {
+      "id": 40,
+      "question": "Level 6: What is 27 + 50?",
+      "options": [
+        87,
+        75,
+        77,
+        73
+      ],
+      "answer": 77
+    },
+    {
+      "id": 41,
+      "question": "Level 6: What is 19 + 79?",
+      "options": [
+        94,
+        98,
+        91,
+        88
+      ],
+      "answer": 98
+    },
+    {
+      "id": 42,
+      "question": "Level 6: What is 53 + 28?",
+      "options": [
+        81,
+        89,
+        72,
+        83
+      ],
+      "answer": 81
+    },
+    {
+      "id": 43,
+      "question": "Level 6: What is 52 + 32?",
+      "options": [
+        77,
+        85,
+        84,
+        91
+      ],
+      "answer": 84
+    },
+    {
+      "id": 44,
+      "question": "Level 6: What is 31 + 46?",
+      "options": [
+        77,
+        80,
+        87,
+        83
+      ],
+      "answer": 77
+    },
+    {
+      "id": 45,
+      "question": "Level 6: What is 30 + 16?",
+      "options": [
+        38,
+        46,
+        44,
+        36
+      ],
+      "answer": 46
+    },
+    {
+      "id": 46,
+      "question": "Level 6: What is 42 + 18?",
+      "options": [
+        60,
+        63,
+        61,
+        51
+      ],
+      "answer": 60
+    },
+    {
+      "id": 47,
+      "question": "Level 6: What is 17 + 20?",
+      "options": [
+        46,
+        37,
+        33,
+        27
+      ],
+      "answer": 37
+    },
+    {
+      "id": 48,
+      "question": "Level 6: What is 42 + 13?",
+      "options": [
+        65,
+        57,
+        61,
+        55
+      ],
+      "answer": 55
+    },
+    {
+      "id": 49,
+      "question": "Level 6: What is 70 + 21?",
+      "options": [
+        84,
+        91,
+        88,
+        83
+      ],
+      "answer": 91
+    },
+    {
+      "id": 50,
+      "question": "Level 6: What is 10 + 57?",
+      "options": [
+        67,
+        76,
+        73,
+        72
+      ],
+      "answer": 67
+    }
+  ]
+}

--- a/pwa-app/data/variables.json
+++ b/pwa-app/data/variables.json
@@ -1,0 +1,40 @@
+{
+  "user": {
+    "battles": [
+      {
+        "battleLevel": 1,
+        "hero": {
+          "id": "shellfin",
+          "sprite": "../images/characters/shellfin_level_1.png"
+        }
+      },
+      {
+        "battleLevel": 2,
+        "hero": {
+          "id": "shellfin",
+          "sprite": "../images/characters/shellfin_level_2.png"
+        }
+      },
+      {
+        "battleLevel": 3,
+        "hero": {
+          "id": "shellfin",
+          "sprite": "../images/characters/shellfin_level_2.png"
+        }
+      },
+      {
+        "battleLevel": 4,
+        "hero": {
+          "id": "shellfin",
+          "sprite": "../images/characters/shellfin_level_2.png"
+        }
+      }
+    ]
+  },
+  "progress": {
+    "currentStreak": 0,
+    "accuracy": 0.0,
+    "timeRemainingSeconds": null,
+    "battleLevel": 1
+  }
+}

--- a/pwa-app/html/battle.html
+++ b/pwa-app/html/battle.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta name="theme-color" content="#0a3d62" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <title>Battle</title>
+    <link rel="manifest" href="../manifest.webmanifest" />
+    <link rel="apple-touch-icon" sizes="300x300" href="../images/brand/logo.png" />
+    <link rel="stylesheet" href="../css/question.css" />
+    <link rel="stylesheet" href="../css/battle-card.css" />
+    <link rel="stylesheet" href="../css/battle.css" />
+  </head>
+  <body>
+  <div class="battle-stat-banner" aria-live="polite">
+    <div class="stat">
+      <span class="label">Accuracy</span>
+      <span class="value" data-banner-accuracy>0%</span>
+    </div>
+    <div class="stat">
+      <span class="label">Time</span>
+      <span class="value" data-banner-time>0s</span>
+    </div>
+  </div>
+  <div class="battle-dev-controls" role="group" aria-label="Battle test controls">
+    <button type="button" class="battle-dev-controls__btn" data-dev-set-streak>
+      Set Streak 4
+    </button>
+    <button type="button" class="battle-dev-controls__btn" data-dev-end-battle>
+      End Battle
+    </button>
+    <button type="button" class="battle-dev-controls__btn" data-dev-reset-level>
+      Reset Level 1
+    </button>
+    <button type="button" class="battle-dev-controls__btn" data-dev-log-out>
+      Log Out
+    </button>
+  </div>
+  <div id="battle">
+    <img id="battle-monster" src="../images/battle/monster_battle_1.png" alt="Monster" />
+    <img
+      id="battle-shellfin"
+      src="../images/characters/shellfin_level_1.png"
+      alt="Shellfin"
+    />
+    <div id="monster-stats" class="stat-box">
+      <div class="name"></div>
+      <div class="stats">
+        <div class="stat attack">
+          <img src="../images/questions/sword.svg" alt="Attack" />
+          <span class="value"></span>
+          <span class="increase"></span>
+        </div>
+        <div class="stat health">
+          <img src="../images/questions/shield.svg" alt="Health" />
+          <span class="value"></span>
+          <span class="increase"></span>
+        </div>
+      </div>
+      <div class="hp-bar"><div class="hp-fill"></div></div>
+    </div>
+    <div id="shellfin-stats" class="stat-box">
+      <div class="name"></div>
+      <div class="stats">
+        <div class="stat attack">
+          <img src="../images/questions/sword.svg" alt="Attack" />
+          <span class="value"></span>
+          <span class="increase"></span>
+        </div>
+        <div class="stat health">
+          <img src="../images/questions/shield.svg" alt="Health" />
+          <span class="value"></span>
+          <span class="increase"></span>
+        </div>
+      </div>
+      <div class="hp-bar"><div class="hp-fill"></div></div>
+    </div>
+  </div>
+    <div id="question">
+      <div class="content">
+        <img class="streak-icon" src="../images/questions/streak.svg" alt="Streak" />
+        <div class="top-bar">
+          <div class="progress-wrap">
+            <div class="streak-label"></div>
+            <div class="progress-bar">
+              <div class="progress-fill"></div>
+            </div>
+          </div>
+        </div>
+        <p class="question-text"></p>
+        <div class="choices"></div>
+        <button type="button">Submit</button>
+      </div>
+    </div>
+    <div
+      id="complete-message"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="battle-complete-title"
+      aria-hidden="true"
+      tabindex="-1"
+    >
+      <section class="battle-card battle-card--pop battle-complete-card">
+        <div class="battle-info">
+          <p id="battle-complete-title" class="battle-title">Battle<br />Complete</p>
+        </div>
+        <img
+          class="enemy-image"
+          src="../images/battle/monster_battle_1.png"
+          alt="Enemy defeated in battle"
+        />
+        <p class="battle-goals-title">Battle Goals</p>
+        <div class="battle-stats">
+          <div class="battle-stat" data-goal="accuracy">
+            <span class="stat-label">Accuracy</span>
+            <span class="stat-value summary-accuracy">
+              <span class="stat-value-text">0%</span>
+            </span>
+          </div>
+          <div class="battle-stat" data-goal="time">
+            <span class="stat-label">Time</span>
+            <span class="stat-value summary-time">
+              <span class="stat-value-text">0s</span>
+            </span>
+          </div>
+        </div>
+        <button type="button" class="btn-primary next-mission-btn" data-action="next">Next Mission</button>
+      </section>
+    </div>
+    <div id="battle-message">
+      <div class="content">
+        <p></p>
+        <button type="button" class="btn-primary">Try Again</button>
+      </div>
+    </div>
+    <script src="../js/pwa.js" defer data-pwa-root=".."></script>
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script src="../js/supabaseClient.js"></script>
+    <script src="../js/loader.js"></script>
+    <script src="../js/battle.js"></script>
+    <script src="../js/question.js"></script>
+  </body>
+</html>

--- a/pwa-app/index.html
+++ b/pwa-app/index.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="theme-color" content="#0a3d62" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+  <title>Reef Rangers</title>
+  <link rel="manifest" href="manifest.webmanifest" />
+  <link rel="apple-touch-icon" sizes="300x300" href="../images/brand/logo.png" />
+  <link rel="stylesheet" href="css/battle-card.css" />
+  <link rel="stylesheet" href="css/index.css" />
+</head>
+<body class="is-preloading">
+  <div class="preloader" data-preloader role="status" aria-live="polite">
+    <img
+      class="preloader__logo"
+      src="../images/brand/logo.png"
+      alt="Reef Rangers logo"
+      width="300"
+      height="300"
+    />
+    <p class="preloader__text">Loading</p>
+    <div class="preloader__spinner" aria-hidden="true"></div>
+  </div>
+  <main class="landing">
+    <div class="bubbles" aria-hidden="true">
+      <span class="bubble" style="--size: 18px; --duration: 6.5s; --delay: 0s;"></span>
+      <span class="bubble" style="--size: 24px; --duration: 7.2s; --delay: 0.6s;"></span>
+      <span class="bubble" style="--size: 14px; --duration: 6s; --delay: 1.1s;"></span>
+      <span class="bubble" style="--size: 20px; --duration: 6.8s; --delay: 0.3s;"></span>
+      <span class="bubble" style="--size: 26px; --duration: 7.5s; --delay: 1.4s;"></span>
+      <span class="bubble" style="--size: 16px; --duration: 6.2s; --delay: 0.9s;"></span>
+      <span class="bubble" style="--size: 22px; --duration: 7s; --delay: 1.7s;"></span>
+      <span class="bubble" style="--size: 18px; --duration: 6.4s; --delay: 0.5s;"></span>
+    </div>
+
+    <img
+      class="hero"
+      src="../images/characters/shellfin_level_1.png"
+      alt="Shellfin ready for battle"
+    />
+
+    <img
+      class="battle-splat"
+      src="../images/battle/battle.png"
+      alt=""
+      aria-hidden="true"
+    />
+    <div id="battle-overlay" class="battle-overlay" aria-hidden="true">
+      <div
+        class="battle-card battle-overlay-card"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="battle-overlay-title battle-overlay-math"
+        aria-describedby="battle-overlay-stats"
+      >
+        <div class="battle-info">
+          <p
+            id="battle-overlay-math"
+            class="math-type"
+            data-battle-math
+          >
+            Math Mission
+          </p>
+          <p
+            id="battle-overlay-title"
+            class="battle-title"
+            data-battle-title
+          >
+            Battle 1
+          </p>
+        </div>
+        <img
+          class="enemy-image"
+          src="../images/battle/monster_battle_1.png"
+          alt="Enemy monster ready for battle"
+          data-battle-enemy
+        />
+        <p class="battle-goals-title">Battle Goals</p>
+        <div id="battle-overlay-stats" class="battle-stats" aria-live="polite">
+          <div class="battle-stat">
+            <span class="stat-label">Accuracy</span>
+            <span class="stat-value accuracy-value">0</span>
+          </div>
+          <div class="battle-stat">
+            <span class="stat-label">Time</span>
+            <span class="stat-value time-value">0</span>
+          </div>
+        </div>
+        <button class="btn-primary battle-btn" type="button">Let's Battle</button>
+      </div>
+    </div>
+    <section class="pwa-install" aria-live="polite">
+      <h1 class="pwa-install__title">Bring Reef Rangers anywhere</h1>
+      <p class="pwa-install__message" data-install-message>
+        Install the app on your device to keep battling monsters offline.
+      </p>
+      <div class="pwa-install__actions">
+        <button
+          class="btn-primary pwa-install__button"
+          type="button"
+          data-install-button
+          hidden
+        >
+          Install App
+        </button>
+        <a class="pwa-install__link" href="signin.html">Sign in to continue</a>
+      </div>
+    </section>
+  </main>
+  <script>
+    window.SUPABASE_URL = 'https://jxlxpumcoihfapmrsaqd.supabase.co';
+    window.SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imp4bHhwdW1jb2loZmFwbXJzYXFkIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTc0MjE3MDcsImV4cCI6MjA3Mjk5NzcwN30.PJiDPZ_Dqli_42isJexeYgsf0ebWbCSOwHtR7lsQTN0';
+  </script>
+  <script src="js/pwa.js" defer data-pwa-root="."></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2" defer></script>
+  <script src="js/supabaseClient.js" defer></script>
+  <script src="js/index.js" defer></script>
+</body>
+</html>

--- a/pwa-app/js/battle.js
+++ b/pwa-app/js/battle.js
@@ -1,0 +1,925 @@
+const LANDING_VISITED_KEY = 'reefRangersVisitedLanding';
+const VISITED_VALUE = 'true';
+const PROGRESS_STORAGE_KEY = 'reefRangersProgress';
+
+const readVisitedFlag = (storage, label) => {
+  if (!storage) {
+    return null;
+  }
+  try {
+    return storage.getItem(LANDING_VISITED_KEY) === VISITED_VALUE;
+  } catch (error) {
+    console.warn(`${label} storage is not available.`, error);
+    return null;
+  }
+};
+
+const setVisitedFlag = (storage, label) => {
+  if (!storage) {
+    return;
+  }
+  try {
+    storage.setItem(LANDING_VISITED_KEY, VISITED_VALUE);
+  } catch (error) {
+    console.warn(`${label} storage is not available.`, error);
+  }
+};
+
+const hasVisitedLanding = () => {
+  const sessionVisited = readVisitedFlag(sessionStorage, 'Session');
+  if (sessionVisited === true) {
+    return true;
+  }
+  if (sessionVisited === null) {
+    return true;
+  }
+
+  const localVisited = readVisitedFlag(localStorage, 'Local');
+  if (localVisited === true) {
+    setVisitedFlag(sessionStorage, 'Session');
+    return true;
+  }
+  if (localVisited === null) {
+    return true;
+  }
+
+  return false;
+};
+
+const landingVisited = hasVisitedLanding();
+
+if (!landingVisited) {
+  window.location.replace('../index.html');
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  if (!landingVisited) {
+    return;
+  }
+  const monsterImg = document.getElementById('battle-monster');
+  const heroImg = document.getElementById('battle-shellfin');
+  const prefersReducedMotion = window.matchMedia(
+    '(prefers-reduced-motion: reduce)'
+  ).matches;
+  const monsterHpFill = document.querySelector('#monster-stats .hp-fill');
+  const heroHpFill = document.querySelector('#shellfin-stats .hp-fill');
+  const monsterNameEl = document.querySelector('#monster-stats .name');
+  const heroNameEl = document.querySelector('#shellfin-stats .name');
+  const monsterStats = document.getElementById('monster-stats');
+  const heroStats = document.getElementById('shellfin-stats');
+
+  const questionBox = document.getElementById('question');
+  const questionText = questionBox.querySelector('.question-text');
+  const choicesEl = questionBox.querySelector('.choices');
+  const topBar = questionBox.querySelector('.top-bar');
+  const progressBar = questionBox.querySelector('.progress-bar');
+  const progressFill = questionBox.querySelector('.progress-fill');
+  const streakLabel = questionBox.querySelector('.streak-label');
+  const streakIcon = questionBox.querySelector('.streak-icon');
+  const bannerAccuracyValue = document.querySelector('[data-banner-accuracy]');
+  const bannerTimeValue = document.querySelector('[data-banner-time]');
+  const setStreakButton = document.querySelector('[data-dev-set-streak]');
+  const endBattleButton = document.querySelector('[data-dev-end-battle]');
+  const resetLevelButton = document.querySelector('[data-dev-reset-level]');
+  const logOutButton = document.querySelector('[data-dev-log-out]');
+  const devControls = document.querySelector('.battle-dev-controls');
+  const heroAttackVal = heroStats.querySelector('.attack .value');
+  const heroHealthVal = heroStats.querySelector('.health .value');
+  const heroAttackInc = heroStats.querySelector('.attack .increase');
+  const heroHealthInc = heroStats.querySelector('.health .increase');
+  const monsterAttackVal = monsterStats.querySelector('.attack .value');
+  const monsterHealthVal = monsterStats.querySelector('.health .value');
+
+  const completeMessage = document.getElementById('complete-message');
+  const battleCompleteTitle = completeMessage?.querySelector('#battle-complete-title');
+  const completeEnemyImg = completeMessage?.querySelector('.enemy-image');
+  const summaryAccuracyStat = completeMessage?.querySelector('[data-goal="accuracy"]');
+  const summaryTimeStat = completeMessage?.querySelector('[data-goal="time"]');
+  const summaryAccuracyValue = summaryAccuracyStat?.querySelector('.summary-accuracy');
+  const summaryTimeValue = summaryTimeStat?.querySelector('.summary-time');
+  const nextMissionBtn = completeMessage?.querySelector('.next-mission-btn');
+
+  const summaryAccuracyText = ensureStatValueText(summaryAccuracyValue);
+  const summaryTimeText = ensureStatValueText(summaryTimeValue);
+
+  if (bannerAccuracyValue) bannerAccuracyValue.textContent = '100%';
+  if (bannerTimeValue) bannerTimeValue.textContent = '0s';
+  if (summaryAccuracyText) summaryAccuracyText.textContent = '100%';
+  if (summaryTimeText) summaryTimeText.textContent = '0s';
+
+  const MIN_STREAK_GOAL = 1;
+  const MAX_STREAK_GOAL = 5;
+  let STREAK_GOAL = MAX_STREAK_GOAL;
+  let questions = [];
+  let currentQuestion = 0;
+  let streak = 0;
+  let streakMaxed = false;
+  let streakIconShown = false;
+  let correctAnswers = 0;
+  let totalAnswers = 0;
+  let wrongAnswers = 0;
+  let accuracyGoal = null;
+  let timeGoalSeconds = 0;
+  let timeRemaining = 0;
+  let initialTimeRemaining = 0;
+  let battleTimerDeadline = null;
+  let battleTimerInterval = null;
+  let battleEnded = false;
+  let currentBattleLevel = null;
+  let battleStartTime = null;
+  let battleLevelAdvanced = false;
+  let battleGoalsMet = false;
+
+  const hero = { attack: 1, health: 5, gems: 0, damage: 0, name: 'Hero' };
+  const monster = { attack: 1, health: 5, damage: 0, name: 'Monster' };
+
+  const markBattleReady = (img) => {
+    if (!img) {
+      return;
+    }
+    img.classList.remove('slide-in');
+    img.classList.add('battle-ready');
+  };
+
+  if (prefersReducedMotion) {
+    markBattleReady(heroImg);
+    markBattleReady(monsterImg);
+  } else {
+    if (heroImg) {
+      heroImg.classList.add('slide-in');
+      heroImg.addEventListener('animationend', () => markBattleReady(heroImg), {
+        once: true,
+      });
+      window.setTimeout(() => markBattleReady(heroImg), 1400);
+    }
+
+    if (monsterImg) {
+      monsterImg.classList.add('slide-in');
+      monsterImg.addEventListener('animationend', () => markBattleReady(monsterImg), {
+        once: true,
+      });
+      window.setTimeout(() => markBattleReady(monsterImg), 1400);
+    }
+  }
+
+  window.requestAnimationFrame(() => {
+    heroStats?.classList.add('show');
+    monsterStats?.classList.add('show');
+  });
+
+  function shuffle(arr) {
+    for (let i = arr.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+    return arr;
+  }
+
+  function ensureStatValueText(valueEl) {
+    if (!valueEl) {
+      return null;
+    }
+    const existing = valueEl.querySelector('.stat-value-text');
+    if (existing) {
+      return existing;
+    }
+    const span = document.createElement('span');
+    span.classList.add('stat-value-text');
+    const initialText = valueEl.textContent ? valueEl.textContent.trim() : '';
+    span.textContent = initialText;
+    valueEl.textContent = '';
+    valueEl.appendChild(span);
+    return span;
+  }
+
+  function applyGoalResult(valueEl, textSpan, text, met) {
+    if (!valueEl || !textSpan) {
+      return;
+    }
+    textSpan.textContent = text;
+    let icon = valueEl.querySelector('.goal-result-icon');
+    if (!icon) {
+      icon = document.createElement('img');
+      icon.classList.add('goal-result-icon');
+      valueEl.insertBefore(icon, textSpan);
+    }
+    icon.src = met
+      ? '../images/complete/correct.svg'
+      : '../images/complete/incorrect.svg';
+    icon.alt = met ? 'Goal met' : 'Goal not met';
+    valueEl.classList.remove('goal-result--met', 'goal-result--missed');
+    valueEl.classList.add(met ? 'goal-result--met' : 'goal-result--missed');
+  }
+
+  function setBattleCompleteTitleLines(...lines) {
+    if (!battleCompleteTitle) {
+      return;
+    }
+
+    const filteredLines = lines
+      .map((line) => (typeof line === 'string' ? line.trim() : ''))
+      .filter((line) => line.length > 0);
+
+    battleCompleteTitle.replaceChildren();
+
+    if (!filteredLines.length) {
+      return;
+    }
+
+    filteredLines.forEach((line, index) => {
+      battleCompleteTitle.appendChild(document.createTextNode(line));
+      if (index < filteredLines.length - 1) {
+        battleCompleteTitle.appendChild(document.createElement('br'));
+      }
+    });
+  }
+
+  function persistProgress(update) {
+    if (!update || typeof update !== 'object') {
+      return;
+    }
+
+    if (window.preloadedData?.variables) {
+      const existingProgress =
+        typeof window.preloadedData.variables.progress === 'object' &&
+        window.preloadedData.variables.progress !== null
+          ? window.preloadedData.variables.progress
+          : {};
+      window.preloadedData.variables.progress = {
+        ...existingProgress,
+        ...update,
+      };
+    }
+
+    try {
+      const storage = window.localStorage;
+      if (!storage) {
+        return;
+      }
+      const raw = storage.getItem(PROGRESS_STORAGE_KEY);
+      let storedProgress = {};
+      if (raw) {
+        try {
+          const parsed = JSON.parse(raw);
+          if (parsed && typeof parsed === 'object') {
+            storedProgress = parsed;
+          }
+        } catch (error) {
+          storedProgress = {};
+        }
+      }
+      const mergedProgress = { ...storedProgress, ...update };
+      storage.setItem(PROGRESS_STORAGE_KEY, JSON.stringify(mergedProgress));
+    } catch (error) {
+      console.warn('Unable to save progress.', error);
+    }
+  }
+
+  function advanceBattleLevel() {
+    if (battleLevelAdvanced) {
+      return;
+    }
+    const baseLevel =
+      typeof currentBattleLevel === 'number'
+        ? currentBattleLevel
+        : typeof window.preloadedData?.variables?.progress?.battleLevel === 'number'
+        ? window.preloadedData.variables.progress.battleLevel
+        : 0;
+    const nextLevel = baseLevel + 1;
+    persistProgress({ battleLevel: nextLevel });
+    currentBattleLevel = nextLevel;
+    battleLevelAdvanced = true;
+  }
+
+  function loadData() {
+    const data = window.preloadedData ?? {};
+    const battleData = data.battle ?? {};
+    const heroData = data.hero ?? {};
+    const enemyData = data.enemy ?? {};
+    const progressData = data.variables?.progress ?? {};
+
+    const resolveAssetPath = (path) => {
+      if (typeof path !== 'string' || path.trim().length === 0) {
+        return null;
+      }
+      const trimmed = path.trim();
+      if (/^https?:\/\//i.test(trimmed)) {
+        return trimmed;
+      }
+      if (trimmed.startsWith('../')) {
+        return trimmed;
+      }
+      if (trimmed.startsWith('./')) {
+        return `../${trimmed.slice(2)}`;
+      }
+      if (trimmed.startsWith('/')) {
+        return `..${trimmed}`;
+      }
+      return `../${trimmed}`;
+    };
+
+    currentBattleLevel =
+      typeof progressData.battleLevel === 'number'
+        ? progressData.battleLevel
+        : typeof data.level?.battleLevel === 'number'
+        ? data.level.battleLevel
+        : null;
+
+    accuracyGoal =
+      typeof battleData.accuracyGoal === 'number' &&
+      Number.isFinite(battleData.accuracyGoal)
+        ? battleData.accuracyGoal
+        : null;
+
+    const parsedTimeGoal = Number(battleData.timeGoalSeconds);
+    timeGoalSeconds =
+      Number.isFinite(parsedTimeGoal) && parsedTimeGoal > 0
+        ? Math.floor(parsedTimeGoal)
+        : 0;
+
+    const storedTime = Number(progressData.timeRemainingSeconds);
+    if (Number.isFinite(storedTime) && storedTime > 0) {
+      timeRemaining = Math.floor(storedTime);
+      if (timeGoalSeconds > 0) {
+        timeRemaining = Math.min(timeRemaining, timeGoalSeconds);
+      }
+    } else {
+      timeRemaining = timeGoalSeconds;
+    }
+
+    if (!Number.isFinite(timeRemaining) || timeRemaining < 0) {
+      timeRemaining = 0;
+    }
+
+    initialTimeRemaining = Number.isFinite(timeRemaining) ? timeRemaining : 0;
+
+    const resolvedStreakGoal = Number(battleData.streakGoal);
+    if (Number.isFinite(resolvedStreakGoal)) {
+      STREAK_GOAL = Math.min(
+        Math.max(Math.round(resolvedStreakGoal), MIN_STREAK_GOAL),
+        MAX_STREAK_GOAL
+      );
+    } else {
+      STREAK_GOAL = Math.min(
+        Math.max(Math.round(STREAK_GOAL), MIN_STREAK_GOAL),
+        MAX_STREAK_GOAL
+      );
+    }
+
+    hero.attack = Number(heroData.attack) || hero.attack;
+    hero.health = Number(heroData.health) || hero.health;
+    hero.damage = Number(heroData.damage) || hero.damage;
+    hero.name = heroData.name || hero.name;
+    if (typeof heroData.gems === 'number') {
+      hero.gems = heroData.gems;
+    }
+
+    const heroSprite = resolveAssetPath(heroData.sprite);
+    if (heroSprite && heroImg) {
+      heroImg.src = heroSprite;
+    }
+    if (heroImg && hero.name) {
+      heroImg.alt = `${hero.name} ready for battle`;
+    }
+
+    monster.attack = Number(enemyData.attack) || monster.attack;
+    monster.health = Number(enemyData.health) || monster.health;
+    monster.damage = Number(enemyData.damage) || monster.damage;
+    monster.name = enemyData.name || monster.name;
+
+    const monsterSprite = resolveAssetPath(enemyData.sprite);
+    if (monsterSprite && monsterImg) {
+      monsterImg.src = monsterSprite;
+    }
+    if (monsterImg && monster.name) {
+      monsterImg.alt = `${monster.name} ready for battle`;
+    }
+    if (monsterSprite && completeEnemyImg) {
+      completeEnemyImg.src = monsterSprite;
+    }
+
+    if (heroAttackVal) heroAttackVal.textContent = hero.attack;
+    if (heroHealthVal) heroHealthVal.textContent = hero.health;
+    if (monsterAttackVal) monsterAttackVal.textContent = monster.attack;
+    if (monsterHealthVal) monsterHealthVal.textContent = monster.health;
+    if (heroNameEl) heroNameEl.textContent = hero.name;
+    if (monsterNameEl) monsterNameEl.textContent = monster.name;
+    if (completeEnemyImg && monster.name) {
+      completeEnemyImg.alt = `${monster.name} ready for battle`;
+    }
+
+    const loadedQuestions = Array.isArray(data.questions)
+      ? data.questions.slice()
+      : [];
+    questions = shuffle(loadedQuestions);
+
+    updateHealthBars();
+    updateBattleTimeDisplay();
+  }
+
+  function updateHealthBars() {
+    const heroPercent = ((hero.health - hero.damage) / hero.health) * 100;
+    const monsterPercent = ((monster.health - monster.damage) / monster.health) * 100;
+    heroHpFill.style.width = heroPercent + '%';
+    monsterHpFill.style.width = monsterPercent + '%';
+  }
+
+  function calculateAccuracy() {
+    if (wrongAnswers === 0) {
+      return 100;
+    }
+    return totalAnswers
+      ? Math.max(0, Math.round((correctAnswers / totalAnswers) * 100))
+      : 100;
+  }
+
+  function updateAccuracyDisplays() {
+    const accuracy = calculateAccuracy();
+    if (bannerAccuracyValue) bannerAccuracyValue.textContent = `${accuracy}%`;
+    if (summaryAccuracyText) summaryAccuracyText.textContent = `${accuracy}%`;
+  }
+
+  function updateBattleTimeDisplay() {
+    const timeValue = Number.isFinite(timeRemaining) ? Math.max(0, Math.floor(timeRemaining)) : 0;
+    if (bannerTimeValue) bannerTimeValue.textContent = `${timeValue}s`;
+    if (summaryTimeText) summaryTimeText.textContent = `${timeValue}s`;
+  }
+
+  function handleBattleTimerTick() {
+    if (battleEnded) {
+      stopBattleTimer();
+      return;
+    }
+    if (!Number.isFinite(battleTimerDeadline)) {
+      stopBattleTimer();
+      return;
+    }
+    const now = Date.now();
+    const secondsLeft = Math.max(0, Math.ceil((battleTimerDeadline - now) / 1000));
+    if (secondsLeft !== timeRemaining) {
+      timeRemaining = secondsLeft;
+      updateBattleTimeDisplay();
+    }
+    if (secondsLeft <= 0) {
+      endBattle(false, { reason: 'timeout' });
+    }
+  }
+
+  function startBattleTimer() {
+    stopBattleTimer();
+    if (!battleStartTime) {
+      battleStartTime = Date.now();
+    }
+    if (!Number.isFinite(timeRemaining) || timeRemaining <= 0) {
+      timeRemaining = Math.max(0, Number.isFinite(timeRemaining) ? Math.floor(timeRemaining) : 0);
+      updateBattleTimeDisplay();
+      if (timeGoalSeconds > 0 && !battleEnded) {
+        endBattle(false, { reason: 'timeout' });
+      }
+      return;
+    }
+    battleTimerDeadline = Date.now() + timeRemaining * 1000;
+    updateBattleTimeDisplay();
+    battleTimerInterval = window.setInterval(handleBattleTimerTick, 250);
+  }
+
+  function stopBattleTimer() {
+    if (battleTimerInterval) {
+      clearInterval(battleTimerInterval);
+      battleTimerInterval = null;
+    }
+    battleTimerDeadline = null;
+  }
+
+  function showQuestion() {
+    if (battleEnded) {
+      return;
+    }
+    const q = questions[currentQuestion];
+    if (!q) return;
+    questionText.textContent = q.question || q.q || '';
+    choicesEl.innerHTML = '';
+
+    let choices = q.choices;
+    if (!choices && q.options) {
+      choices = q.options.map((opt) => ({ name: opt, correct: opt === q.answer }));
+    }
+
+    (choices || []).forEach((choice) => {
+      const div = document.createElement('div');
+      div.classList.add('choice');
+      div.dataset.correct = !!choice.correct;
+      if (choice.image) {
+        const img = document.createElement('img');
+        img.src = `../images/questions/${choice.image}`;
+        img.alt = choice.name || '';
+        div.appendChild(img);
+      }
+      const p = document.createElement('p');
+      p.textContent = choice.name || '';
+      div.appendChild(p);
+      choicesEl.appendChild(div);
+    });
+    questionBox.classList.add('show');
+    updateStreak();
+  }
+
+  function updateStreak() {
+    const percent = Math.min(streak / STREAK_GOAL, 1) * 100;
+    if (streak > 0) {
+      topBar?.classList.add('show');
+      progressBar.classList.add('with-label');
+      void progressFill.offsetWidth;
+      progressFill.style.width = percent + '%';
+      if (streakMaxed) {
+        progressFill.style.background = '#FF6A00';
+        streakLabel.textContent = '2x Attack';
+        streakLabel.style.color = '#FF6A00';
+        streakLabel.classList.remove('show');
+        void streakLabel.offsetWidth;
+        streakLabel.classList.add('show');
+        if (streakIcon && !streakIconShown) {
+          progressFill.addEventListener(
+            'transitionend',
+            () => {
+              streakIcon.classList.add('show');
+            },
+            { once: true }
+          );
+          streakIconShown = true;
+        }
+      } else {
+        progressFill.style.background = '#006AFF';
+        streakLabel.style.color = '#006AFF';
+        streakLabel.textContent = `${streak} in a row`;
+        streakLabel.classList.remove('show');
+        void streakLabel.offsetWidth;
+        streakLabel.classList.add('show');
+        if (streakIcon) {
+          streakIcon.classList.remove('show');
+        }
+        streakIconShown = false;
+      }
+    } else {
+      topBar?.classList.remove('show');
+      progressBar.classList.remove('with-label');
+      progressFill.style.width = '0%';
+      progressFill.style.background = '#006AFF';
+      streakLabel.classList.remove('show');
+      if (streakIcon) {
+        streakIcon.classList.remove('show');
+      }
+      streakIconShown = false;
+    }
+  }
+
+  function showIncrease(el, text) {
+    if (!el) return;
+    el.classList.remove('show');
+    el.textContent = text;
+    void el.offsetWidth;
+    el.classList.add('show');
+    setTimeout(() => {
+      el.classList.remove('show');
+    }, 2000);
+  }
+
+  function heroAttack() {
+    if (battleEnded) {
+      return;
+    }
+    heroImg.classList.add('attack');
+    const handler = (e) => {
+      if (e.animationName !== 'hero-attack') return;
+      heroImg.classList.remove('attack');
+      heroImg.removeEventListener('animationend', handler);
+      setTimeout(() => {
+        if (battleEnded) {
+          return;
+        }
+        monster.damage += hero.attack;
+        updateHealthBars();
+        if (streakMaxed) {
+          // Double-attack was used; reset streak.
+          streak = 0;
+          streakMaxed = false;
+          updateStreak();
+        }
+        setTimeout(() => {
+          if (battleEnded) {
+            return;
+          }
+          if (monster.damage >= monster.health) {
+            endBattle(true);
+          } else {
+            currentQuestion++;
+            showQuestion();
+          }
+        }, 2000);
+      }, 500);
+    };
+    heroImg.addEventListener('animationend', handler);
+  }
+
+  function monsterAttack() {
+    if (battleEnded) {
+      return;
+    }
+    setTimeout(() => {
+      if (battleEnded) {
+        return;
+      }
+      monsterImg.classList.add('attack');
+      const handler = (e) => {
+        if (e.animationName !== 'monster-attack') return;
+        monsterImg.classList.remove('attack');
+        monsterImg.removeEventListener('animationend', handler);
+        setTimeout(() => {
+          if (battleEnded) {
+            return;
+          }
+          hero.damage += monster.attack;
+          updateHealthBars();
+          setTimeout(() => {
+            if (battleEnded) {
+              return;
+            }
+            if (hero.damage >= hero.health) {
+              endBattle(false);
+            } else {
+              currentQuestion++;
+              showQuestion();
+            }
+          }, 2000);
+        }, 500);
+      };
+      monsterImg.addEventListener('animationend', handler);
+    }, 300);
+  }
+
+  setStreakButton?.addEventListener('click', () => {
+    if (battleEnded) {
+      return;
+    }
+    const targetStreak = Math.max(0, STREAK_GOAL - 1);
+    streak = targetStreak;
+    streakMaxed = false;
+    updateStreak();
+  });
+
+  endBattleButton?.addEventListener('click', () => {
+    if (battleEnded) {
+      return;
+    }
+    document.dispatchEvent(new Event('close-question'));
+    window.setTimeout(() => {
+      endBattle(true);
+    }, 0);
+  });
+
+  resetLevelButton?.addEventListener('click', () => {
+    persistProgress({ battleLevel: 1 });
+    currentBattleLevel = 1;
+    battleLevelAdvanced = false;
+    battleGoalsMet = false;
+  });
+
+  logOutButton?.addEventListener('click', async () => {
+    const supabase = window.supabaseClient;
+
+    if (supabase?.auth?.signOut) {
+      try {
+        const { error } = await supabase.auth.signOut();
+        if (error) {
+          console.warn('Supabase sign out failed', error);
+        }
+      } catch (error) {
+        console.warn('Unexpected error during sign out', error);
+      }
+    }
+
+    window.location.replace('../signin.html');
+  });
+
+  document.addEventListener('answer-submitted', (e) => {
+    if (battleEnded) {
+      return;
+    }
+    const correct = e.detail.correct;
+    totalAnswers++;
+    if (correct) {
+      correctAnswers++;
+    } else {
+      wrongAnswers++;
+    }
+    updateAccuracyDisplays();
+    if (correct) {
+      let incEl = null;
+      let incText = '';
+      if (!streakMaxed) {
+        streak++;
+        if (streak >= STREAK_GOAL) {
+          streak = STREAK_GOAL;
+          streakMaxed = true;
+          hero.attack *= 2;
+          if (heroAttackVal) heroAttackVal.textContent = hero.attack;
+          incEl = heroAttackInc;
+          incText = 'x2';
+        } else {
+          const stats = ['attack', 'health'];
+          const stat = stats[Math.floor(Math.random() * stats.length)];
+          if (stat === 'attack') {
+            hero.attack++;
+            if (heroAttackVal) heroAttackVal.textContent = hero.attack;
+            incEl = heroAttackInc;
+            incText = '+1';
+          } else {
+            hero.health++;
+            if (heroHealthVal) heroHealthVal.textContent = hero.health;
+            incEl = heroHealthInc;
+            incText = '+1';
+            updateHealthBars();
+          }
+        }
+      } else {
+        const stats = ['attack', 'health'];
+        const stat = stats[Math.floor(Math.random() * stats.length)];
+        if (stat === 'attack') {
+          hero.attack++;
+          if (heroAttackVal) heroAttackVal.textContent = hero.attack;
+          incEl = heroAttackInc;
+          incText = '+1';
+        } else {
+          hero.health++;
+          if (heroHealthVal) heroHealthVal.textContent = hero.health;
+          incEl = heroHealthInc;
+          incText = '+1';
+          updateHealthBars();
+        }
+      }
+
+      updateStreak();
+
+      // Keep the question visible briefly so the player can
+      // see the result and streak progress before it closes.
+      // If the streak just hit the goal (x2), linger a bit longer.
+      const lingerTime = incText === 'x2' ? 3000 : 2000;
+      setTimeout(() => {
+        document.dispatchEvent(new Event('close-question'));
+        setTimeout(() => {
+          showIncrease(incEl, incText);
+          setTimeout(heroAttack, 1000);
+        }, 300);
+      }, lingerTime);
+    } else {
+      streak = 0;
+      streakMaxed = false;
+      updateStreak();
+      setTimeout(() => {
+        document.dispatchEvent(new Event('close-question'));
+        monsterAttack();
+      }, 2000);
+    }
+  });
+  function endBattle(win, _options = {}) {
+    if (battleEnded) {
+      return;
+    }
+    battleEnded = true;
+    devControls?.classList.add('battle-dev-controls--hidden');
+    document.dispatchEvent(new Event('close-question'));
+    stopBattleTimer();
+    updateAccuracyDisplays();
+    updateBattleTimeDisplay();
+
+    const accuracy = calculateAccuracy();
+    const accuracyDisplay = `${accuracy}%`;
+    const accuracyGoalMet =
+      typeof accuracyGoal === 'number' ? accuracy / 100 >= accuracyGoal : true;
+
+    const now = Date.now();
+    const elapsedByTimer = initialTimeRemaining > 0
+      ? Math.max(0, Math.round(initialTimeRemaining - timeRemaining))
+      : 0;
+    const elapsedByClock = battleStartTime
+      ? Math.max(0, Math.round((now - battleStartTime) / 1000))
+      : 0;
+    const elapsedSeconds = initialTimeRemaining > 0
+      ? Math.max(elapsedByTimer, elapsedByClock)
+      : elapsedByClock;
+    const timeDisplay = `${elapsedSeconds}s`;
+    const timeGoalMet =
+      timeGoalSeconds > 0 ? elapsedSeconds <= timeGoalSeconds : true;
+
+    if (summaryAccuracyValue && summaryAccuracyText) {
+      applyGoalResult(
+        summaryAccuracyValue,
+        summaryAccuracyText,
+        accuracyDisplay,
+        accuracyGoalMet
+      );
+    }
+
+    if (summaryTimeValue && summaryTimeText) {
+      applyGoalResult(
+        summaryTimeValue,
+        summaryTimeText,
+        timeDisplay,
+        timeGoalMet
+      );
+    }
+
+    if (completeEnemyImg && monsterImg) {
+      completeEnemyImg.src = monsterImg.src;
+      if (monster.name) {
+        completeEnemyImg.alt = win
+          ? `${monster.name} defeated in battle`
+          : `${monster.name} preparing for the next battle`;
+      }
+    }
+
+    const goalsAchieved = win && accuracyGoalMet && timeGoalMet;
+
+    if (win && goalsAchieved) {
+      const monsterName =
+        typeof monster?.name === 'string' ? monster.name.trim() : '';
+      const victoryName = monsterName || 'Monster';
+      setBattleCompleteTitleLines(victoryName, 'Defeated!');
+    } else {
+      setBattleCompleteTitleLines('Keep', 'Practicing!');
+    }
+
+    battleGoalsMet = goalsAchieved;
+    if (battleGoalsMet) {
+      advanceBattleLevel();
+    }
+
+    if (nextMissionBtn) {
+      nextMissionBtn.textContent = battleGoalsMet ? 'Next Mission' : 'Try Again';
+      nextMissionBtn.dataset.action = battleGoalsMet ? 'next' : 'retry';
+    }
+
+    if (completeMessage) {
+      completeMessage.classList.add('show');
+      completeMessage.setAttribute('aria-hidden', 'false');
+      if (typeof completeMessage.focus === 'function') {
+        completeMessage.focus();
+      }
+    }
+  }
+
+  if (nextMissionBtn) {
+    nextMissionBtn.addEventListener('click', () => {
+      const action = nextMissionBtn.dataset.action;
+      if (action === 'retry') {
+        window.location.reload();
+      } else {
+        if (battleGoalsMet && !battleLevelAdvanced) {
+          advanceBattleLevel();
+        }
+        window.location.href = '../index.html';
+      }
+    });
+  }
+
+  function initBattle() {
+    battleEnded = false;
+    streak = 0;
+    streakMaxed = false;
+    streakIconShown = false;
+    currentQuestion = 0;
+    correctAnswers = 0;
+    totalAnswers = 0;
+    wrongAnswers = 0;
+    battleStartTime = null;
+    initialTimeRemaining = 0;
+    battleLevelAdvanced = false;
+    battleGoalsMet = false;
+    if (completeMessage) {
+      completeMessage.classList.remove('show');
+      completeMessage.setAttribute('aria-hidden', 'true');
+    }
+    setBattleCompleteTitleLines('Battle', 'Complete');
+    if (nextMissionBtn) {
+      nextMissionBtn.textContent = 'Next Mission';
+      nextMissionBtn.dataset.action = 'next';
+    }
+    if (summaryAccuracyValue) {
+      summaryAccuracyValue.classList.remove('goal-result--met', 'goal-result--missed');
+    }
+    if (summaryTimeValue) {
+      summaryTimeValue.classList.remove('goal-result--met', 'goal-result--missed');
+    }
+    loadData();
+    updateStreak();
+    updateAccuracyDisplays();
+    startBattleTimer();
+    setTimeout(showQuestion, 2000);
+  }
+
+  if (window.preloadedData) {
+    initBattle();
+  } else {
+    document.addEventListener('data-loaded', initBattle, { once: true });
+  }
+});

--- a/pwa-app/js/index.js
+++ b/pwa-app/js/index.js
@@ -1,0 +1,632 @@
+const LANDING_VISITED_KEY = 'reefRangersVisitedLanding';
+
+const VISITED_VALUE = 'true';
+const PROGRESS_STORAGE_KEY = 'reefRangersProgress';
+const MIN_PRELOAD_DURATION_MS = 2000;
+
+const redirectToSignIn = () => {
+  window.location.replace('signin.html');
+};
+
+const ensureAuthenticated = async () => {
+  const supabase = window.supabaseClient;
+  if (!supabase) {
+    redirectToSignIn();
+    return false;
+  }
+
+  try {
+    const { data, error } = await supabase.auth.getSession();
+    if (error) {
+      console.warn('Authentication session lookup failed', error);
+    }
+
+    if (!data?.session) {
+      redirectToSignIn();
+      return false;
+    }
+    return true;
+  } catch (error) {
+    console.warn('Unexpected authentication error', error);
+    redirectToSignIn();
+    return false;
+  }
+};
+
+const startLandingExperience = () => {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', bootstrapLanding);
+  } else {
+    bootstrapLanding();
+  }
+};
+
+(async () => {
+  const isAuthenticated = await ensureAuthenticated();
+  if (isAuthenticated) {
+    startLandingExperience();
+  }
+})();
+
+const getNow = () =>
+  typeof performance !== 'undefined' && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now();
+
+const sanitizeAssetPath = (path) => {
+  if (typeof path !== 'string') {
+    return null;
+  }
+  let trimmed = path.trim();
+  if (!trimmed || trimmed.startsWith('data:')) {
+    return null;
+  }
+  while (trimmed.startsWith('./') || trimmed.startsWith('../')) {
+    if (trimmed.startsWith('./')) {
+      trimmed = trimmed.slice(2);
+    } else if (trimmed.startsWith('../')) {
+      trimmed = trimmed.slice(3);
+    }
+  }
+  return trimmed;
+};
+
+const mergeVariablesWithProgress = (rawVariablesData) => {
+  const variables =
+    rawVariablesData && typeof rawVariablesData === 'object'
+      ? { ...rawVariablesData }
+      : {};
+
+  const storedProgress = readStoredProgress();
+
+  if (storedProgress && typeof storedProgress === 'object') {
+    const baseProgress =
+      rawVariablesData && typeof rawVariablesData.progress === 'object'
+        ? rawVariablesData.progress
+        : {};
+    const mergedProgress = { ...baseProgress };
+
+    if (typeof storedProgress.battleLevel === 'number') {
+      mergedProgress.battleLevel = storedProgress.battleLevel;
+    }
+
+    if (typeof storedProgress.timeRemainingSeconds === 'number') {
+      mergedProgress.timeRemainingSeconds =
+        storedProgress.timeRemainingSeconds;
+    }
+
+    variables.progress = mergedProgress;
+  } else if (
+    rawVariablesData &&
+    typeof rawVariablesData.progress === 'object' &&
+    !variables.progress
+  ) {
+    variables.progress = { ...rawVariablesData.progress };
+  }
+
+  return variables;
+};
+
+const determineBattlePreview = (levelsData, variablesData) => {
+  const levels = Array.isArray(levelsData?.levels) ? levelsData.levels : [];
+  const variables = mergeVariablesWithProgress(variablesData);
+
+  if (!levels.length) {
+    return { levels, variables, preview: null };
+  }
+
+  const progressLevel = variables?.progress?.battleLevel;
+  const activeLevel =
+    levels.find((level) => level?.battleLevel === progressLevel) ?? levels[0];
+
+  if (!activeLevel) {
+    return { levels, variables, preview: null };
+  }
+
+  const userBattles = Array.isArray(variables?.user?.battles)
+    ? variables.user.battles
+    : [];
+
+  const findUserBattle = (level) => {
+    if (typeof level !== 'number') {
+      return null;
+    }
+    return (
+      userBattles.find(
+        (entry) => typeof entry?.battleLevel === 'number' && entry.battleLevel === level
+      ) ?? null
+    );
+  };
+
+  const activeUserBattle =
+    findUserBattle(activeLevel?.battleLevel) ?? userBattles[0] ?? null;
+
+  const levelHero = activeLevel?.battle?.hero ?? {};
+  const heroData = {
+    ...levelHero,
+    ...(activeUserBattle?.hero ?? {}),
+  };
+
+  const heroSprite =
+    typeof heroData?.sprite === 'string' ? heroData.sprite.trim() : '';
+  const heroName = typeof heroData?.name === 'string' ? heroData.name.trim() : '';
+  const heroAlt = heroName ? `${heroName} ready for battle` : 'Hero ready for battle';
+
+  const battle = activeLevel?.battle ?? {};
+  const mathLabelSource =
+    typeof activeLevel.mathType === 'string'
+      ? activeLevel.mathType
+      : typeof battle?.mathType === 'string'
+      ? battle.mathType
+      : 'Math Mission';
+  const mathLabel = mathLabelSource.trim() || 'Math Mission';
+
+  const enemyData = battle?.enemy ?? {};
+  const enemySprite =
+    typeof enemyData?.sprite === 'string' ? enemyData.sprite.trim() : '';
+  const enemyName =
+    typeof enemyData?.name === 'string' ? enemyData.name.trim() : '';
+  const enemyAlt = enemyName ? `${enemyName} ready for battle` : 'Enemy ready for battle';
+
+  const levelName = typeof activeLevel?.name === 'string' ? activeLevel.name.trim() : '';
+  const battleTitleLabel =
+    levelName ||
+    (typeof activeLevel?.battleLevel === 'number'
+      ? `Battle ${activeLevel.battleLevel}`
+      : 'Upcoming Battle');
+
+  const accuracyGoal =
+    typeof battle?.accuracyGoal === 'number'
+      ? Math.round(battle.accuracyGoal * 100)
+      : null;
+
+  const timeGoal =
+    typeof battle?.timeGoalSeconds === 'number' ? battle.timeGoalSeconds : null;
+
+  return {
+    levels,
+    variables,
+    preview: {
+      activeLevel,
+      battleLevel: activeLevel?.battleLevel ?? null,
+      mathLabel,
+      battleTitleLabel,
+      hero: { ...heroData, sprite: heroSprite },
+      heroAlt,
+      enemy: { ...enemyData, sprite: enemySprite },
+      enemyAlt,
+      overlayAccuracyText: accuracyGoal !== null ? `${accuracyGoal}%` : '0%',
+      overlayTimeText: timeGoal !== null ? `${timeGoal}s` : '0s',
+    },
+  };
+};
+
+const applyBattlePreview = (previewData = {}) => {
+  const heroImage = document.querySelector('.hero');
+  const battleMathElements = document.querySelectorAll('[data-battle-math]');
+  const battleTitleElements = document.querySelectorAll('[data-battle-title]');
+  const battleEnemyElements = document.querySelectorAll('[data-battle-enemy]');
+  const overlayAccuracy = document.querySelector('.accuracy-value');
+  const overlayTime = document.querySelector('.time-value');
+
+  if (heroImage) {
+    const heroSprite =
+      typeof previewData?.hero?.sprite === 'string' ? previewData.hero.sprite : '';
+    if (heroSprite) {
+      heroImage.src = heroSprite;
+    }
+    heroImage.alt =
+      typeof previewData?.heroAlt === 'string' && previewData.heroAlt.trim()
+        ? previewData.heroAlt
+        : 'Hero ready for battle';
+  }
+
+  battleMathElements.forEach((element) => {
+    if (!element) {
+      return;
+    }
+    element.textContent =
+      typeof previewData?.mathLabel === 'string' && previewData.mathLabel.trim()
+        ? previewData.mathLabel
+        : 'Math Mission';
+  });
+
+  battleTitleElements.forEach((element) => {
+    if (!element) {
+      return;
+    }
+    element.textContent =
+      typeof previewData?.battleTitleLabel === 'string' &&
+      previewData.battleTitleLabel.trim()
+        ? previewData.battleTitleLabel
+        : 'Upcoming Battle';
+  });
+
+  battleEnemyElements.forEach((element) => {
+    if (!element) {
+      return;
+    }
+    const enemySprite =
+      typeof previewData?.enemy?.sprite === 'string'
+        ? previewData.enemy.sprite
+        : '';
+    if (enemySprite && (element instanceof HTMLImageElement || element.tagName === 'IMG')) {
+      element.src = enemySprite;
+    }
+    if (element instanceof HTMLImageElement || element.tagName === 'IMG') {
+      element.alt =
+        typeof previewData?.enemyAlt === 'string' && previewData.enemyAlt.trim()
+          ? previewData.enemyAlt
+          : 'Enemy ready for battle';
+    }
+  });
+
+  if (overlayAccuracy) {
+    overlayAccuracy.textContent =
+      typeof previewData?.overlayAccuracyText === 'string'
+        ? previewData.overlayAccuracyText
+        : '0%';
+  }
+
+  if (overlayTime) {
+    overlayTime.textContent =
+      typeof previewData?.overlayTimeText === 'string'
+        ? previewData.overlayTimeText
+        : '0s';
+  }
+};
+
+const preloaderElement = document.querySelector('[data-preloader]');
+let preloaderStartTime = getNow();
+let preloaderFinished = false;
+let preloaderHidePromise = null;
+
+const finishPreloader = () => {
+  if (preloaderHidePromise) {
+    return preloaderHidePromise;
+  }
+
+  preloaderHidePromise = (async () => {
+    if (preloaderFinished) {
+      document.body.classList.remove('is-preloading');
+      return;
+    }
+
+    preloaderFinished = true;
+    const elapsed = getNow() - preloaderStartTime;
+    if (elapsed < MIN_PRELOAD_DURATION_MS) {
+      await new Promise((resolve) =>
+        window.setTimeout(resolve, MIN_PRELOAD_DURATION_MS - elapsed)
+      );
+    }
+
+    document.body.classList.remove('is-preloading');
+
+    if (!preloaderElement) {
+      return;
+    }
+
+    preloaderElement.setAttribute('aria-hidden', 'true');
+    preloaderElement.classList.add('preloader--hidden');
+
+    await new Promise((resolve) => window.setTimeout(resolve, 400));
+
+    if (preloaderElement.parentElement) {
+      preloaderElement.parentElement.removeChild(preloaderElement);
+    }
+  })();
+
+  return preloaderHidePromise;
+};
+
+const readStoredProgress = () => {
+  try {
+    const storage = window.localStorage;
+    if (!storage) {
+      return null;
+    }
+    const raw = storage.getItem(PROGRESS_STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch (error) {
+    console.warn('Stored progress unavailable.', error);
+    return null;
+  }
+};
+
+const setVisitedFlag = (storage, label) => {
+  if (!storage) {
+    return;
+  }
+  try {
+    storage.setItem(LANDING_VISITED_KEY, VISITED_VALUE);
+  } catch (error) {
+    console.warn(`${label} storage is not available.`, error);
+  }
+};
+
+const markLandingVisited = () => {
+  setVisitedFlag(sessionStorage, 'Session');
+  setVisitedFlag(localStorage, 'Local');
+};
+
+const randomizeBubbleTimings = () => {
+  const bubbles = document.querySelectorAll('.bubble');
+
+  bubbles.forEach((bubble) => {
+    const computedStyles = window.getComputedStyle(bubble);
+    const durationValue = computedStyles.getPropertyValue('--duration').trim();
+    const durationInSeconds = Number.parseFloat(durationValue);
+
+    if (!Number.isFinite(durationInSeconds) || durationInSeconds <= 0) {
+      const fallbackOffset = -(Math.random() * 2);
+      bubble.style.setProperty('--delay', `${fallbackOffset.toFixed(3)}s`);
+      return;
+    }
+
+    const randomOffset = Math.random() * durationInSeconds;
+    bubble.style.setProperty('--delay', `${-randomOffset.toFixed(3)}s`);
+  });
+};
+
+const preloadLandingAssets = async () => {
+  const results = { levelsData: null, variablesData: null, previewData: null };
+  const imageAssets = new Set(['../images/background/background.png']);
+  const questionFiles = new Set();
+
+  const addImageAsset = (path) => {
+    const normalized = sanitizeAssetPath(path);
+    if (normalized) {
+      imageAssets.add(normalized);
+    }
+  };
+
+  if (!document.body.classList.contains('is-preloading')) {
+    document.body.classList.add('is-preloading');
+  }
+
+  preloaderStartTime = getNow();
+
+  document
+    .querySelectorAll('img[src]')
+    .forEach((img) => addImageAsset(img.getAttribute('src')));
+
+  const loadJson = async (url) => {
+    try {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`Failed to preload ${url}`);
+      }
+      return await response.json();
+    } catch (error) {
+      console.error(error);
+      return null;
+    }
+  };
+
+  try {
+    const [levelsData, rawVariablesData] = await Promise.all([
+      loadJson('data/levels.json'),
+      loadJson('data/variables.json'),
+    ]);
+
+    const { levels, variables, preview } = determineBattlePreview(
+      levelsData,
+      rawVariablesData
+    );
+
+    results.levelsData =
+      levelsData && typeof levelsData === 'object'
+        ? { ...levelsData, levels }
+        : { levels };
+    results.variablesData = variables;
+    results.previewData = preview;
+
+    if (levels.length) {
+      levels.forEach((level) => {
+        const battle = level?.battle ?? {};
+        addImageAsset(battle?.hero?.sprite);
+        addImageAsset(battle?.enemy?.sprite);
+
+        const questionFile = battle?.questionReference?.file;
+        if (typeof questionFile === 'string') {
+          const sanitizedFile = sanitizeAssetPath(questionFile);
+          if (sanitizedFile) {
+            const normalized = sanitizedFile.startsWith('data/')
+              ? sanitizedFile
+              : `data/${sanitizedFile.replace(/^\/+/, '')}`;
+            questionFiles.add(normalized);
+          }
+        }
+      });
+    }
+
+    if (Array.isArray(variables?.user?.battles)) {
+      variables.user.battles.forEach((battleEntry) => {
+        addImageAsset(battleEntry?.hero?.sprite);
+      });
+    }
+
+    const prioritizedImages = [];
+    const heroSprite = sanitizeAssetPath(preview?.hero?.sprite) || preview?.hero?.sprite;
+    const enemySprite =
+      sanitizeAssetPath(preview?.enemy?.sprite) || preview?.enemy?.sprite;
+
+    if (heroSprite) {
+      prioritizedImages.push(heroSprite);
+    }
+    if (enemySprite) {
+      prioritizedImages.push(enemySprite);
+    }
+
+    const imagePaths = Array.from(
+      new Set([...prioritizedImages.filter(Boolean), ...imageAssets])
+    );
+    const questionPaths = Array.from(questionFiles);
+
+    const preloadQuestion = async (url) => {
+      try {
+        const response = await fetch(url);
+        if (!response.ok) {
+          throw new Error(`Failed to preload ${url}`);
+        }
+        await response.json();
+      } catch (error) {
+        console.warn(error);
+      }
+    };
+
+    const preloadImage = (src) =>
+      new Promise((resolve) => {
+        if (!src) {
+          resolve(false);
+          return;
+        }
+        const image = new Image();
+        image.decoding = 'async';
+        const finalize = (success) => {
+          if (!success) {
+            console.warn(`Failed to preload image: ${src}`);
+          }
+          resolve(success);
+        };
+        image.onload = () => finalize(true);
+        image.onerror = () => finalize(false);
+        image.src = src;
+      });
+
+    await Promise.allSettled([
+      ...questionPaths.map(preloadQuestion),
+      ...imagePaths.map(preloadImage),
+    ]);
+
+    if (preview) {
+      applyBattlePreview(preview);
+    }
+  } catch (error) {
+    console.error('Failed to preload landing assets.', error);
+  } finally {
+    await finishPreloader();
+  }
+
+  return results;
+};
+
+const initLandingInteractions = (preloadedData = {}) => {
+  markLandingVisited();
+  randomizeBubbleTimings();
+
+  const battleOverlay = document.getElementById('battle-overlay');
+  const overlayCard = battleOverlay?.querySelector('.battle-overlay-card');
+  const battleButton = battleOverlay?.querySelector('.battle-btn');
+  const splatImage = document.querySelector('.battle-splat');
+
+  const loadBattlePreview = async () => {
+    try {
+      let levelsData = preloadedData?.levelsData ?? null;
+      let variablesData = preloadedData?.variablesData ?? null;
+      let previewData = preloadedData?.previewData ?? null;
+
+      if (!levelsData) {
+        const levelsRes = await fetch('data/levels.json');
+        if (!levelsRes.ok) {
+          throw new Error('Failed to load battle level data.');
+        }
+        levelsData = await levelsRes.json();
+      }
+
+      if (!variablesData) {
+        try {
+          const variablesRes = await fetch('data/variables.json');
+          if (variablesRes.ok) {
+            variablesData = await variablesRes.json();
+          }
+        } catch (error) {
+          console.warn('Unable to load battle variables.', error);
+        }
+      }
+
+      if (!previewData) {
+        const previewResult = determineBattlePreview(levelsData, variablesData);
+        levelsData =
+          levelsData && typeof levelsData === 'object'
+            ? { ...levelsData, levels: previewResult.levels }
+            : { levels: previewResult.levels };
+        variablesData = previewResult.variables;
+        previewData = previewResult.preview;
+      }
+
+      if (previewData) {
+        applyBattlePreview(previewData);
+      }
+    } catch (error) {
+      console.error('Failed to load battle preview', error);
+    }
+  };
+
+  loadBattlePreview();
+  if (!battleOverlay) {
+    return;
+  }
+
+  const BATTLE_SPLAT_DELAY = 3000;
+  const BATTLE_CARD_DELAY = 2000;
+  let splatTimeoutId;
+  let overlayTimeoutId;
+
+  const openOverlay = () => {
+    if (document.body.classList.contains('battle-overlay-open')) {
+      return;
+    }
+
+    document.body.classList.add('battle-overlay-open');
+    battleOverlay.setAttribute('aria-hidden', 'false');
+
+    if (overlayCard) {
+      overlayCard.classList.remove('battle-card--pop');
+      overlayCard.classList.remove('battle-overlay-card--visible');
+      void overlayCard.offsetWidth;
+      overlayCard.classList.add('battle-overlay-card--visible');
+      overlayCard.classList.add('battle-card--pop');
+    }
+
+    window.setTimeout(() => {
+      battleButton?.focus({ preventScroll: true });
+    }, 200);
+  };
+
+  const startBattleSequence = () => {
+    window.clearTimeout(splatTimeoutId);
+    window.clearTimeout(overlayTimeoutId);
+
+    splatTimeoutId = window.setTimeout(() => {
+      if (splatImage) {
+        splatImage.classList.add('battle-splat--active');
+      }
+
+      overlayTimeoutId = window.setTimeout(openOverlay, BATTLE_CARD_DELAY);
+    }, BATTLE_SPLAT_DELAY);
+  };
+
+  startBattleSequence();
+
+  if (battleButton) {
+    battleButton.addEventListener('click', () => {
+      window.location.href = 'html/battle.html';
+    });
+  }
+};
+
+const bootstrapLanding = async () => {
+  try {
+    const preloadedData = await preloadLandingAssets();
+    initLandingInteractions(preloadedData);
+  } catch (error) {
+    console.error('Failed to initialize the landing experience.', error);
+    await finishPreloader();
+    initLandingInteractions({});
+  }
+};

--- a/pwa-app/js/loader.js
+++ b/pwa-app/js/loader.js
@@ -1,0 +1,199 @@
+const STORAGE_KEY_PROGRESS = 'reefRangersProgress';
+
+const readStoredProgress = () => {
+  try {
+    const storage = window.localStorage;
+    if (!storage) {
+      return null;
+    }
+    const raw = storage.getItem(STORAGE_KEY_PROGRESS);
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch (error) {
+    console.warn('Stored progress could not be read.', error);
+    return null;
+  }
+};
+
+(async function () {
+  try {
+    const [varsRes, levelsRes] = await Promise.all([
+      fetch('../data/variables.json'),
+      fetch('../data/levels.json'),
+    ]);
+
+    if (!varsRes.ok || !levelsRes.ok) {
+      throw new Error('Failed to fetch required configuration data.');
+    }
+
+    const [varsData, levelsData] = await Promise.all([
+      varsRes.json(),
+      levelsRes.json(),
+    ]);
+
+    const levels = Array.isArray(levelsData?.levels) ? levelsData.levels : [];
+    const storedProgress = readStoredProgress();
+    const baseVariables =
+      varsData && typeof varsData === 'object' ? varsData : {};
+    const baseProgress =
+      baseVariables && typeof baseVariables.progress === 'object'
+        ? baseVariables.progress
+        : {};
+    const userBattles = Array.isArray(baseVariables?.user?.battles)
+      ? baseVariables.user.battles
+      : [];
+    const progress = { ...baseProgress };
+
+    if (storedProgress && typeof storedProgress === 'object') {
+      if (typeof storedProgress.battleLevel === 'number') {
+        progress.battleLevel = storedProgress.battleLevel;
+      }
+      if (typeof storedProgress.timeRemainingSeconds === 'number') {
+        progress.timeRemainingSeconds = storedProgress.timeRemainingSeconds;
+      }
+    }
+    const activeBattleLevel =
+      progress.battleLevel ?? levels[0]?.battleLevel ?? null;
+
+    const currentLevel =
+      levels.find((level) => level?.battleLevel === activeBattleLevel) ??
+      levels[0] ??
+      null;
+
+    if (
+      currentLevel &&
+      typeof currentLevel.battleLevel === 'number' &&
+      progress.battleLevel !== currentLevel.battleLevel
+    ) {
+      progress.battleLevel = currentLevel.battleLevel;
+    }
+
+    const resolveAssetPath = (path) => {
+      if (typeof path !== 'string') {
+        return null;
+      }
+      const trimmed = path.trim();
+      if (!trimmed) {
+        return null;
+      }
+      if (/^https?:\/\//i.test(trimmed)) {
+        return trimmed;
+      }
+      if (trimmed.startsWith('../')) {
+        return trimmed;
+      }
+      if (trimmed.startsWith('./')) {
+        return `../${trimmed.slice(2)}`;
+      }
+      if (trimmed.startsWith('/')) {
+        return `..${trimmed}`;
+      }
+      return `../${trimmed}`;
+    };
+
+    const preloadImage = (path) =>
+      new Promise((resolve) => {
+        if (!path || typeof Image === 'undefined') {
+          resolve();
+          return;
+        }
+
+        const img = new Image();
+        const cleanup = () => {
+          img.onload = null;
+          img.onerror = null;
+          resolve();
+        };
+        img.onload = cleanup;
+        img.onerror = cleanup;
+        img.src = path;
+      });
+
+    let questions = [];
+    const questionFile = currentLevel?.battle?.questionReference?.file;
+
+    if (questionFile) {
+      try {
+        const questionsRes = await fetch(`../data/${questionFile}`);
+        if (questionsRes.ok) {
+          const questionsJson = await questionsRes.json();
+          if (Array.isArray(questionsJson)) {
+            questions = questionsJson;
+          } else if (Array.isArray(questionsJson?.questions)) {
+            questions = questionsJson.questions;
+          }
+        } else {
+          console.warn(`Questions file not found: ${questionFile}`);
+        }
+      } catch (error) {
+        console.error('Failed to load questions data', error);
+      }
+    }
+
+    const resolveUserBattle = (level) => {
+      if (typeof level !== 'number') {
+        return null;
+      }
+      return (
+        userBattles.find(
+          (entry) => typeof entry?.battleLevel === 'number' && entry.battleLevel === level
+        ) ?? null
+      );
+    };
+
+    const activeUserBattle =
+      resolveUserBattle(activeBattleLevel) ?? userBattles[0] ?? null;
+
+    const levelBattle = currentLevel?.battle ?? {};
+    const hero = {
+      ...(levelBattle?.hero ?? {}),
+      ...(activeUserBattle?.hero ?? {}),
+    };
+    const battle = { ...levelBattle, hero };
+    let enemy = battle?.enemy ?? null;
+
+    const heroSprite = resolveAssetPath(hero?.sprite);
+    if (heroSprite) {
+      hero.sprite = heroSprite;
+    }
+
+    const enemySprite = resolveAssetPath(enemy?.sprite);
+    if (enemySprite) {
+      enemy = { ...(enemy ?? {}), sprite: enemySprite };
+      battle.enemy = enemy;
+    }
+
+    const assetsToPreload = [];
+    if (heroSprite) {
+      assetsToPreload.push(heroSprite);
+    }
+    if (enemySprite) {
+      assetsToPreload.push(enemySprite);
+    }
+    const variables = { ...baseVariables, progress };
+
+    if (assetsToPreload.length) {
+      const uniqueAssets = Array.from(new Set(assetsToPreload));
+      await Promise.all(uniqueAssets.map(preloadImage));
+    }
+
+    window.preloadedData = {
+      variables,
+      levels,
+      level: currentLevel,
+      battle,
+      hero,
+      enemy,
+      questions,
+    };
+
+    document.dispatchEvent(new Event('data-loaded'));
+  } catch (e) {
+    console.error('Failed to load data', e);
+    window.preloadedData = {};
+    document.dispatchEvent(new Event('data-loaded'));
+  }
+})();

--- a/pwa-app/js/pwa.js
+++ b/pwa-app/js/pwa.js
@@ -1,0 +1,96 @@
+const currentScript = document.currentScript;
+const rootPath = currentScript?.dataset?.pwaRoot ?? '.';
+
+function registerServiceWorker() {
+  if (!('serviceWorker' in navigator)) {
+    updateInstallMessage('Service workers are not supported on this browser yet.');
+    return;
+  }
+
+  const swUrl = new URL(`${rootPath}/sw.js`, window.location.href);
+
+  window.addEventListener('load', () => {
+    navigator.serviceWorker
+      .register(swUrl.href)
+      .catch((error) => {
+        console.error('Service worker registration failed', error);
+        updateInstallMessage('Unable to enable offline mode. Try refreshing the page.');
+      });
+  });
+}
+
+let deferredPrompt = null;
+
+function setupInstallPrompt() {
+  const installButton = document.querySelector('[data-install-button]');
+  const installMessage = document.querySelector('[data-install-message]');
+
+  if (!installButton) {
+    return;
+  }
+
+  const isStandalone = window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone;
+  const isIos = /iphone|ipad|ipod/i.test(window.navigator.userAgent);
+
+  if (installMessage) {
+    if (isStandalone) {
+      installMessage.textContent = 'All set! Reef Rangers is ready on your device.';
+    } else if (isIos) {
+      installMessage.textContent = 'Tap the share button and choose "Add to Home Screen" to install the app.';
+    } else {
+      installMessage.textContent = 'Install the app on your device to keep battling monsters offline.';
+    }
+  }
+
+  window.addEventListener('beforeinstallprompt', (event) => {
+    event.preventDefault();
+    deferredPrompt = event;
+    installButton.hidden = false;
+    if (installMessage) {
+      installMessage.textContent = 'Install the app for quick access on your home screen.';
+    }
+  });
+
+  installButton.addEventListener('click', async () => {
+    if (!deferredPrompt) {
+      installButton.hidden = true;
+      if (installMessage) {
+        installMessage.textContent = 'The app is ready to use in your browser.';
+      }
+      return;
+    }
+
+    deferredPrompt.prompt();
+    const choice = await deferredPrompt.userChoice;
+
+    if (choice.outcome === 'accepted') {
+      if (installMessage) {
+        installMessage.textContent = 'Great! Finish installing Reef Rangers from your browser prompt.';
+      }
+    } else if (installMessage) {
+      installMessage.textContent = 'No worries. You can install the app later from your browser menu.';
+    }
+
+    deferredPrompt = null;
+    installButton.hidden = true;
+  });
+
+  window.addEventListener('appinstalled', () => {
+    if (installMessage) {
+      installMessage.textContent = 'All set! Reef Rangers is now installed on your device.';
+    }
+    installButton.hidden = true;
+  });
+}
+
+function updateInstallMessage(message) {
+  const installMessage = document.querySelector('[data-install-message]');
+  if (installMessage) {
+    installMessage.textContent = message;
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  registerServiceWorker();
+  setupInstallPrompt();
+});

--- a/pwa-app/js/question.js
+++ b/pwa-app/js/question.js
@@ -1,0 +1,64 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const questionBox = document.getElementById('question');
+  const choicesContainer = questionBox.querySelector('.choices');
+  const button = questionBox.querySelector('button');
+
+  button.disabled = true;
+
+  choicesContainer.addEventListener('click', (e) => {
+    const choice = e.target.closest('.choice');
+    if (!choice) return;
+
+    Array.from(choicesContainer.children).forEach((c) => c.classList.remove('selected'));
+    choice.classList.add('selected');
+    button.disabled = false;
+  });
+
+  button.addEventListener('click', () => {
+    const choice = choicesContainer.querySelector('.choice.selected');
+    if (!choice) return;
+
+    button.disabled = true;
+    const isCorrect = choice.dataset.correct === 'true';
+
+    Array.from(choicesContainer.children).forEach((c) =>
+      c.classList.remove('selected')
+    );
+    if (isCorrect) {
+      choice.classList.add('correct-choice');
+    } else {
+      const correctChoices = choicesContainer.querySelectorAll(
+        '.choice[data-correct="true"]'
+      );
+      correctChoices.forEach((c) => c.classList.add('correct-choice'));
+      choice.classList.add('wrong-choice');
+    }
+
+    button.classList.add('result', isCorrect ? 'correct' : 'incorrect');
+    button.innerHTML = isCorrect
+      ? '<img src="../images/questions/button/correct.svg" alt="Correct icon" /> Correct'
+      : '<img src="../images/questions/button/incorrect.svg" alt="Incorrect icon" /> Incorrect';
+
+    document.dispatchEvent(
+      new CustomEvent('answer-submitted', { detail: { correct: isCorrect } })
+    );
+
+  });
+
+  function closeQuestion() {
+    function handleFade(e) {
+      if (e.propertyName === 'opacity') {
+        questionBox.removeEventListener('transitionend', handleFade);
+        button.classList.remove('result', 'correct', 'incorrect');
+        button.textContent = 'Submit';
+        Array.from(choicesContainer.children).forEach((c) =>
+          c.classList.remove('selected', 'correct-choice', 'wrong-choice')
+        );
+      }
+    }
+    questionBox.addEventListener('transitionend', handleFade);
+    questionBox.classList.remove('show');
+  }
+
+  document.addEventListener('close-question', closeQuestion);
+});

--- a/pwa-app/js/signin.js
+++ b/pwa-app/js/signin.js
@@ -1,0 +1,103 @@
+const setElementVisibility = (element, shouldShow) => {
+  if (!element) {
+    return;
+  }
+  element.hidden = !shouldShow;
+};
+
+const setFieldState = (field, isDisabled) => {
+  if (!field) {
+    return;
+  }
+  field.disabled = Boolean(isDisabled);
+};
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const form = document.querySelector('.preloader__form');
+  const emailField = document.getElementById('signin-email');
+  const passwordField = document.getElementById('signin-password');
+  const submitButton = form?.querySelector('button[type="submit"]');
+  const submitButtonLabel = submitButton?.querySelector(
+    '.preloader__button-label'
+  );
+  const errorMessage = document.querySelector('[data-signin-error]');
+  const supabase = window.supabaseClient;
+
+  const showError = (message) => {
+    if (!errorMessage) {
+      return;
+    }
+    errorMessage.textContent = message;
+    setElementVisibility(errorMessage, Boolean(message));
+  };
+
+  const setLoading = (isLoading) => {
+    setFieldState(emailField, isLoading);
+    setFieldState(passwordField, isLoading);
+    if (submitButton) {
+      submitButton.disabled = Boolean(isLoading);
+      submitButton.classList.toggle('is-loading', Boolean(isLoading));
+      submitButton.setAttribute('aria-busy', isLoading ? 'true' : 'false');
+      if (submitButtonLabel) {
+        submitButtonLabel.textContent = isLoading ? '' : 'Sign In';
+      }
+    }
+  };
+
+  if (!form || !emailField || !passwordField) {
+    showError('The sign in form could not be initialized.');
+    return;
+  }
+
+  if (!supabase) {
+    showError('Authentication service is unavailable. Please try again later.');
+    return;
+  }
+
+  try {
+    const { data, error } = await supabase.auth.getSession();
+    if (error) {
+      console.warn('Failed to fetch existing session', error);
+    }
+    if (data?.session) {
+      window.location.replace('index.html');
+      return;
+    }
+  } catch (error) {
+    console.warn('Session lookup failed', error);
+  }
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    showError('');
+
+    const email = emailField.value.trim();
+    const password = passwordField.value;
+
+    if (!email || !password) {
+      showError('Please provide both an email and password.');
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      const { error } = await supabase.auth.signInWithPassword({
+        email,
+        password,
+      });
+
+      if (error) {
+        showError(error.message || 'Unable to sign in. Please try again.');
+        setLoading(false);
+        return;
+      }
+
+      window.location.replace('index.html');
+    } catch (error) {
+      console.error('Unexpected error during sign in', error);
+      showError('An unexpected error occurred. Please try again.');
+      setLoading(false);
+    }
+  });
+});

--- a/pwa-app/js/supabaseClient.js
+++ b/pwa-app/js/supabaseClient.js
@@ -1,0 +1,8 @@
+const SUPABASE_URL = window.SUPABASE_URL || 'https://jxlxpumcoihfapmrsaqd.supabase.co';
+const SUPABASE_ANON_KEY = window.SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imp4bHhwdW1jb2loZmFwbXJzYXFkIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTc0MjE3MDcsImV4cCI6MjA3Mjk5NzcwN30.PJiDPZ_Dqli_42isJexeYgsf0ebWbCSOwHtR7lsQTN0';
+
+const supabaseClient = window.supabase?.createClient
+  ? window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY)
+  : null;
+
+window.supabaseClient = supabaseClient;

--- a/pwa-app/manifest.webmanifest
+++ b/pwa-app/manifest.webmanifest
@@ -1,0 +1,18 @@
+{
+  "name": "Reef Rangers",
+  "short_name": "ReefRangers",
+  "description": "Battle sea monsters and sharpen your math skills wherever you are.",
+  "start_url": "./index.html",
+  "scope": "./",
+  "display": "standalone",
+  "background_color": "#0a3d62",
+  "theme_color": "#0a3d62",
+  "icons": [
+    {
+      "src": "../images/brand/logo.png",
+      "sizes": "300x300",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/pwa-app/signin.html
+++ b/pwa-app/signin.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#0a3d62" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <title>Sign In | Reef Rangers</title>
+    <link rel="manifest" href="manifest.webmanifest" />
+    <link rel="apple-touch-icon" sizes="300x300" href="../images/brand/logo.png" />
+    <link rel="stylesheet" href="css/battle-card.css" />
+    <link rel="stylesheet" href="css/signin.css" />
+  </head>
+  <body>
+    <div class="preloader">
+      <img
+        class="preloader__logo"
+        src="../images/brand/logo.png"
+        alt="Reef Rangers logo"
+        width="300"
+        height="300"
+      />
+      <form class="preloader__form" action="#" method="post" novalidate>
+        <label class="visually-hidden" for="signin-email">Email</label>
+        <input
+          class="preloader__field"
+          type="email"
+          id="signin-email"
+          name="email"
+          placeholder="Email"
+          autocomplete="email"
+          required
+        />
+        <label class="visually-hidden" for="signin-password">Password</label>
+        <input
+          class="preloader__field"
+          type="password"
+          id="signin-password"
+          name="password"
+          placeholder="Password"
+          autocomplete="current-password"
+          required
+        />
+        <button class="btn-primary preloader__button" type="submit">
+          <span class="preloader__button-label">Sign In</span>
+          <span class="preloader__spinner" aria-hidden="true"></span>
+        </button>
+      </form>
+      <p class="preloader__error" data-signin-error role="alert" hidden></p>
+    </div>
+    <script>
+      window.SUPABASE_URL = 'https://jxlxpumcoihfapmrsaqd.supabase.co';
+      window.SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imp4bHhwdW1jb2loZmFwbXJzYXFkIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTc0MjE3MDcsImV4cCI6MjA3Mjk5NzcwN30.PJiDPZ_Dqli_42isJexeYgsf0ebWbCSOwHtR7lsQTN0';
+    </script>
+    <script src="js/pwa.js" defer data-pwa-root="."></script>
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2" defer></script>
+    <script src="js/supabaseClient.js" defer></script>
+    <script src="js/signin.js" defer></script>
+  </body>
+</html>

--- a/pwa-app/sw.js
+++ b/pwa-app/sw.js
@@ -1,0 +1,91 @@
+const CACHE_NAME = 'reef-rangers-cache-v1';
+const OFFLINE_ASSETS = [
+  './',
+  './index.html',
+  './signin.html',
+  './html/battle.html',
+  './manifest.webmanifest',
+  './css/index.css',
+  './css/battle-card.css',
+  './css/battle.css',
+  './css/question.css',
+  './css/signin.css',
+  './js/pwa.js',
+  './js/index.js',
+  './js/battle.js',
+  './js/question.js',
+  './js/signin.js',
+  './js/supabaseClient.js',
+  './js/loader.js',
+  '../images/brand/logo.png',
+  '../images/characters/shellfin_level_1.png',
+  '../images/battle/battle.png',
+  '../images/battle/monster_battle_1.png',
+  '../images/questions/sword.svg',
+  '../images/questions/shield.svg',
+  '../images/questions/streak.svg',
+  './data/levels.json',
+  './data/variables.json',
+  './data/questions/level_1_questions.json',
+  './data/questions/level_2_questions.json',
+  './data/questions/level_3_questions.json',
+  './data/questions/level_4_questions.json',
+  './data/questions/level_5_questions.json',
+  './data/questions/level_6_questions.json'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(OFFLINE_ASSETS))
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys
+          .filter((key) => key !== CACHE_NAME)
+          .map((key) => caches.delete(key))
+      )
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  const requestURL = new URL(event.request.url);
+
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request).catch(() => caches.match('./index.html'))
+    );
+    return;
+  }
+
+  if (requestURL.origin !== location.origin) {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then((cachedResponse) => {
+      if (cachedResponse) {
+        return cachedResponse;
+      }
+
+      return fetch(event.request)
+        .then((response) => {
+          const responseClone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => {
+            cache.put(event.request, responseClone);
+          });
+          return response;
+        })
+        .catch(() => caches.match('./index.html'));
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- delete the duplicated binary image assets from the PWA test copy
- point HTML, manifest, data, and scripts at the shared root images so nothing breaks
- keep the service worker caching list in sync with the new asset locations

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cb6ae96ce083299d99cbb743b21582