### PR TITLE
Add safe-area handling for mobile layouts

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -260,7 +260,7 @@ button:focus-visible {
 .card--home {
   position: absolute;
   left: 50%;
-  bottom: 16px;
+  bottom: calc(16px + env(safe-area-inset-bottom, 0px));
   transform: translateX(-50%);
   width: min(420px, calc(100% - 32px));
   margin: 0;

--- a/css/index.css
+++ b/css/index.css
@@ -16,6 +16,7 @@ main.landing {
   position: relative;
   width: 100%;
   min-height: 100vh;
+  min-height: 100dvh;
   opacity: 1;
   transform: translate3d(0, 0, 0);
   filter: none;
@@ -145,7 +146,8 @@ body:not(.is-preloading) main.landing {
   justify-content: center;
   gap: clamp(24px, 8vw, 72px);
   width: min(720px, 100%);
-  padding: 0 16px clamp(120px, 22vh, 200px);
+  padding: 0 16px
+    calc(clamp(120px, 22vh, 200px) + env(safe-area-inset-bottom, 0px));
   overflow: visible;
   pointer-events: none;
   z-index: 1;
@@ -418,7 +420,9 @@ body:not(.is-preloading) main.landing {
 .pwa-install {
   position: relative;
   z-index: 7;
-  margin: clamp(16px, 4vw, 32px) auto clamp(40px, 8vh, 96px);
+  margin: clamp(16px, 4vw, 32px)
+    auto
+    calc(clamp(40px, 8vh, 96px) + env(safe-area-inset-bottom, 0px));
   padding: clamp(16px, 4vw, 32px);
   max-width: min(420px, 90%);
   border-radius: 28px;
@@ -475,7 +479,7 @@ body:not(.is-preloading) main.landing {
 @media (min-width: 768px) {
   .pwa-install {
     position: absolute;
-    bottom: clamp(32px, 5vh, 72px);
+    bottom: calc(clamp(32px, 5vh, 72px) + env(safe-area-inset-bottom, 0px));
     right: clamp(32px, 6vw, 96px);
     margin: 0;
     text-align: left;

--- a/css/signin.css
+++ b/css/signin.css
@@ -4,6 +4,10 @@ body {
   min-height: 100vh;
   min-height: 100dvh;
   padding: 16px;
+  padding-top: calc(16px + env(safe-area-inset-top, 0px));
+  padding-bottom: calc(16px + env(safe-area-inset-bottom, 0px));
+  padding-left: calc(16px + env(safe-area-inset-left, 0px));
+  padding-right: calc(16px + env(safe-area-inset-right, 0px));
   box-sizing: border-box;
   background-color: #001b41;
 }


### PR DESCRIPTION
## Summary
- update the landing page layout to respect iOS safe-area insets by padding decorative bubbles and cards
- adjust the install prompt positioning to account for the Safari bottom controls across viewports
- apply safe-area padding to authentication pages to keep forms above the mobile browser chrome

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cde36c3cf08329a7798cc7c1df86d9