### PR TITLE
Fix battle asset loading for relative deployments

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -7,7 +7,7 @@ body {
   margin: 0;
   min-height: 100%;
   overflow: hidden;
-  background: url('/mathmonsters/images/background/background.png') no-repeat center/cover;
+  background: url('../images/background/background.png') no-repeat center/cover;
   padding: 16px;
   box-sizing: border-box;
 }

--- a/html/battle.html
+++ b/html/battle.html
@@ -7,11 +7,11 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <title>Battle</title>
-    <link rel="manifest" href="/mathmonsters/manifest.webmanifest" />
-    <link rel="apple-touch-icon" sizes="300x300" href="/mathmonsters/images/brand/logo.png" />
-    <link rel="stylesheet" href="/mathmonsters/css/global.css" />
-    <link rel="stylesheet" href="/mathmonsters/css/question.css" />
-    <link rel="stylesheet" href="/mathmonsters/css/battle.css" />
+    <link rel="manifest" href="../manifest.webmanifest" />
+    <link rel="apple-touch-icon" sizes="300x300" href="../images/brand/logo.png" />
+    <link rel="stylesheet" href="../css/global.css" />
+    <link rel="stylesheet" href="../css/question.css" />
+    <link rel="stylesheet" href="../css/battle.css" />
   </head>
   <body>
   <div class="battle-dev-controls" role="group" aria-label="Battle test controls">
@@ -29,10 +29,10 @@
     </button>
   </div>
   <div id="battle">
-    <img id="battle-monster" src="/mathmonsters/images/battle/monster_battle_1.png" alt="Monster" />
+    <img id="battle-monster" src="../images/battle/monster_battle_1_1.png" alt="Monster" />
     <img
       id="battle-shellfin"
-      src="/mathmonsters/images/characters/shellfin_level_1.png"
+      src="../images/characters/shellfin_level_1.png"
       alt="Shellfin"
     />
     <div id="monster-stats" class="stat-box">
@@ -68,7 +68,7 @@
   </div>
     <div id="question">
       <div class="content">
-        <img class="streak-icon" src="/mathmonsters/images/questions/streak.svg" alt="Streak" />
+        <img class="streak-icon" src="../images/questions/streak.svg" alt="Streak" />
         <div class="top-bar">
           <div class="progress-wrap">
             <div class="streak-label"></div>
@@ -96,7 +96,7 @@
         </div>
         <img
           class="enemy-image"
-          src="/mathmonsters/images/battle/monster_battle_1.png"
+          src="../images/battle/monster_battle_1_1.png"
           alt="Enemy defeated in battle"
         />
         <p class="battle-goals-title">Battle Rewards</p>
@@ -118,11 +118,11 @@
         <button type="button" class="btn-primary">Try Again</button>
       </div>
     </div>
-    <script src="/mathmonsters/js/pwa.js" defer data-pwa-root="/mathmonsters"></script>
+    <script src="../js/pwa.js" defer data-pwa-root=".."></script>
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-    <script src="/mathmonsters/js/supabaseClient.js"></script>
-    <script src="/mathmonsters/js/loader.js"></script>
-    <script src="/mathmonsters/js/battle.js"></script>
-    <script src="/mathmonsters/js/question.js"></script>
+    <script src="../js/supabaseClient.js"></script>
+    <script src="../js/loader.js" data-asset-base=".."></script>
+    <script src="../js/battle.js" data-asset-base=".."></script>
+    <script src="../js/question.js" data-asset-base=".."></script>
   </body>
 </html>

--- a/js/loader.js
+++ b/js/loader.js
@@ -1,5 +1,52 @@
 const STORAGE_KEY_PROGRESS = 'reefRangersProgress';
