### PR TITLE
Improve mobile full-screen experience on sign-in

### DIFF
--- a/css/signin.css
+++ b/css/signin.css
@@ -1,8 +1,10 @@
 body {
   margin: 0;
   min-height: 100vh;
+  min-height: 100dvh;
   padding: 16px;
   box-sizing: border-box;
+  background-color: #001b41;
 }
 
 .preloader {
@@ -17,6 +19,10 @@ body {
   background-color: #001b41;
   text-align: center;
   box-sizing: border-box;
+  padding-top: calc(16px + env(safe-area-inset-top, 0px));
+  padding-bottom: calc(16px + env(safe-area-inset-bottom, 0px));
+  padding-left: calc(16px + env(safe-area-inset-left, 0px));
+  padding-right: calc(16px + env(safe-area-inset-right, 0px));
 }
 
 .preloader__logo {
@@ -167,6 +173,10 @@ body {
 @media (max-width: 480px) {
   .preloader {
     padding: 16px;
+    padding-top: calc(16px + env(safe-area-inset-top, 0px));
+    padding-bottom: calc(16px + env(safe-area-inset-bottom, 0px));
+    padding-left: calc(16px + env(safe-area-inset-left, 0px));
+    padding-right: calc(16px + env(safe-area-inset-right, 0px));
   }
 
   .preloader__form {

--- a/html/signin.html
+++ b/html/signin.html
@@ -2,9 +2,14 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#0a3d62" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
+    <meta name="theme-color" content="#001b41" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <title>Sign In | Reef Rangers</title>
     <link rel="manifest" href="../manifest.webmanifest" />
     <link rel="apple-touch-icon" sizes="300x300" href="/mathmonsters/images/brand/logo.png" />


### PR DESCRIPTION
## Summary
- enable standalone display and consistent theme color for the sign-in page on mobile
- update sign-in layout spacing to respect safe-area insets and ensure the app background fills the screen

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68cddd3334448329bebbe006ff2b747a