### PR TITLE
Refine battle intro sequence and ensure hero fallback

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -274,8 +274,8 @@ button:focus-visible {
     env(safe-area-inset-bottom, 0px)
   );
   transform: translateX(-50%);
-  width: min(420px, calc(100% - 32px));
-  margin: 0;
+  width: min(420px, calc(100% - 48px));
+  margin: 24px;
   padding: 24px 28px 28px;
   gap: 20px;
   z-index: 6;

--- a/css/index.css
+++ b/css/index.css
@@ -316,11 +316,19 @@ body:not(.is-preloading) main.landing {
   animation: battle-intro-pop 0.6s cubic-bezier(0.16, 1, 0.3, 1) forwards;
 }
 
+.battle-intro.is-hiding .battle-intro__image {
+  animation: battle-intro-pop-out 0.45s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
 .battle-intro.is-reduced-motion .battle-intro__image {
   transform: scale(1);
 }
 
 .battle-intro.is-reduced-motion.is-visible .battle-intro__image {
+  animation: none;
+}
+
+.battle-intro.is-reduced-motion.is-hiding .battle-intro__image {
   animation: none;
 }
 
@@ -333,6 +341,20 @@ body:not(.is-preloading) main.landing {
   }
   100% {
     transform: scale(1);
+  }
+}
+
+@keyframes battle-intro-pop-out {
+  0% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  45% {
+    transform: scale(1.12);
+  }
+  100% {
+    transform: scale(0.2);
+    opacity: 0;
   }
 }
 


### PR DESCRIPTION
## Summary
- add spacing to the landing battle card and extend the battle intro animations for hide/show states
- orchestrate the landing transition so the hero, card, and intro art run sequentially with one second pauses
- provide a resilient default hero definition and sprite fallback so the battle scene always loads hero data

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ce069e5b688329a06303469074734e