### PR TITLE
Update battle UI and fix sprite paths

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -97,9 +97,7 @@ body {
 }
 
 .stat-box .stats {
-  display: flex;
-  gap: 16px;
-  align-items: center;
+  display: none;
 }
 
 .stat-box .stat {
@@ -304,30 +302,6 @@ body {
   margin-top: 0;
 }
 
-.battle-stat-banner {
-  margin: 40px auto 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 48px;
-}
-
-.battle-stat-banner .stat {
-  display: flex;
-  align-items: baseline;
-  gap: 8px;
-}
-
-.battle-stat-banner .label {
-  font-size: 18px;
-  color: rgba(255, 255, 255, 0.5);
-}
-
-.battle-stat-banner .value {
-  font-size: 18px;
-  color: #ffffff;
-  text-transform: none;
-}
 
 .battle-dev-controls {
   position: fixed;

--- a/css/index.css
+++ b/css/index.css
@@ -112,6 +112,7 @@ body:not(.is-preloading) main.landing {
 
 .card--home.is-battle-transition {
   will-change: transform, opacity;
+  animation: card-pop-out 0.45s cubic-bezier(0.16, 1, 0.3, 1) forwards;
 }
 
 @keyframes card-pop-out {

--- a/html/battle.html
+++ b/html/battle.html
@@ -15,16 +15,6 @@
     <link rel="stylesheet" href="../css/battle.css" />
   </head>
   <body>
-  <div class="battle-stat-banner" aria-live="polite">
-    <div class="stat">
-      <span class="label">Accuracy</span>
-      <span class="value" data-banner-accuracy>0%</span>
-    </div>
-    <div class="stat">
-      <span class="label">Time</span>
-      <span class="value" data-banner-time>0s</span>
-    </div>
-  </div>
   <div class="battle-dev-controls" role="group" aria-label="Battle test controls">
     <button type="button" class="battle-dev-controls__btn" data-dev-set-streak>
       Set Streak 4
@@ -40,7 +30,7 @@
     </button>
   </div>
   <div id="battle">
-    <img id="battle-monster" src="../images/battle/monster_battle_1.png" alt="Monster" />
+    <img id="battle-monster" src="../images/battle/monster_battle_1_1.png" alt="Monster" />
     <img
       id="battle-shellfin"
       src="../images/characters/shellfin_level_1.png"
@@ -109,7 +99,7 @@
         </div>
         <img
           class="enemy-image"
-          src="../images/battle/monster_battle_1.png"
+          src="../images/battle/monster_battle_1_1.png"
           alt="Enemy defeated in battle"
         />
         <p class="battle-goals-title">Battle Goals</p>

--- a/sw.js
+++ b/sw.js
@@ -22,7 +22,7 @@ const OFFLINE_ASSETS = [
   'images/brand/logo.png',
   'images/characters/shellfin_level_1.png',
   'images/battle/battle.png',
-  'images/battle/monster_battle_1.png',
+  'images/battle/monster_battle_1_1.png',
   'images/questions/sword.svg',
   'images/questions/shield.svg',
   'images/questions/streak.svg',


### PR DESCRIPTION
## Summary
- remove the unused battle stat banner and hide in-battle stat rows
- ensure the landing battle card animates out with the rest of the screen
- correct monster sprite paths and cached assets so battle art loads properly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce173572d08329a9eedb307aeaab14