### PR TITLE
Adjust auth page layouts and styling

### DIFF
--- a/css/signin.css
+++ b/css/signin.css
@@ -55,6 +55,10 @@ body {
   font-size: 20px;
 }
 
+.preloader__field:not(:placeholder-shown) {
+  color: #ffffff;
+}
+
 .preloader__field::placeholder {
   color: #949faf;
   font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
@@ -81,14 +85,20 @@ body {
   box-sizing: border-box;
 }
 
+.preloader__button:hover,
+.preloader__button:focus-visible {
+  background: linear-gradient(rgba(0, 0, 0, 0.24), rgba(0, 0, 0, 0.24)), #006aff;
+}
+
 .preloader__link {
   color: #ffffff;
   font-size: 20px;
   text-decoration: underline;
+  margin-top: 8px;
+  display: inline-block;
 }
 
-.preloader__link:focus-visible,
-.preloader__link:hover {
+.preloader__link:focus-visible {
   text-decoration: none;
 }
 

--- a/register.html
+++ b/register.html
@@ -7,7 +7,11 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <title>Register | Reef Rangers</title>
     <link rel="manifest" href="manifest.webmanifest" />
-    <link rel="apple-touch-icon" sizes="300x300" href="/images/brand/logo.png" />
+    <link
+      rel="apple-touch-icon"
+      sizes="300x300"
+      href="/mathmonsters/images/brand/logo.png"
+    />
     <link rel="stylesheet" href="css/battle-card.css" />
     <link rel="stylesheet" href="css/signin.css" />
   </head>
@@ -15,7 +19,7 @@
     <div class="preloader">
       <img
         class="preloader__logo"
-        src="/images/brand/logo.png"
+        src="/mathmonsters/images/brand/logo.png"
         alt="Reef Rangers logo"
         width="300"
         height="300"
@@ -56,8 +60,8 @@
           <span class="preloader__button-label">Register</span>
           <span class="preloader__spinner" aria-hidden="true"></span>
         </button>
-        <a class="preloader__link" href="signin.html">Sign In</a>
       </form>
+      <a class="preloader__link" href="signin.html">Sign In</a>
       <p class="preloader__error" data-register-error role="alert" hidden></p>
     </div>
     <script>

--- a/signin.html
+++ b/signin.html
@@ -46,8 +46,8 @@
           <span class="preloader__button-label">Sign In</span>
           <span class="preloader__spinner" aria-hidden="true"></span>
         </button>
-        <a class="preloader__link" href="register.html">Register</a>
       </form>
+      <a class="preloader__link" href="register.html">Register</a>
       <p class="preloader__error" data-signin-error role="alert" hidden></p>
     </div>
     <script>


### PR DESCRIPTION
## Summary
- move the Register and Sign In navigation links outside their respective forms and keep the link underline on hover
- ensure the auth form inputs retain white text after blur and add a 24% black hover overlay to the primary action button
- align the Register page assets with the Sign In page by using the shared logo path

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc74b935348329b8d98ff623087338