-const ASSET_BASE_PATH = '/mathmonsters';
+const FALLBACK_ASSET_BASE = '/mathmonsters';
+
+const determineAssetBasePath = () => {
+  const fallbackBase = FALLBACK_ASSET_BASE;
+  const doc = typeof document !== 'undefined' ? document : null;
+  const currentScript = doc?.currentScript;
+  const scriptedBase =
+    typeof currentScript?.dataset?.assetBase === 'string'
+      ? currentScript.dataset.assetBase.trim()
+      : '';
+  if (scriptedBase) {
+    if (typeof window !== 'undefined') {
+      window.mathMonstersAssetBase = scriptedBase;
+    }
+    return scriptedBase;
+  }
+
+  if (doc) {
+    const taggedScript = doc.querySelector('script[data-asset-base]');
+    const taggedBase =
+      typeof taggedScript?.dataset?.assetBase === 'string'
+        ? taggedScript.dataset.assetBase.trim()
+        : '';
+    if (taggedBase) {
+      if (typeof window !== 'undefined') {
+        window.mathMonstersAssetBase = taggedBase;
+      }
+      return taggedBase;
+    }
+  }
+
+  if (typeof window !== 'undefined') {
+    const globalBase =
+      typeof window.mathMonstersAssetBase === 'string'
+        ? window.mathMonstersAssetBase.trim()
+        : '';
+    if (globalBase) {
+      return globalBase;
+    }
+  }
+
+  if (typeof window !== 'undefined') {
+    window.mathMonstersAssetBase = fallbackBase;
+  }
+  return fallbackBase;
+};
+
+const ASSET_BASE_PATH = determineAssetBasePath();
 
 const normalizeAssetPath = (inputPath) => {
   if (typeof inputPath !== 'string') {
@@ -35,6 +82,15 @@ const normalizeAssetPath = (inputPath) => {
   }
 
   trimmed = trimmed.replace(/^\/+/, '');
+
+  const fallbackNormalized = FALLBACK_ASSET_BASE.replace(/^\/+/, '');
+  if (
+    fallbackNormalized &&
+    ASSET_BASE_PATH !== FALLBACK_ASSET_BASE &&
+    trimmed.startsWith(`${fallbackNormalized}/`)
+  ) {
+    trimmed = trimmed.slice(fallbackNormalized.length + 1);
+  }
 
   const base = ASSET_BASE_PATH.endsWith('/')
     ? ASSET_BASE_PATH.slice(0, -1)

--- a/js/question.js
+++ b/js/question.js
@@ -1,7 +1,23 @@
+const getAssetBasePath = () => {
+  const fallback = '/mathmonsters';
+  const globalBase =
+    typeof window.mathMonstersAssetBase === 'string'
+      ? window.mathMonstersAssetBase.trim()
+      : '';
+  if (globalBase) {
+    return globalBase;
+  }
+  return fallback;
+};
+
 document.addEventListener('DOMContentLoaded', () => {
   const questionBox = document.getElementById('question');
   const choicesContainer = questionBox.querySelector('.choices');
   const button = questionBox.querySelector('button');
+  const assetBase = getAssetBasePath();
+  const trimmedBase = assetBase.endsWith('/')
+    ? assetBase.slice(0, -1)
+    : assetBase;
 
   button.disabled = true;
 
@@ -35,9 +51,11 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     button.classList.add('result', isCorrect ? 'correct' : 'incorrect');
-    button.innerHTML = isCorrect
-      ? '<img src="/mathmonsters/images/questions/button/correct.svg" alt="Correct icon" /> Correct'
-      : '<img src="/mathmonsters/images/questions/button/incorrect.svg" alt="Incorrect icon" /> Incorrect';
+    const iconType = isCorrect ? 'correct' : 'incorrect';
+    const iconPath = `${trimmedBase}/images/questions/button/${iconType}.svg`;
+    button.innerHTML =
+      `<img src="${iconPath}" alt="${isCorrect ? 'Correct' : 'Incorrect'} icon" /> ` +
+      (isCorrect ? 'Correct' : 'Incorrect');
 
     document.dispatchEvent(
       new CustomEvent('answer-submitted', { detail: { correct: isCorrect } })


### PR DESCRIPTION
## Summary
- detect the correct asset base path in the battle loader and logic so assets resolve when the app is served from a subdirectory
- update battle markup, question UI, and CSS to use the computed base and existing monster artwork

## Testing
- python -m http.server 8000 &
- curl -I http://127.0.0.1:8000/html/battle.html
- curl -I http://127.0.0.1:8000/images/battle/monster_battle_1_1.png


------
https://chatgpt.com/codex/tasks/task_e_68cdbd904cb88329999ebb3a4a82de51