### PR TITLE
Fix duplicate asset base prefix in loader

### DIFF
--- a/js/loader.js
+++ b/js/loader.js
@@ -121,11 +121,7 @@ const normalizeAssetPath = (inputPath) => {
   trimmed = trimmed.replace(/^\/+/, '');
 
   const fallbackNormalized = FALLBACK_ASSET_BASE.replace(/^\/+/, '');
-  if (
-    fallbackNormalized &&
-    ASSET_BASE_PATH !== FALLBACK_ASSET_BASE &&
-    trimmed.startsWith(`${fallbackNormalized}/`)
-  ) {
+  if (fallbackNormalized && trimmed.startsWith(`${fallbackNormalized}/`)) {
     trimmed = trimmed.slice(fallbackNormalized.length + 1);
   }
 


### PR DESCRIPTION
## Summary
- adjust loader asset path normalization to strip duplicate fallback prefixes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce1878bfd88329971780b27ccf014c