### PR TITLE
Add consistent page padding

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -9,6 +9,8 @@ body {
   overflow: hidden;
   background: url('/mathmonsters/images/background/background.png') no-repeat center/cover;
   font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  padding: 16px;
+  box-sizing: border-box;
 }
 
 #battle {

--- a/css/index.css
+++ b/css/index.css
@@ -4,6 +4,7 @@
 
 body {
   margin: 0;
+  padding: 16px;
   min-height: 100vh;
   font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
   color: #272B34;

--- a/css/signin.css
+++ b/css/signin.css
@@ -2,6 +2,8 @@ body {
   margin: 0;
   min-height: 100vh;
   font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  padding: 16px;
+  box-sizing: border-box;
 }
 
 .preloader {


### PR DESCRIPTION
## Summary
- add 16px body padding to the landing, battle, and auth pages to keep spacing consistent
- ensure battle and auth layouts use border-box sizing so the new padding does not affect viewport sizing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc7006f644832997ba34963082bba8