### PR TITLE
Adjust landing battle intro timing and positioning

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -220,9 +220,9 @@ body:not(.is-preloading) main.landing {
 
 .battle-intro {
   position: absolute;
-  left: 50%;
-  bottom: 32vh;
-  transform: translate(-50%, 0);
+  left: var(--battle-intro-left, 50%);
+  top: var(--battle-intro-top, 48%);
+  transform: translate(-50%, -50%);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -233,9 +233,9 @@ body:not(.is-preloading) main.landing {
 }
 
 .battle-intro__image {
-  width: clamp(220px, 48vw, 420px);
-  max-width: 90vw;
-  height: auto;
+  width: min(300px, 90vw);
+  height: min(300px, 90vw);
+  object-fit: contain;
   transform: scale(0.2);
   transform-origin: center;
 }

--- a/index.html
+++ b/index.html
@@ -71,8 +71,8 @@
       class="battle-intro__image"
       src="/mathmonsters/images/battle/battle.png"
       alt="Battle begins"
-      width="350"
-      height="350"
+      width="300"
+      height="300"
     />
   </div>
   <script>

--- a/js/index.js
+++ b/js/index.js
@@ -3,7 +3,7 @@ const LANDING_VISITED_KEY = 'reefRangersVisitedLanding';
 const VISITED_VALUE = 'true';
 const PROGRESS_STORAGE_KEY = 'reefRangersProgress';
 const MIN_PRELOAD_DURATION_MS = 2000;
-const BATTLE_INTRO_DELAY_MS = 2000;
+const BATTLE_INTRO_DELAY_MS = 1000;
 const BATTLE_INTRO_VISIBLE_DURATION_MS = 2000;
 
 // Gentle idle motion caps (pixels)
@@ -239,6 +239,7 @@ const determineBattlePreview = (levelsData, variablesData) => {
 const updateHeroFloat = () => {
   const heroImage = document.querySelector('.hero');
   const battleCard = document.querySelector('[data-battle-card]');
+  const battleIntro = document.querySelector('[data-battle-intro]');
 
   if (!heroImage || !battleCard) return;
 
@@ -255,10 +256,23 @@ const updateHeroFloat = () => {
       Math.max(HERO_FLOAT_MIN_PX, rawRange)
     );
 
-    const topOffset = Math.max(0, Math.min(clampedSpace, 24));
+    const topOffset = Math.max(0, Math.min(clampedSpace, 72));
 
     heroImage.style.setProperty('--hero-top', `${topOffset}px`);
     heroImage.style.setProperty('--hero-float-range', `${floatRange}px`);
+
+    if (battleIntro) {
+      const scrollX =
+        typeof window === 'undefined' ? 0 : window.scrollX || window.pageXOffset || 0;
+      const scrollY =
+        typeof window === 'undefined' ? 0 : window.scrollY || window.pageYOffset || 0;
+      const heroCenterX = heroRect.left + heroRect.width / 2 + scrollX;
+      const heroCenterY = heroRect.top + heroRect.height / 2 + scrollY;
+
+      battleIntro.style.setProperty('--battle-intro-left', `${heroCenterX}px`);
+      battleIntro.style.setProperty('--battle-intro-top', `${heroCenterY}px`);
+    }
+
   };
 
   if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {


### PR DESCRIPTION
## Summary
- let the hero float originate lower and reuse the position to align the battle intro overlay with the sprite
- reduce the battle intro delay to 1 second while keeping the redirect behaviour intact
- size the battle intro artwork to 300px and keep it centered above the hero

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cdc933cc508329a531a25258ebef66