### PR TITLE
Adjust welcome styling and battle intro transitions

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -65,6 +65,11 @@ body:not(.is-preloading) main.landing {
   pointer-events: none;
 }
 
+.hero.is-battle-transition {
+  animation: hero-pop-out 0.45s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  will-change: transform, opacity;
+}
+
 @keyframes hero-float {
   0% {
     transform: translate(-50%, calc(-1 * var(--hero-float-range, 32px)));
@@ -81,6 +86,50 @@ body:not(.is-preloading) main.landing {
   .hero {
     animation: none;
     transform: translate(-50%, 0);
+  }
+
+  .hero.is-battle-transition {
+    opacity: 0;
+  }
+}
+
+@keyframes hero-pop-out {
+  0% {
+    transform: translate(-50%, calc(-1 * var(--hero-float-range, 32px))) scale(1);
+    opacity: 1;
+  }
+  60% {
+    transform: translate(-50%, calc(-1 * var(--hero-float-range, 32px))) scale(1.14);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-50%, calc(-1 * var(--hero-float-range, 32px))) scale(1.28);
+    opacity: 0;
+  }
+}
+
+.card--home.is-battle-transition {
+  animation: card-pop-out 0.45s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  will-change: transform, opacity;
+}
+
+@keyframes card-pop-out {
+  0% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  55% {
+    transform: scale(1.08);
+  }
+  100% {
+    transform: scale(0.85);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card--home.is-battle-transition {
+    opacity: 0;
   }
 }
 

--- a/css/signin.css
+++ b/css/signin.css
@@ -36,7 +36,14 @@ body {
 .preloader__headline {
   margin: 0;
   color: #ffffff;
-  font-size: 32px;
+}
+
+.preloader__actions {
+  width: 420px;
+  max-width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
 }
 
 .preloader__field {

--- a/html/welcome.html
+++ b/html/welcome.html
@@ -20,11 +20,13 @@
         width="300"
         height="300"
       />
-      <h1 class="preloader__headline">Turn math into an epic adventure!</h1>
-      <button class="preloader__button btn-primary" type="button" data-new-game>
-        New Game
-      </button>
-      <a class="preloader__secondary-button" href="signin.html">Sign In</a>
+      <h1 class="preloader__headline title">Turn math into an epic adventure!</h1>
+      <div class="preloader__actions">
+        <button class="preloader__button btn-primary" type="button" data-new-game>
+          New Game
+        </button>
+        <a class="preloader__secondary-button" href="signin.html">Sign In</a>
+      </div>
     </div>
     <script>
       window.SUPABASE_URL = 'https://jxlxpumcoihfapmrsaqd.supabase.co';

--- a/js/battle.js
+++ b/js/battle.js
@@ -949,6 +949,18 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     }
 
+    try {
+      window.localStorage?.clear();
+    } catch (error) {
+      console.warn('Unable to clear local storage.', error);
+    }
+
+    try {
+      window.sessionStorage?.clear();
+    } catch (error) {
+      console.warn('Unable to clear session storage.', error);
+    }
+
     window.location.replace(`${ASSET_BASE_PATH}/html/signin.html`);
   });
 


### PR DESCRIPTION
## Summary
- restyle the welcome headline with the shared title treatment while keeping it white and group the call-to-action buttons with a 24px gap
- animate the landing hero and card pop-out before showing the battle intro splash, then delay one second before navigating to battle
- clear all persisted local and session data when using the battle developer Log Out control

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cdd32a699c8329af3cb416f5ef0786