### PR TITLE
Apply mobile fullscreen metadata globally

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -1,14 +1,10 @@
-html,
 body {
-  height: 100%;
-}
-
-body {
+  --app-safe-area-padding: 16px;
   margin: 0;
-  min-height: 100%;
+  min-height: 100vh;
+  min-height: 100dvh;
   overflow: hidden;
   background: url('../images/background/background.png') no-repeat center/cover;
-  padding: 16px;
   box-sizing: border-box;
 }
 

--- a/css/global.css
+++ b/css/global.css
@@ -13,9 +13,40 @@
   --button-hover-gradient-end: #1a73ff;
 }
 
-html,
+html {
+  height: 100%;
+}
+
 body {
+  margin: 0;
+  min-height: 100vh;
+  min-height: 100dvh;
   font-family: var(--font-family-rounded);
+  color: #272b34;
+  background-color: #001b41;
+}
+
+@supports (-webkit-touch-callout: none) {
+  body {
+    min-height: -webkit-fill-available;
+  }
+}
+
+.app-safe-area {
+  --app-safe-area-padding: 0px;
+  padding: var(--app-safe-area-padding, 0px);
+  padding-top: calc(
+    var(--app-safe-area-padding, 0px) + env(safe-area-inset-top, 0px)
+  );
+  padding-bottom: calc(
+    var(--app-safe-area-padding, 0px) + env(safe-area-inset-bottom, 0px)
+  );
+  padding-left: calc(
+    var(--app-safe-area-padding, 0px) + env(safe-area-inset-left, 0px)
+  );
+  padding-right: calc(
+    var(--app-safe-area-padding, 0px) + env(safe-area-inset-right, 0px)
+  );
 }
 
 button,

--- a/css/index.css
+++ b/css/index.css
@@ -5,6 +5,7 @@
 body {
   margin: 0;
   min-height: 100vh;
+  min-height: 100dvh;
   color: #272B34;
   background: url('/mathmonsters/images/background/background.png') no-repeat center/cover;
   position: relative;
@@ -357,6 +358,7 @@ body:not(.is-preloading) main.landing {
 /* Simple preload experience ---------------------------------------------- */
 
 .preloader {
+  --app-safe-area-padding: 32px;
   position: fixed;
   inset: 0;
   display: flex;
@@ -364,7 +366,6 @@ body:not(.is-preloading) main.landing {
   align-items: center;
   justify-content: center;
   gap: 24px;
-  padding: 32px;
   background-color: #001b41;
   z-index: 10;
   text-align: center;

--- a/css/signin.css
+++ b/css/signin.css
@@ -1,11 +1,5 @@
-body {
-  margin: 0;
-  min-height: 100vh;
-  padding: 16px;
-  box-sizing: border-box;
-}
-
 .preloader {
+  --app-safe-area-padding: 16px;
   position: fixed;
   inset: 0;
   display: flex;
@@ -13,7 +7,6 @@ body {
   justify-content: center;
   align-items: center;
   gap: 40px;
-  padding: 16px;
   background-color: #001b41;
   text-align: center;
   box-sizing: border-box;
@@ -165,10 +158,6 @@ body {
 }
 
 @media (max-width: 480px) {
-  .preloader {
-    padding: 16px;
-  }
-
   .preloader__form {
     max-width: none;
   }

--- a/html/battle.html
+++ b/html/battle.html
@@ -2,8 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-    <meta name="theme-color" content="#0a3d62" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover, maximum-scale=1.0, user-scalable=no"
+    />
+    <meta name="theme-color" content="#001b41" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <title>Battle</title>
@@ -13,7 +17,7 @@
     <link rel="stylesheet" href="../css/question.css" />
     <link rel="stylesheet" href="../css/battle.css" />
   </head>
-  <body>
+  <body class="app-safe-area">
   <div class="battle-dev-controls" role="group" aria-label="Battle test controls">
     <button type="button" class="battle-dev-controls__btn" data-dev-set-streak>
       Set Streak 4

--- a/html/register.html
+++ b/html/register.html
@@ -2,9 +2,17 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#0a3d62" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
+    <meta name="theme-color" content="#001b41" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta
+      name="apple-mobile-web-app-status-bar-style"
+      content="black-translucent"
+    />
     <title>Register | Reef Rangers</title>
     <link rel="manifest" href="../manifest.webmanifest" />
     <link
@@ -16,7 +24,7 @@
     <link rel="stylesheet" href="../css/signin.css" />
   </head>
   <body>
-    <div class="preloader">
+    <div class="preloader app-safe-area">
       <img
         class="preloader__logo"
         src="/mathmonsters/images/brand/logo.png"

--- a/html/signin.html
+++ b/html/signin.html
@@ -2,9 +2,14 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#0a3d62" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
+    <meta name="theme-color" content="#001b41" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <title>Sign In | Reef Rangers</title>
     <link rel="manifest" href="../manifest.webmanifest" />
     <link rel="apple-touch-icon" sizes="300x300" href="/mathmonsters/images/brand/logo.png" />
@@ -12,7 +17,7 @@
     <link rel="stylesheet" href="../css/signin.css" />
   </head>
   <body>
-    <div class="preloader">
+    <div class="preloader app-safe-area">
       <img
         class="preloader__logo"
         src="/mathmonsters/images/brand/logo.png"

--- a/html/welcome.html
+++ b/html/welcome.html
@@ -2,9 +2,17 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#0a3d62" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
+    <meta name="theme-color" content="#001b41" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta
+      name="apple-mobile-web-app-status-bar-style"
+      content="black-translucent"
+    />
     <title>Welcome | Reef Rangers</title>
     <link rel="manifest" href="../manifest.webmanifest" />
     <link rel="apple-touch-icon" sizes="300x300" href="/mathmonsters/images/brand/logo.png" />
@@ -12,7 +20,7 @@
     <link rel="stylesheet" href="../css/signin.css" />
   </head>
   <body>
-    <div class="preloader">
+    <div class="preloader app-safe-area">
       <img
         class="preloader__logo"
         src="/mathmonsters/images/brand/logo.png"

--- a/index.html
+++ b/index.html
@@ -2,10 +2,14 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="theme-color" content="#0a3d62" />
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+  />
+  <meta name="theme-color" content="#001b41" />
+  <meta name="mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
-  <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <title>Reef Rangers</title>
   <link rel="manifest" href="manifest.webmanifest" />
   <link rel="apple-touch-icon" sizes="300x300" href="/mathmonsters/images/brand/logo.png" />
@@ -13,7 +17,12 @@
   <link rel="stylesheet" href="css/index.css" />
 </head>
 <body class="is-preloading">
-  <div class="preloader" data-preloader role="status" aria-live="polite">
+  <div
+    class="preloader app-safe-area"
+    data-preloader
+    role="status"
+    aria-live="polite"
+  >
     <img
       class="preloader__logo"
       src="/mathmonsters/images/brand/logo.png"

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -5,8 +5,8 @@
   "start_url": "./index.html",
   "scope": "./",
   "display": "standalone",
-  "background_color": "#0a3d62",
-  "theme_color": "#0a3d62",
+  "background_color": "#001b41",
+  "theme_color": "#001b41",
   "icons": [
     {
       "src": "/images/brand/logo.png",


### PR DESCRIPTION
## Summary
- align every page's metadata to request fullscreen display with a consistent theme color
- add a reusable safe-area utility and apply it to preloader and battle surfaces so layouts respect iOS insets
- update the PWA manifest to match the login palette across the experience

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cddd3334448329bebbe006ff2b747a