### PR TITLE
Add SPLAT launch animation and refresh battle stats

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -73,11 +73,13 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 16px;
-  gap: 16px;
-  border-radius: 8px;
-  border: 1px solid rgba(255, 255, 255, 0.5);
-  backdrop-filter: blur(4px);
+  padding: 16px 18px;
+  gap: 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  background: rgba(12, 36, 64, 0.52);
   opacity: 0;
   transform: translateY(24px) scale(0.95);
   filter: blur(12px);
@@ -96,73 +98,23 @@ body {
   color: #fff;
 }
 
-.stat-box .stats {
-  display: flex;
-  gap: 16px;
-  align-items: center;
-}
-
-.stat-box .stat {
-  position: relative;
-  display: flex;
-  align-items: center;
-  font-size: 20px;
-  color: #fff;
-}
-
-.stat-box .stat img {
-  width: 20px;
-  height: 20px;
-  margin-right: 4px;
-}
-
-.stat-box .stat .increase {
-  position: absolute;
-  top: -7px;
-  right: -5px;
-  font-size: 20px;
-  background: #00B600;
-  color: #FFFFFF;
-  border-radius: 8px;
-  padding: 6px 12px;
-  opacity: 0;
-  transform: scale(0);
-  pointer-events: none;
-}
-
-.stat-box .stat .increase.show {
-  animation: increase-pop 0.6s forwards;
-}
-
-@keyframes increase-pop {
-  0% {
-    opacity: 0;
-    transform: scale(0);
-  }
-  60% {
-    opacity: 1;
-    transform: scale(1.3);
-  }
-  100% {
-    opacity: 1;
-    transform: scale(1);
-  }
-}
-
-.hp-bar {
-  width: 130px;
-  height: 12px;
-  border: 1px solid #fff;
-  border-radius: 4px;
-  margin-top: 4px;
+.stat-box__progress {
+  width: 180px;
+  max-width: 100%;
+  height: 14px;
+  background-color: rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.35);
   overflow: hidden;
 }
 
-.hp-fill {
-  background: #FFBB00;
+.stat-box__progress .progress__fill {
   height: 100%;
-  width: 100%;
-  transition: width 0.5s ease-in-out;
+  transition: width 0.45s ease;
+}
+
+.stat-box__progress .progress__fill::after {
+  inset: 2px 6px 0 6px;
 }
 
 #battle-shellfin.attack {

--- a/css/index.css
+++ b/css/index.css
@@ -203,6 +203,80 @@ body:not(.is-preloading) main.landing {
   100% { --ty: -110vh;              --sx: 1.06; --sy: 1.06; opacity: 0; }
 }
 
+.splat-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(10, 61, 98, 0.92);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.35s ease;
+  z-index: 12;
+}
+
+.splat-overlay.is-active {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.splat-overlay__letters {
+  display: flex;
+  gap: clamp(12px, 3vw, 32px);
+  font-family: var(--font-heading, 'Baloo 2', system-ui, sans-serif);
+  font-size: clamp(56px, 18vw, 164px);
+  letter-spacing: clamp(4px, 1vw, 12px);
+  color: #ffffff;
+  text-transform: uppercase;
+}
+
+.splat-letter {
+  display: inline-block;
+  opacity: 0;
+  transform: translateY(32px) scale(0.6);
+  animation: splat-letter-pop 0.6s cubic-bezier(0.25, 0.9, 0.35, 1.4) forwards;
+  animation-delay: calc(var(--index, 0) * 0.12s);
+  animation-play-state: paused;
+}
+
+.splat-overlay.is-active .splat-letter {
+  animation-play-state: running;
+}
+
+@keyframes splat-letter-pop {
+  0% {
+    opacity: 0;
+    transform: translateY(32px) scale(0.6);
+  }
+  60% {
+    opacity: 1;
+    transform: translateY(-8px) scale(1.12);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .splat-overlay {
+    transition: none;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+
+  .splat-letter {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}
+
 /* Organic horizontal meander tied to --drift */
 @keyframes bubble-drift {
   0%   { --tx: calc(var(--drift) * -1); }

--- a/html/battle.html
+++ b/html/battle.html
@@ -47,35 +47,33 @@
     />
     <div id="monster-stats" class="stat-box">
       <div class="name"></div>
-      <div class="stats">
-        <div class="stat attack">
-          <img src="/mathmonsters/images/questions/sword.svg" alt="Attack" />
-          <span class="value"></span>
-          <span class="increase"></span>
-        </div>
-        <div class="stat health">
-          <img src="/mathmonsters/images/questions/shield.svg" alt="Health" />
-          <span class="value"></span>
-          <span class="increase"></span>
-        </div>
+      <div
+        class="progress progress--orange stat-box__progress"
+        data-hp-progress
+        data-hp-target="monster"
+        role="progressbar"
+        aria-valuemin="0"
+        aria-valuemax="100"
+        aria-valuenow="100"
+        style="--progress-value: 1"
+      >
+        <span class="progress__fill"></span>
       </div>
-      <div class="hp-bar"><div class="hp-fill"></div></div>
     </div>
     <div id="shellfin-stats" class="stat-box">
       <div class="name"></div>
-      <div class="stats">
-        <div class="stat attack">
-          <img src="/mathmonsters/images/questions/sword.svg" alt="Attack" />
-          <span class="value"></span>
-          <span class="increase"></span>
-        </div>
-        <div class="stat health">
-          <img src="/mathmonsters/images/questions/shield.svg" alt="Health" />
-          <span class="value"></span>
-          <span class="increase"></span>
-        </div>
+      <div
+        class="progress progress--orange stat-box__progress"
+        data-hp-progress
+        data-hp-target="hero"
+        role="progressbar"
+        aria-valuemin="0"
+        aria-valuemax="100"
+        aria-valuenow="100"
+        style="--progress-value: 1"
+      >
+        <span class="progress__fill"></span>
       </div>
-      <div class="hp-bar"><div class="hp-fill"></div></div>
     </div>
   </div>
     <div id="question">

--- a/index.html
+++ b/index.html
@@ -66,6 +66,20 @@
       </button>
     </section>
   </main>
+  <div
+    class="splat-overlay"
+    data-splat-overlay
+    data-splat-duration="1600"
+    aria-hidden="true"
+  >
+    <div class="splat-overlay__letters" aria-hidden="true">
+      <span class="splat-letter" style="--index: 0">S</span>
+      <span class="splat-letter" style="--index: 1">P</span>
+      <span class="splat-letter" style="--index: 2">L</span>
+      <span class="splat-letter" style="--index: 3">A</span>
+      <span class="splat-letter" style="--index: 4">T</span>
+    </div>
+  </div>
   <script>
     window.SUPABASE_URL = 'https://jxlxpumcoihfapmrsaqd.supabase.co';
     window.SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imp4bHhwdW1jb2loZmFwbXJzYXFkIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTc0MjE3MDcsImV4cCI6MjA3Mjk5NzcwN30.PJiDPZ_Dqli_42isJexeYgsf0ebWbCSOwHtR7lsQTN0';


### PR DESCRIPTION
## Summary
- add a SPLAT transition overlay on the landing page that plays before navigating into the battle experience
- wire the landing battle button to run the SPLAT sequence (with reduced motion fallback) before redirecting
- restyle battle stat boxes to remove the old stat rows and replace HP bars with the shared orange progress bar component, updating health logic accordingly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd922fe0708329835097511eef2869