### PR TITLE
Wrap battle scripts to avoid global collisions

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -1,3 +1,4 @@
+(() => {
 const LANDING_VISITED_KEY = 'reefRangersVisitedLanding';
 const VISITED_VALUE = 'true';
 const PROGRESS_STORAGE_KEY = 'reefRangersProgress';
@@ -1116,3 +1117,4 @@ document.addEventListener('DOMContentLoaded', () => {
     document.addEventListener('data-loaded', initBattle, { once: true });
   }
 });
+})();

--- a/js/loader.js
+++ b/js/loader.js
@@ -1,3 +1,4 @@
+(() => {
 const STORAGE_KEY_PROGRESS = 'reefRangersProgress';
 const FALLBACK_ASSET_BASE = '/mathmonsters';
 
@@ -343,4 +344,5 @@ const readStoredProgress = () => {
     window.preloadedData = {};
     document.dispatchEvent(new Event('data-loaded'));
   }
+})();
 })();


### PR DESCRIPTION
## Summary
- wrap `loader.js` in an IIFE so its helper constants/functions do not leak into the global scope
- wrap `battle.js` in an IIFE to avoid clashing with loader helpers and let the battle logic execute again

## Testing
- python -m http.server 8000 (manual verification via Playwright)


------
https://chatgpt.com/codex/tasks/task_e_68cdce95aac08329acc6707843d2c6f1