### PR TITLE
Adjust layout for welcome, loading, and battle screens

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -17,8 +17,8 @@ body {
 #battle-monster,
 #battle-shellfin {
   position: absolute;
-  width: 300px;
-  max-width: 80vw;
+  width: clamp(120px, 26vw, 320px);
+  height: auto;
   opacity: 0;
   filter: blur(18px);
   transform: translateZ(0);
@@ -41,13 +41,13 @@ body {
 }
 
 #battle-monster {
-  top: 10%;
-  left: 55%;
+  top: clamp(32px, 12vh, 160px);
+  left: clamp(16px, 24vw, 55%);
 }
 
 #battle-shellfin {
-  bottom: 10%;
-  right: 55%;
+  bottom: clamp(32px, 14vh, 160px);
+  right: clamp(16px, 24vw, 55%);
   transform: translateZ(0) scaleX(-1);
   transform-origin: center;
 }

--- a/css/index.css
+++ b/css/index.css
@@ -375,7 +375,7 @@ body:not(.is-preloading) main.landing {
 /* Simple preload experience ---------------------------------------------- */
 
 .preloader {
-  --app-safe-area-padding: 32px;
+  --app-safe-area-padding: clamp(24px, 6vw, 48px);
   position: fixed;
   inset: 0;
   display: flex;
@@ -387,6 +387,19 @@ body:not(.is-preloading) main.landing {
   z-index: 10;
   text-align: center;
   transition: opacity 0.4s ease;
+  padding-top: calc(
+    var(--app-safe-area-padding) + env(safe-area-inset-top, 0px)
+  );
+  padding-bottom: calc(
+    var(--app-safe-area-padding) + env(safe-area-inset-bottom, 0px)
+  );
+  padding-left: calc(
+    var(--app-safe-area-padding) + env(safe-area-inset-left, 0px)
+  );
+  padding-right: calc(
+    var(--app-safe-area-padding) + env(safe-area-inset-right, 0px)
+  );
+  box-sizing: border-box;
 }
 
 .preloader__logo {

--- a/css/signin.css
+++ b/css/signin.css
@@ -178,11 +178,14 @@ body {
 
 @media (max-width: 480px) {
   .preloader {
-    justify-content: flex-start;
+    justify-content: center;
     align-items: center;
     gap: 24px;
     padding-top: calc(
       24px + env(safe-area-inset-top, 0px)
+    );
+    padding-bottom: calc(
+      24px + env(safe-area-inset-bottom, 0px)
     );
   }
   .preloader__form {


### PR DESCRIPTION
## Summary
- center the welcome screen preloader layout on small screens while preserving safe-area spacing
- add safe-area aware padding to the landing preloader so loading content stays centered across devices
- resize and reposition battle characters with responsive clamps to keep the hero sprite visible during fights

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cdf605ace08329b220d12371e60adb