### PR TITLE
Add welcome page with guest gameplay option

### DIFF
--- a/css/signin.css
+++ b/css/signin.css
@@ -81,6 +81,42 @@ body {
   box-sizing: border-box;
 }
 
+.preloader__tagline {
+  margin: 0;
+  max-width: 420px;
+  color: #ffffff;
+  font-size: 20px;
+}
+
+.preloader__secondary-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  width: 420px;
+  max-width: 100%;
+  min-height: 64px;
+  margin: 0;
+  box-sizing: border-box;
+  border: 2px solid rgba(255, 255, 255, 0.25);
+  border-radius: 12px;
+  color: #ffffff;
+  text-decoration: none;
+  font-size: 20px;
+  font-weight: 700;
+  background-color: transparent;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.preloader__secondary-button:hover {
+  transform: translateY(-2px);
+}
+
+.preloader__secondary-button:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.7);
+  outline-offset: 3px;
+}
+
 .preloader__link {
   color: #ffffff;
   font-size: 20px;

--- a/js/index.js
+++ b/js/index.js
@@ -2,6 +2,7 @@ const LANDING_VISITED_KEY = 'reefRangersVisitedLanding';
 
 const VISITED_VALUE = 'true';
 const PROGRESS_STORAGE_KEY = 'reefRangersProgress';
+const GUEST_SESSION_KEY = 'reefRangersGuestSession';
 const MIN_PRELOAD_DURATION_MS = 2000;
 const BATTLE_INTRO_DELAY_MS = 1000;
 const BATTLE_INTRO_VISIBLE_DURATION_MS = 2000;
@@ -10,14 +11,39 @@ const BATTLE_INTRO_VISIBLE_DURATION_MS = 2000;
 const HERO_FLOAT_MIN_PX = 5;   // tiny but visible
 const HERO_FLOAT_MAX_PX = 7;  // prevents big bobbing
 
-const redirectToSignIn = () => {
-  window.location.replace('signin.html');
+const redirectToWelcome = () => {
+  window.location.replace('welcome.html');
+};
+
+const isGuestModeActive = () => {
+  try {
+    const storage = window.localStorage;
+    if (!storage) {
+      return false;
+    }
+    return storage.getItem(GUEST_SESSION_KEY) === 'true';
+  } catch (error) {
+    console.warn('Guest mode detection failed.', error);
+    return false;
+  }
+};
+
+const clearGuestMode = () => {
+  try {
+    window.localStorage?.removeItem(GUEST_SESSION_KEY);
+  } catch (error) {
+    console.warn('Unable to clear guest mode flag.', error);
+  }
 };
 
 const ensureAuthenticated = async () => {
+  if (isGuestModeActive()) {
+    return true;
+  }
+
   const supabase = window.supabaseClient;
   if (!supabase) {
-    redirectToSignIn();
+    redirectToWelcome();
     return false;
   }
 
@@ -28,13 +54,14 @@ const ensureAuthenticated = async () => {
     }
 
     if (!data?.session) {
-      redirectToSignIn();
+      redirectToWelcome();
       return false;
     }
+    clearGuestMode();
     return true;
   } catch (error) {
     console.warn('Unexpected authentication error', error);
-    redirectToSignIn();
+    redirectToWelcome();
     return false;
   }
 };

--- a/js/register.js
+++ b/js/register.js
@@ -1,3 +1,13 @@
+const GUEST_SESSION_KEY = 'reefRangersGuestSession';
+
+const clearGuestSessionFlag = () => {
+  try {
+    window.localStorage?.removeItem(GUEST_SESSION_KEY);
+  } catch (error) {
+    console.warn('Unable to clear guest session flag.', error);
+  }
+};
+
 const setElementVisibility = (element, shouldShow) => {
   if (!element) {
     return;
@@ -62,6 +72,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       console.warn('Failed to fetch existing session', error);
     }
     if (data?.session) {
+      clearGuestSessionFlag();
       window.location.replace('index.html');
       return;
     }
@@ -102,10 +113,12 @@ document.addEventListener('DOMContentLoaded', async () => {
       }
 
       if (data?.session) {
+        clearGuestSessionFlag();
         window.location.replace('index.html');
         return;
       }
 
+      clearGuestSessionFlag();
       window.location.replace('signin.html');
     } catch (error) {
       console.error('Unexpected error during registration', error);

--- a/js/signin.js
+++ b/js/signin.js
@@ -1,3 +1,13 @@
+const GUEST_SESSION_KEY = 'reefRangersGuestSession';
+
+const clearGuestSessionFlag = () => {
+  try {
+    window.localStorage?.removeItem(GUEST_SESSION_KEY);
+  } catch (error) {
+    console.warn('Unable to clear guest session flag.', error);
+  }
+};
+
 const setElementVisibility = (element, shouldShow) => {
   if (!element) {
     return;
@@ -60,6 +70,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       console.warn('Failed to fetch existing session', error);
     }
     if (data?.session) {
+      clearGuestSessionFlag();
       window.location.replace('index.html');
       return;
     }
@@ -93,6 +104,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         return;
       }
 
+      clearGuestSessionFlag();
       window.location.replace('index.html');
     } catch (error) {
       console.error('Unexpected error during sign in', error);

--- a/js/welcome.js
+++ b/js/welcome.js
@@ -1,0 +1,77 @@
+const GUEST_SESSION_KEY = 'reefRangersGuestSession';
+const PROGRESS_STORAGE_KEY = 'reefRangersProgress';
+
+const createDefaultProgress = () => ({
+  battleLevel: 1,
+  currentExperience: 0,
+});
+
+const persistGuestSession = () => {
+  try {
+    const storage = window.localStorage;
+    if (!storage) {
+      return false;
+    }
+    storage.setItem(GUEST_SESSION_KEY, 'true');
+    const existingProgress = storage.getItem(PROGRESS_STORAGE_KEY);
+    if (!existingProgress) {
+      storage.setItem(
+        PROGRESS_STORAGE_KEY,
+        JSON.stringify(createDefaultProgress())
+      );
+    }
+    return true;
+  } catch (error) {
+    console.warn('Guest session could not be saved.', error);
+    return false;
+  }
+};
+
+const clearGuestSessionFlag = () => {
+  try {
+    window.localStorage?.removeItem(GUEST_SESSION_KEY);
+  } catch (error) {
+    console.warn('Unable to clear guest session flag.', error);
+  }
+};
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const newGameButton = document.querySelector('[data-new-game]');
+  const supabase = window.supabaseClient;
+
+  const setButtonState = (isDisabled) => {
+    if (!newGameButton) {
+      return;
+    }
+    newGameButton.disabled = Boolean(isDisabled);
+    newGameButton.setAttribute('aria-disabled', isDisabled ? 'true' : 'false');
+  };
+
+  if (supabase?.auth?.getSession) {
+    try {
+      const { data, error } = await supabase.auth.getSession();
+      if (error) {
+        console.warn('Unable to check existing session.', error);
+      }
+      if (data?.session) {
+        clearGuestSessionFlag();
+        window.location.replace('index.html');
+        return;
+      }
+    } catch (error) {
+      console.warn('Unexpected session lookup error.', error);
+    }
+  }
+
+  if (newGameButton) {
+    newGameButton.addEventListener('click', () => {
+      setButtonState(true);
+      const success = persistGuestSession();
+      if (!success) {
+        setButtonState(false);
+        return;
+      }
+      window.location.replace('index.html');
+    });
+  }
+});

--- a/sw.js
+++ b/sw.js
@@ -2,6 +2,7 @@ const CACHE_NAME = 'reef-rangers-cache-v1';
 const OFFLINE_ASSETS = [
   './',
   './index.html',
+  './welcome.html',
   './signin.html',
   './html/battle.html',
   './manifest.webmanifest',
@@ -14,6 +15,7 @@ const OFFLINE_ASSETS = [
   './js/battle.js',
   './js/question.js',
   './js/signin.js',
+  './js/welcome.js',
   './js/supabaseClient.js',
   './js/loader.js',
   './images/brand/logo.png',

--- a/welcome.html
+++ b/welcome.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#0a3d62" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <title>Welcome | Reef Rangers</title>
+    <link rel="manifest" href="manifest.webmanifest" />
+    <link rel="apple-touch-icon" sizes="300x300" href="/mathmonsters/images/brand/logo.png" />
+    <link rel="stylesheet" href="css/global.css" />
+    <link rel="stylesheet" href="css/signin.css" />
+  </head>
+  <body>
+    <div class="preloader">
+      <img
+        class="preloader__logo"
+        src="/mathmonsters/images/brand/logo.png"
+        alt="Reef Rangers logo"
+        width="300"
+        height="300"
+      />
+      <h1 class="preloader__headline">Welcome</h1>
+      <p class="preloader__tagline">Turn math into an epic adventure!</p>
+      <button class="preloader__button btn-primary" type="button" data-new-game>
+        New Game
+      </button>
+      <a class="preloader__secondary-button" href="signin.html">Sign In</a>
+    </div>
+    <script>
+      window.SUPABASE_URL = 'https://jxlxpumcoihfapmrsaqd.supabase.co';
+      window.SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imp4bHhwdW1jb2loZmFwbXJzYXFkIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTc0MjE3MDcsImV4cCI6MjA3Mjk5NzcwN30.PJiDPZ_Dqli_42isJexeYgsf0ebWbCSOwHtR7lsQTN0';
+    </script>
+    <script src="js/pwa.js" defer data-pwa-root="."></script>
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2" defer></script>
+    <script src="js/supabaseClient.js" defer></script>
+    <script src="js/welcome.js" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- create a new welcome screen mirroring the sign-in layout with a guest "New Game" call to action
- add guest-session handling so local players can start without Supabase auth and clean up when users sign in or register
- style the new welcome actions and include the page in the service worker offline cache

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cdcadedc0483299d05c5def5589a29