### PR TITLE
Fix asset base fallback so battle hero sprite loads

### DIFF
--- a/js/loader.js
+++ b/js/loader.js
@@ -2,6 +2,41 @@
 const STORAGE_KEY_PROGRESS = 'reefRangersProgress';
 const FALLBACK_ASSET_BASE = '/mathmonsters';
 
+const deriveBaseFromLocation = (fallbackBase) => {
+  if (typeof window === 'undefined') {
+    return fallbackBase || '.';
+  }
+
+  const rawFallback =
+    typeof fallbackBase === 'string' ? fallbackBase.trim() : '';
+  const locationPath =
+    typeof window.location?.pathname === 'string'
+      ? window.location.pathname
+      : '';
+
+  if (rawFallback && locationPath.startsWith(rawFallback)) {
+    return fallbackBase;
+  }
+
+  const withoutQuery = locationPath.replace(/[?#].*$/, '');
+  const trimmedPath = withoutQuery.replace(/\/+$/, '');
+  const segments = trimmedPath.split('/').filter(Boolean);
+
+  if (segments.length === 0) {
+    return '.';
+  }
+
+  const lastSegment = segments[segments.length - 1] || '';
+  const treatAsDirectory = lastSegment && !lastSegment.includes('.');
+  const depth = treatAsDirectory ? segments.length : segments.length - 1;
+
+  if (depth <= 0) {
+    return '.';
+  }
+
+  return Array(depth).fill('..').join('/');
+};
+
 const determineAssetBasePath = () => {
   const fallbackBase = FALLBACK_ASSET_BASE;
   const doc = typeof document !== 'undefined' ? document : null;
@@ -41,10 +76,11 @@ const determineAssetBasePath = () => {
     }
   }
 
-  if (typeof window !== 'undefined') {
-    window.mathMonstersAssetBase = fallbackBase;
+  const derivedBase = deriveBaseFromLocation(fallbackBase);
+  if (typeof window !== 'undefined' && derivedBase) {
+    window.mathMonstersAssetBase = derivedBase;
   }
-  return fallbackBase;
+  return derivedBase || fallbackBase;
 };
 
 const ASSET_BASE_PATH = determineAssetBasePath();


### PR DESCRIPTION
## Summary
- derive a relative asset base from the current location when the `data-asset-base` attribute is unavailable
- apply the derived base in both the loader and battle scripts so assets resolve without the `/mathmonsters` prefix

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cdefc9301c83299a53eafbd2ccc615