### PR TITLE
Fix battle initialization crash

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -544,7 +544,6 @@ document.addEventListener('DOMContentLoaded', () => {
     questions = shuffle(loadedQuestions);
 
     updateHealthBars();
-    updateBattleTimeDisplay();
   }
 
   function updateHealthBars() {


### PR DESCRIPTION
## Summary
- prevent the battle screen from calling a non-existent `updateBattleTimeDisplay` function during load so the script no longer crashes

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68cdb7ff8a048329a32528493497023f