### PR TITLE
Improve landing page safe area handling

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -257,10 +257,22 @@ button:focus-visible {
   min-height: 64px;
 }
 
+:root {
+  --viewport-bottom-offset: 0px;
+}
+
 .card--home {
   position: absolute;
   left: 50%;
-  bottom: 16px;
+  bottom: calc(16px + var(--viewport-bottom-offset, 0px));
+  bottom: calc(
+    16px + var(--viewport-bottom-offset, 0px) +
+    constant(safe-area-inset-bottom)
+  );
+  bottom: calc(
+    16px + var(--viewport-bottom-offset, 0px) +
+    env(safe-area-inset-bottom, 0px)
+  );
   transform: translateX(-50%);
   width: min(420px, calc(100% - 32px));
   margin: 0;

--- a/css/index.css
+++ b/css/index.css
@@ -16,6 +16,7 @@ main.landing {
   position: relative;
   width: 100%;
   min-height: 100vh;
+  min-height: 100dvh;
   opacity: 1;
   transform: translate3d(0, 0, 0);
   filter: none;
@@ -145,7 +146,23 @@ body:not(.is-preloading) main.landing {
   justify-content: center;
   gap: clamp(24px, 8vw, 72px);
   width: min(720px, 100%);
-  padding: 0 16px clamp(120px, 22vh, 200px);
+  padding: 0 16px
+    calc(
+      clamp(120px, 22vh, 200px) +
+      var(--viewport-bottom-offset, 0px)
+    );
+  padding: 0 16px
+    calc(
+      clamp(120px, 22vh, 200px) +
+      var(--viewport-bottom-offset, 0px) +
+      constant(safe-area-inset-bottom)
+    );
+  padding: 0 16px
+    calc(
+      clamp(120px, 22vh, 200px) +
+      var(--viewport-bottom-offset, 0px) +
+      env(safe-area-inset-bottom, 0px)
+    );
   overflow: visible;
   pointer-events: none;
   z-index: 1;
@@ -418,7 +435,9 @@ body:not(.is-preloading) main.landing {
 .pwa-install {
   position: relative;
   z-index: 7;
-  margin: clamp(16px, 4vw, 32px) auto clamp(40px, 8vh, 96px);
+  margin: clamp(16px, 4vw, 32px)
+    auto
+    calc(clamp(40px, 8vh, 96px) + env(safe-area-inset-bottom, 0px));
   padding: clamp(16px, 4vw, 32px);
   max-width: min(420px, 90%);
   border-radius: 28px;
@@ -475,7 +494,7 @@ body:not(.is-preloading) main.landing {
 @media (min-width: 768px) {
   .pwa-install {
     position: absolute;
-    bottom: clamp(32px, 5vh, 72px);
+    bottom: calc(clamp(32px, 5vh, 72px) + env(safe-area-inset-bottom, 0px));
     right: clamp(32px, 6vw, 96px);
     margin: 0;
     text-align: left;

--- a/css/signin.css
+++ b/css/signin.css
@@ -4,6 +4,10 @@ body {
   min-height: 100vh;
   min-height: 100dvh;
   padding: 16px;
+  padding-top: calc(16px + env(safe-area-inset-top, 0px));
+  padding-bottom: calc(16px + env(safe-area-inset-bottom, 0px));
+  padding-left: calc(16px + env(safe-area-inset-left, 0px));
+  padding-right: calc(16px + env(safe-area-inset-right, 0px));
   box-sizing: border-box;
   background-color: #001b41;
 }

--- a/js/index.js
+++ b/js/index.js
@@ -12,6 +12,54 @@ const BATTLE_INTRO_WAIT_AFTER_VISIBLE_MS = 1000;
 const HERO_FLOAT_MIN_PX = 5;   // tiny but visible
 const HERO_FLOAT_MAX_PX = 7;  // prevents big bobbing
 
+const CSS_VIEWPORT_OFFSET_VAR = '--viewport-bottom-offset';
+
+const updateViewportOffsetVariable = () => {
+  const root = document.documentElement;
+  if (!root) {
+    return;
+  }
+
+  const viewport = window.visualViewport;
+  if (!viewport) {
+    root.style.setProperty(CSS_VIEWPORT_OFFSET_VAR, '0px');
+    return;
+  }
+
+  const layoutViewportHeight = window.innerHeight || viewport.height;
+  const bottomOverlap =
+    layoutViewportHeight - (viewport.height + viewport.offsetTop);
+  const safeOffset = Math.max(0, Math.round(bottomOverlap));
+  root.style.setProperty(CSS_VIEWPORT_OFFSET_VAR, `${safeOffset}px`);
+};
+
+const initViewportOffsetWatcher = () => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  updateViewportOffsetVariable();
+
+  const viewport = window.visualViewport;
+  if (viewport) {
+    viewport.addEventListener('resize', updateViewportOffsetVariable, {
+      passive: true,
+    });
+    viewport.addEventListener('scroll', updateViewportOffsetVariable, {
+      passive: true,
+    });
+  }
+
+  window.addEventListener('resize', updateViewportOffsetVariable, {
+    passive: true,
+  });
+  window.addEventListener('orientationchange', updateViewportOffsetVariable, {
+    passive: true,
+  });
+};
+
+initViewportOffsetWatcher();
+
 const redirectToWelcome = () => {
   window.location.replace('html/welcome.html');
 };


### PR DESCRIPTION
## Summary
- add a viewport bottom offset CSS variable that tracks the visual viewport overlap from Safari controls
- update the landing card and bubbles to combine the dynamic viewport offset with safe-area insets
- ensure legacy iOS safe-area constant syntax is supported when positioning the landing layout

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cde36c3cf08329a7798cc7c1df86d9