### PR TITLE
Improve auth screens for mobile

### DIFF
--- a/css/signin.css
+++ b/css/signin.css
@@ -3,45 +3,48 @@ body {
   margin: 0;
   min-height: 100vh;
   min-height: 100dvh;
-  padding: 16px;
-  padding-top: calc(16px + env(safe-area-inset-top, 0px));
-  padding-bottom: calc(16px + env(safe-area-inset-bottom, 0px));
-  padding-left: calc(16px + env(safe-area-inset-left, 0px));
-  padding-right: calc(16px + env(safe-area-inset-right, 0px));
-  box-sizing: border-box;
   background-color: #001b41;
 }
 
 .preloader {
-  --app-safe-area-padding: 16px;
+  --app-safe-area-padding: clamp(16px, 5vw, 48px);
   position: fixed;
   inset: 0;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  gap: 40px;
+  gap: clamp(24px, 6vh, 48px);
   background-color: #001b41;
   text-align: center;
   box-sizing: border-box;
-  padding-top: calc(16px + env(safe-area-inset-top, 0px));
-  padding-bottom: calc(16px + env(safe-area-inset-bottom, 0px));
-  padding-left: calc(16px + env(safe-area-inset-left, 0px));
-  padding-right: calc(16px + env(safe-area-inset-right, 0px));
+  padding-top: calc(
+    var(--app-safe-area-padding) + env(safe-area-inset-top, 0px)
+  );
+  padding-bottom: calc(
+    var(--app-safe-area-padding) + env(safe-area-inset-bottom, 0px)
+  );
+  padding-left: calc(
+    var(--app-safe-area-padding) + env(safe-area-inset-left, 0px)
+  );
+  padding-right: calc(
+    var(--app-safe-area-padding) + env(safe-area-inset-right, 0px)
+  );
+  overflow-y: auto;
 }
 
 .preloader__logo {
-  width: 200px;
-  height: 200px;
+  width: clamp(160px, 40vw, 220px);
+  height: clamp(160px, 40vw, 220px);
   object-fit: contain;
 }
 
 .preloader__form {
-  max-width: 420px;
+  width: min(420px, 100%);
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: 24px;
+  align-items: stretch;
+  gap: clamp(20px, 4vh, 28px);
 }
 
 .preloader__headline {
@@ -50,24 +53,22 @@ body {
 }
 
 .preloader__actions {
-  width: 420px;
-  max-width: 100%;
+  width: min(420px, 100%);
   display: flex;
   flex-direction: column;
   gap: 24px;
 }
 
 .preloader__field {
-  width: 420px;
-  max-width: 100%;
-  height: 64px;
-  padding: 0 24px;
+  width: 100%;
+  height: clamp(56px, 7vh, 64px);
+  padding: 0 clamp(16px, 4vw, 24px);
   box-sizing: border-box;
   border: none;
   border-radius: 8px;
   background-color: #293f5f;
   color: #949faf;
-  font-size: 20px;
+  font-size: clamp(18px, 5vw, 20px);
 }
 
 .preloader__field:not(:placeholder-shown) {
@@ -76,7 +77,7 @@ body {
 
 .preloader__field::placeholder {
   color: #949faf;
-  font-size: 20px;
+  font-size: clamp(18px, 5vw, 20px);
 }
 
 .preloader__field:focus {
@@ -94,16 +95,17 @@ body {
   align-items: center;
   justify-content: center;
   gap: 16px;
-  width: 420px;
-  max-width: 100%;
+  width: 100%;
+  min-height: clamp(56px, 7vh, 64px);
   box-sizing: border-box;
 }
 
 .preloader__tagline {
   margin: 0;
-  max-width: 420px;
+  max-width: min(420px, 100%);
   color: #ffffff;
-  font-size: 20px;
+  font-size: clamp(18px, 5vw, 20px);
+  text-wrap: balance;
 }
 
 .preloader__secondary-button {
@@ -111,16 +113,15 @@ body {
   align-items: center;
   justify-content: center;
   gap: 12px;
-  width: 420px;
-  max-width: 100%;
-  min-height: 64px;
+  width: 100%;
+  min-height: clamp(56px, 7vh, 64px);
   margin: 0;
   box-sizing: border-box;
   border: 2px solid rgba(255, 255, 255, 0.25);
   border-radius: 12px;
   color: #ffffff;
   text-decoration: none;
-  font-size: 20px;
+  font-size: clamp(18px, 5vw, 20px);
   font-weight: 700;
   background-color: transparent;
   transition: transform 0.25s ease, box-shadow 0.25s ease;
@@ -137,7 +138,7 @@ body {
 
 .preloader__link {
   color: #ffffff;
-  font-size: 20px;
+  font-size: clamp(18px, 5vw, 20px);
   text-decoration: underline;
   margin-top: 8px;
   display: inline-block;
@@ -168,7 +169,7 @@ body {
 }
 
 .preloader__error {
-  max-width: 420px;
+  max-width: min(420px, 100%);
   margin: 0;
   color: #ff6b6b;
   font-size: 16px;
@@ -177,14 +178,19 @@ body {
 
 @media (max-width: 480px) {
   .preloader {
-    padding: 16px;
-    padding-top: calc(16px + env(safe-area-inset-top, 0px));
-    padding-bottom: calc(16px + env(safe-area-inset-bottom, 0px));
-    padding-left: calc(16px + env(safe-area-inset-left, 0px));
-    padding-right: calc(16px + env(safe-area-inset-right, 0px));
+    justify-content: flex-start;
+    align-items: center;
+    gap: 24px;
+    padding-top: calc(
+      24px + env(safe-area-inset-top, 0px)
+    );
   }
   .preloader__form {
     max-width: none;
+  }
+  .preloader__logo {
+    width: clamp(140px, 35vw, 180px);
+    height: clamp(140px, 35vw, 180px);
   }
 }
 .visually-hidden {

--- a/html/register.html
+++ b/html/register.html
@@ -24,7 +24,7 @@
     <link rel="stylesheet" href="../css/signin.css" />
   </head>
   <body>
-    <div class="preloader app-safe-area">
+    <main class="preloader app-safe-area" role="main">
       <img
         class="preloader__logo"
         src="/mathmonsters/images/brand/logo.png"
@@ -32,8 +32,30 @@
         width="300"
         height="300"
       />
-      <h1 class="preloader__headline">Register</h1>
-      <form class="preloader__form" action="#" method="post" novalidate>
+      <h1 class="preloader__headline title">Register</h1>
+      <p class="preloader__tagline subtitle">
+        Create your Reef Rangers account to track progress and earn rewards.
+      </p>
+      <form
+        class="preloader__form"
+        action="#"
+        method="post"
+        novalidate
+        autocomplete="on"
+      >
+        <label class="visually-hidden" for="register-name">Name</label>
+        <input
+          class="preloader__field"
+          type="text"
+          id="register-name"
+          name="name"
+          placeholder="Name"
+          autocomplete="name"
+          inputmode="text"
+          autocapitalize="words"
+          spellcheck="false"
+          required
+        />
         <label class="visually-hidden" for="register-email">Email</label>
         <input
           class="preloader__field"
@@ -42,6 +64,9 @@
           name="email"
           placeholder="Email"
           autocomplete="email"
+          inputmode="email"
+          autocapitalize="none"
+          spellcheck="false"
           required
         />
         <label class="visually-hidden" for="register-password">Password</label>
@@ -55,13 +80,19 @@
           required
         />
         <button class="btn-primary preloader__button" type="submit">
-          <span class="preloader__button-label">Submit</span>
+          <span class="preloader__button-label">Register</span>
           <span class="preloader__spinner" aria-hidden="true"></span>
         </button>
       </form>
       <a class="preloader__link" href="signin.html">Sign In</a>
-      <p class="preloader__error" data-register-error role="alert" hidden></p>
-    </div>
+      <p
+        class="preloader__error"
+        data-register-error
+        role="alert"
+        aria-live="polite"
+        hidden
+      ></p>
+    </main>
     <script>
       window.SUPABASE_URL = 'https://jxlxpumcoihfapmrsaqd.supabase.co';
       window.SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imp4bHhwdW1jb2loZmFwbXJzYXFkIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTc0MjE3MDcsImV4cCI6MjA3Mjk5NzcwN30.PJiDPZ_Dqli_42isJexeYgsf0ebWbCSOwHtR7lsQTN0';

--- a/html/signin.html
+++ b/html/signin.html
@@ -17,7 +17,7 @@
     <link rel="stylesheet" href="../css/signin.css" />
   </head>
   <body>
-    <div class="preloader app-safe-area">
+    <main class="preloader app-safe-area" role="main">
       <img
         class="preloader__logo"
         src="/mathmonsters/images/brand/logo.png"
@@ -25,8 +25,17 @@
         width="300"
         height="300"
       />
-      <h1 class="preloader__headline">Sign In</h1>
-      <form class="preloader__form" action="#" method="post" novalidate>
+      <h1 class="preloader__headline title">Sign In</h1>
+      <p class="preloader__tagline subtitle">
+        Continue your underwater adventure by signing in to your account.
+      </p>
+      <form
+        class="preloader__form"
+        action="#"
+        method="post"
+        novalidate
+        autocomplete="on"
+      >
         <label class="visually-hidden" for="signin-email">Email</label>
         <input
           class="preloader__field"
@@ -35,6 +44,9 @@
           name="email"
           placeholder="Email"
           autocomplete="email"
+          inputmode="email"
+          autocapitalize="none"
+          spellcheck="false"
           required
         />
         <label class="visually-hidden" for="signin-password">Password</label>
@@ -45,16 +57,23 @@
           name="password"
           placeholder="Password"
           autocomplete="current-password"
+          inputmode="text"
           required
         />
         <button class="btn-primary preloader__button" type="submit">
-          <span class="preloader__button-label">Submit</span>
+          <span class="preloader__button-label">Sign In</span>
           <span class="preloader__spinner" aria-hidden="true"></span>
         </button>
       </form>
       <a class="preloader__link" href="register.html">Register</a>
-      <p class="preloader__error" data-signin-error role="alert" hidden></p>
-    </div>
+      <p
+        class="preloader__error"
+        data-signin-error
+        role="alert"
+        aria-live="polite"
+        hidden
+      ></p>
+    </main>
     <script>
       window.SUPABASE_URL = 'https://jxlxpumcoihfapmrsaqd.supabase.co';
       window.SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imp4bHhwdW1jb2loZmFwbXJzYXFkIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTc0MjE3MDcsImV4cCI6MjA3Mjk5NzcwN30.PJiDPZ_Dqli_42isJexeYgsf0ebWbCSOwHtR7lsQTN0';


### PR DESCRIPTION
## Summary
- refine the sign-in and registration layouts to match the welcome page experience and improve accessibility
- add the missing name field and enhanced autocomplete hints to the registration form
- update shared auth styling to better scale on small screens with adaptive spacing and scroll handling

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cdec335db88329ab59ca1da0c6557f