### PR TITLE
Align hero sprite float between card and viewport

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -52,21 +52,36 @@ body:not(.is-preloading) main.landing {
 
 .hero {
   position: absolute;
-  bottom: 32vh;
   left: 50%;
+  top: var(--hero-top, clamp(72px, 18vh, 240px));
   max-width: 300px;
   max-height: 300px;
-  transform: translate(-50%, 0);
-  animation: hero-float 3.5s ease-in-out infinite;
+  transform: translate(-50%, calc(-1 * var(--hero-float-range, 32px)));
+  animation: hero-float var(--hero-float-duration, 3.5s) ease-in-out infinite;
+  --hero-float-range: 32px;
+  --hero-float-duration: 3.5s;
   image-rendering: auto;
   z-index: 2;
   pointer-events: none;
 }
 
 @keyframes hero-float {
-  0%   { transform: translate(-50%, 0) translateY(0); }
-  50%  { transform: translate(-50%, 0) translateY(-32px); }
-  100% { transform: translate(-50%, 0) translateY(0); }
+  0% {
+    transform: translate(-50%, calc(-1 * var(--hero-float-range, 32px)));
+  }
+  50% {
+    transform: translate(-50%, var(--hero-float-range, 32px));
+  }
+  100% {
+    transform: translate(-50%, calc(-1 * var(--hero-float-range, 32px)));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero {
+    animation: none;
+    transform: translate(-50%, 0);
+  }
 }
 
 /* Bubble field */

--- a/js/index.js
+++ b/js/index.js
@@ -232,6 +232,33 @@ const determineBattlePreview = (levelsData, variablesData) => {
   };
 };
 
+const updateHeroFloat = () => {
+  const heroImage = document.querySelector('.hero');
+  const battleCard = document.querySelector('[data-battle-card]');
+
+  if (!heroImage || !battleCard) {
+    return;
+  }
+
+  const applyLayout = () => {
+    const cardRect = battleCard.getBoundingClientRect();
+    const heroRect = heroImage.getBoundingClientRect();
+
+    const availableSpace = cardRect.top - heroRect.height;
+    const clampedSpace = Math.max(0, availableSpace);
+    const floatOffset = clampedSpace / 2;
+
+    heroImage.style.setProperty('--hero-top', `${floatOffset}px`);
+    heroImage.style.setProperty('--hero-float-range', `${floatOffset}px`);
+  };
+
+  if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+    window.requestAnimationFrame(applyLayout);
+  } else {
+    applyLayout();
+  }
+};
+
 const applyBattlePreview = (previewData = {}) => {
   const heroImage = document.querySelector('.hero');
   const battleMathElements = document.querySelectorAll('[data-battle-math]');
@@ -284,6 +311,8 @@ const applyBattlePreview = (previewData = {}) => {
     progressElement.setAttribute('aria-valuenow', `${Math.round(progressValue * 100)}`);
     progressElement.setAttribute('aria-valuetext', `${progressText} experience`);
   }
+
+  updateHeroFloat();
 };
 
 const preloaderElement = document.querySelector('[data-preloader]');
@@ -534,6 +563,7 @@ const initLandingInteractions = (preloadedData = {}) => {
 
   const battleCard = document.querySelector('[data-battle-card]');
   const battleButton = document.querySelector('[data-battle-button]');
+  const heroImage = document.querySelector('.hero');
 
   const loadBattlePreview = async () => {
     try {
@@ -579,6 +609,16 @@ const initLandingInteractions = (preloadedData = {}) => {
   };
 
   loadBattlePreview();
+
+  if (typeof window !== 'undefined') {
+    window.addEventListener('resize', updateHeroFloat);
+  }
+
+  if (heroImage) {
+    heroImage.addEventListener('load', updateHeroFloat);
+  }
+
+  updateHeroFloat();
 
   if (battleButton) {
     battleButton.addEventListener('click', async (event) => {


### PR DESCRIPTION
## Summary
- adjust the landing hero styling so its position and float animation honor the space between the battle card and the top of the viewport, including a reduced-motion fallback
- add JavaScript helpers to recalculate the hero's offsets whenever the layout changes, keeping the sprite centered between the card and the window

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cdbb23f49483298386f9a4e5f8e487