### PR TITLE
Add global font family styling

### DIFF
--- a/css/battle-card.css
+++ b/css/battle-card.css
@@ -25,7 +25,6 @@
 
 .battle-card .battle-goals-title {
   margin: 0;
-  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
   font-size: 20px;
   color: #272b34;
 }
@@ -40,7 +39,6 @@
   margin: 0;
   font-size: 32px;
   font-weight: 700;
-  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
   color: #272b34;
 }
 
@@ -73,14 +71,12 @@
 .battle-card .stat-label {
   font-size: 18px;
   color: #888888;
-  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
 }
 
 .battle-card .stat-value {
   font-size: 24px;
   font-weight: 700;
   color: #006AFF;
-  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
 }
 
 .battle-card .stat-value {
@@ -110,7 +106,6 @@
   color: #fff;
   border: none;
   border-radius: 8px;
-  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
   font-size: 20px;
   cursor: pointer;
   transition: transform 0.3s ease, box-shadow 0.3s ease;

--- a/css/battle.css
+++ b/css/battle.css
@@ -8,7 +8,6 @@ body {
   min-height: 100%;
   overflow: hidden;
   background: url('/mathmonsters/images/background/background.png') no-repeat center/cover;
-  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
   padding: 16px;
   box-sizing: border-box;
 }
@@ -93,7 +92,6 @@ body {
 }
 
 .stat-box .name {
-  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
   font-size: 20px;
   color: #fff;
 }
@@ -108,7 +106,6 @@ body {
   position: relative;
   display: flex;
   align-items: center;
-  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
   font-size: 20px;
   color: #fff;
 }
@@ -124,7 +121,6 @@ body {
   top: -7px;
   right: -5px;
   font-size: 20px;
-  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
   background: #00B600;
   color: #FFFFFF;
   border-radius: 8px;
@@ -276,7 +272,6 @@ body {
 }
 
 #battle-message .content p {
-  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
   font-size: 24px;
   margin: 0 0 16px;
 }
@@ -315,7 +310,6 @@ body {
   align-items: center;
   justify-content: center;
   gap: 48px;
-  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
 }
 
 .battle-stat-banner .stat {

--- a/css/global.css
+++ b/css/global.css
@@ -1,0 +1,15 @@
+:root {
+  --font-family-rounded: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+}
+
+html,
+body {
+  font-family: var(--font-family-rounded);
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}

--- a/css/index.css
+++ b/css/index.css
@@ -6,7 +6,6 @@ body {
   margin: 0;
   padding: 16px;
   min-height: 100vh;
-  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
   color: #272B34;
   background: url('/mathmonsters/images/background/background.png') no-repeat center/cover;
   position: relative;
@@ -322,7 +321,6 @@ body.battle-overlay-open .battle-overlay { opacity: 1; pointer-events: auto; }
 
 .preloader__text {
   margin: 0;
-  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
   font-size: 32px;
   color: #ffffff;
 }

--- a/css/question.css
+++ b/css/question.css
@@ -34,13 +34,11 @@
 }
 
 #question h1 {
-  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
   font-size: 16px;
   color: #888888;
 }
 
 #question .question-text {
-  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
   font-size: 24px;
   margin: 0;
   padding: 0;
@@ -56,7 +54,6 @@
   color: #fff;
   border: none;
   border-radius: 8px;
-  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
   font-size: 20px;
 }
 
@@ -113,7 +110,6 @@
 }
 
 #question .streak-label {
-  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
   font-size: 20px;
   color: #006AFF;
   opacity: 1;
@@ -199,7 +195,6 @@
 }
 
 #question .choice p {
-  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
   font-size: 24px;
   color: #272B34;
   margin: 0;

--- a/css/signin.css
+++ b/css/signin.css
@@ -1,7 +1,6 @@
 body {
   margin: 0;
   min-height: 100vh;
-  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
   padding: 16px;
   box-sizing: border-box;
 }
@@ -51,7 +50,6 @@ body {
   border-radius: 8px;
   background-color: #293f5f;
   color: #949faf;
-  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
   font-size: 20px;
 }
 
@@ -61,7 +59,6 @@ body {
 
 .preloader__field::placeholder {
   color: #949faf;
-  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
   font-size: 20px;
 }
 

--- a/html/battle.html
+++ b/html/battle.html
@@ -9,6 +9,7 @@
     <title>Battle</title>
     <link rel="manifest" href="../manifest.webmanifest" />
     <link rel="apple-touch-icon" sizes="300x300" href="/mathmonsters/images/brand/logo.png" />
+    <link rel="stylesheet" href="../css/global.css" />
     <link rel="stylesheet" href="../css/question.css" />
     <link rel="stylesheet" href="../css/battle-card.css" />
     <link rel="stylesheet" href="../css/battle.css" />

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <title>Reef Rangers</title>
   <link rel="manifest" href="manifest.webmanifest" />
   <link rel="apple-touch-icon" sizes="300x300" href="/mathmonsters/images/brand/logo.png" />
+  <link rel="stylesheet" href="css/global.css" />
   <link rel="stylesheet" href="css/battle-card.css" />
   <link rel="stylesheet" href="css/index.css" />
 </head>

--- a/register.html
+++ b/register.html
@@ -12,6 +12,7 @@
       sizes="300x300"
       href="/mathmonsters/images/brand/logo.png"
     />
+    <link rel="stylesheet" href="css/global.css" />
     <link rel="stylesheet" href="css/battle-card.css" />
     <link rel="stylesheet" href="css/signin.css" />
   </head>

--- a/signin.html
+++ b/signin.html
@@ -7,7 +7,8 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <title>Sign In | Reef Rangers</title>
     <link rel="manifest" href="manifest.webmanifest" />
-  <link rel="apple-touch-icon" sizes="300x300" href="/mathmonsters/images/brand/logo.png" />
+    <link rel="apple-touch-icon" sizes="300x300" href="/mathmonsters/images/brand/logo.png" />
+    <link rel="stylesheet" href="css/global.css" />
     <link rel="stylesheet" href="css/battle-card.css" />
     <link rel="stylesheet" href="css/signin.css" />
   </head>


### PR DESCRIPTION
## Summary
- add a global stylesheet that defines the shared Arial Rounded MT Bold font family and ensures controls inherit it
- remove redundant font-family declarations from page-specific CSS files
- load the global font styles across the app so all pages use the shared configuration

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ccb0a1b3848329a3724aee494e70d0