### PR TITLE
Fix hero sprite visibility and center battle intro

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -282,7 +282,7 @@ body {
   right: 12px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 4px;
   padding: 0;
   background: none;
   border: none;
@@ -295,20 +295,17 @@ body {
 }
 
 .battle-dev-controls__btn {
-  --btn-gradient-start: #0095ff;
-  --btn-gradient-end: #006aff;
-  --btn-hover-gradient-start: #33aaff;
-  --btn-hover-gradient-end: #1a73ff;
-
-  min-width: 180px;
-  padding: 10px 16px;
+  min-width: 0;
+  padding: 4px 8px;
   font: inherit;
-  font-size: 14px;
-  line-height: 1.2;
+  font-size: 12px;
+  line-height: 1.1;
   text-transform: none;
   letter-spacing: normal;
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.35);
+  color: #f5f7fb;
+  background: rgba(0, 18, 45, 0.65);
+  border-radius: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
   box-shadow: none;
 }
 

--- a/css/index.css
+++ b/css/index.css
@@ -286,9 +286,9 @@ body:not(.is-preloading) main.landing {
 }
 
 .battle-intro {
-  position: absolute;
+  position: fixed;
   left: var(--battle-intro-left, 50%);
-  top: var(--battle-intro-top, 45%);
+  top: var(--battle-intro-top, 50%);
   transform: translate(-50%, -50%);
   display: flex;
   align-items: center;

--- a/js/battle.js
+++ b/js/battle.js
@@ -508,8 +508,14 @@ document.addEventListener('DOMContentLoaded', () => {
   function loadData() {
     const data = window.preloadedData ?? {};
     const battleData = data.battle ?? {};
-    const heroData = data.hero ?? {};
-    const enemyData = data.enemy ?? {};
+    const heroData = {
+      ...(battleData?.hero ?? {}),
+      ...(data.hero ?? {}),
+    };
+    const enemyData = {
+      ...(battleData?.enemy ?? {}),
+      ...(data.enemy ?? {}),
+    };
     const progressData = data.variables?.progress ?? {};
 
     currentBattleLevel =
@@ -568,8 +574,15 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     const heroSprite = resolveAssetPath(heroData.sprite);
-    if (heroSprite && heroImg) {
-      heroImg.src = heroSprite;
+    if (heroImg) {
+      if (heroSprite) {
+        heroImg.src = heroSprite;
+      } else {
+        const fallbackHeroSprite = resolveAssetPath(battleData?.hero?.sprite);
+        if (fallbackHeroSprite) {
+          heroImg.src = fallbackHeroSprite;
+        }
+      }
     }
     if (heroImg && hero.name) {
       heroImg.alt = `${hero.name} ready for battle`;

--- a/js/index.js
+++ b/js/index.js
@@ -400,15 +400,8 @@ const updateHeroFloat = () => {
     heroImage.style.setProperty('--hero-float-range', `${floatRange}px`);
 
     if (battleIntro) {
-      const scrollX =
-        typeof window === 'undefined' ? 0 : window.scrollX || window.pageXOffset || 0;
-      const scrollY =
-        typeof window === 'undefined' ? 0 : window.scrollY || window.pageYOffset || 0;
-      const heroCenterX = heroRect.left + heroRect.width / 2 + scrollX;
-      const heroCenterY = heroRect.top + heroRect.height / 2 + scrollY;
-
-      battleIntro.style.setProperty('--battle-intro-left', `${heroCenterX}px`);
-      battleIntro.style.setProperty('--battle-intro-top', `${heroCenterY}px`);
+      battleIntro.style.removeProperty('--battle-intro-left');
+      battleIntro.style.removeProperty('--battle-intro-top');
     }
 
   };


### PR DESCRIPTION
## Summary
- ensure the battle hero sprite pulls from any available data source so it reliably loads in the arena
- center the pre-battle intro overlay and prevent layout code from pushing it off-center
- restyle the temporary developer controls to be compact, plain buttons

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cde93ed6848329b2db6793be367fec