### PR TITLE
Improve logout, landing animation, and question selection

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -157,29 +157,33 @@ const runBattleIntroSequence = async () => {
       return true;
     }
 
-    if (element.classList.contains(className)) {
-      return true;
-    }
-
     return new Promise((resolve) => {
-      const handleAnimationEnd = (event) => {
-        if (event.target !== element) {
+      let resolved = false;
+      const cleanup = () => {
+        if (resolved) {
           return;
         }
+        resolved = true;
         element.removeEventListener('animationend', handleAnimationEnd);
         resolve(true);
       };
 
+      const handleAnimationEnd = (event) => {
+        if (event.target !== element) {
+          return;
+        }
+        cleanup();
+      };
+
       element.addEventListener('animationend', handleAnimationEnd);
 
+      element.classList.remove(className);
       // Force layout before toggling class to ensure animation runs consistently.
       void element.offsetWidth;
       element.classList.add(className);
 
-      window.setTimeout(() => {
-        element.removeEventListener('animationend', handleAnimationEnd);
-        resolve(true);
-      }, durationMs + 100);
+      const timeoutDuration = Number.isFinite(durationMs) ? durationMs : 0;
+      window.setTimeout(cleanup, timeoutDuration + 100);
     });
   };
 

--- a/js/question.js
+++ b/js/question.js
@@ -12,34 +12,113 @@ const getAssetBasePath = () => {
 
 document.addEventListener('DOMContentLoaded', () => {
   const questionBox = document.getElementById('question');
+  if (!questionBox) {
+    return;
+  }
+
   const choicesContainer = questionBox.querySelector('.choices');
   const button = questionBox.querySelector('button');
+
+  if (!choicesContainer || !button) {
+    return;
+  }
+
   const assetBase = getAssetBasePath();
   const trimmedBase = assetBase.endsWith('/')
     ? assetBase.slice(0, -1)
     : assetBase;
 
-  button.disabled = true;
+  const setSubmitDisabled = (isDisabled) => {
+    button.disabled = isDisabled;
+    button.setAttribute('aria-disabled', isDisabled ? 'true' : 'false');
+  };
 
-  choicesContainer.addEventListener('click', (e) => {
-    const choice = e.target.closest('.choice');
-    if (!choice) return;
+  const clearChoiceSelections = () => {
+    choicesContainer
+      .querySelectorAll('.choice')
+      .forEach((choice) => {
+        choice.classList.remove('selected', 'correct-choice', 'wrong-choice');
+        choice.setAttribute('aria-checked', 'false');
+      });
+  };
 
-    Array.from(choicesContainer.children).forEach((c) => c.classList.remove('selected'));
+  const activateChoice = (choice) => {
+    if (!choice || !choice.classList) {
+      return;
+    }
+
+    clearChoiceSelections();
     choice.classList.add('selected');
-    button.disabled = false;
+    choice.setAttribute('aria-checked', 'true');
+    if (typeof choice.focus === 'function') {
+      try {
+        choice.focus({ preventScroll: true });
+      } catch (error) {
+        choice.focus();
+      }
+    }
+    setSubmitDisabled(false);
+  };
+
+  const findChoiceFromEvent = (event) => {
+    const target = event?.target;
+    if (!(target instanceof Element)) {
+      return null;
+    }
+    return target.closest('.choice');
+  };
+
+  const handleChoiceActivation = (event) => {
+    const choice = findChoiceFromEvent(event);
+    if (!choice) {
+      return;
+    }
+
+    if (typeof event?.preventDefault === 'function') {
+      event.preventDefault();
+    }
+    if (typeof event?.stopPropagation === 'function') {
+      event.stopPropagation();
+    }
+
+    activateChoice(choice);
+  };
+
+  const pointerEventsSupported =
+    typeof window !== 'undefined' && 'PointerEvent' in window;
+
+  if (pointerEventsSupported) {
+    choicesContainer.addEventListener('pointerup', handleChoiceActivation);
+  }
+
+  choicesContainer.addEventListener('click', (event) => {
+    if (pointerEventsSupported && event.detail !== 0) {
+      return;
+    }
+    handleChoiceActivation(event);
   });
+
+  choicesContainer.addEventListener('keydown', (event) => {
+    if (event.key !== 'Enter' && event.key !== ' ') {
+      return;
+    }
+    handleChoiceActivation(event);
+  });
+
+  setSubmitDisabled(true);
 
   button.addEventListener('click', () => {
     const choice = choicesContainer.querySelector('.choice.selected');
-    if (!choice) return;
+    if (!choice) {
+      return;
+    }
 
-    button.disabled = true;
+    setSubmitDisabled(true);
     const isCorrect = choice.dataset.correct === 'true';
 
-    Array.from(choicesContainer.children).forEach((c) =>
-      c.classList.remove('selected')
-    );
+    clearChoiceSelections();
+    choice.setAttribute('aria-checked', 'true');
+
     if (isCorrect) {
       choice.classList.add('correct-choice');
     } else {
@@ -60,23 +139,30 @@ document.addEventListener('DOMContentLoaded', () => {
     document.dispatchEvent(
       new CustomEvent('answer-submitted', { detail: { correct: isCorrect } })
     );
-
   });
 
   function closeQuestion() {
-    function handleFade(e) {
-      if (e.propertyName === 'opacity') {
-        questionBox.removeEventListener('transitionend', handleFade);
-        button.classList.remove('result', 'correct', 'incorrect');
-        button.textContent = 'Submit';
-        Array.from(choicesContainer.children).forEach((c) =>
-          c.classList.remove('selected', 'correct-choice', 'wrong-choice')
-        );
+    const handleFade = (e) => {
+      if (e.propertyName !== 'opacity') {
+        return;
       }
-    }
+      questionBox.removeEventListener('transitionend', handleFade);
+      button.classList.remove('result', 'correct', 'incorrect');
+      button.textContent = 'Submit';
+      clearChoiceSelections();
+      setSubmitDisabled(true);
+    };
+
     questionBox.addEventListener('transitionend', handleFade);
     questionBox.classList.remove('show');
   }
 
   document.addEventListener('close-question', closeQuestion);
+
+  document.addEventListener('question-opened', () => {
+    button.classList.remove('result', 'correct', 'incorrect');
+    button.textContent = 'Submit';
+    clearChoiceSelections();
+    setSubmitDisabled(true);
+  });
 });


### PR DESCRIPTION
## Summary
- ensure the landing card animation replays by resetting the CSS class before running battle transitions
- expand the dev log out control to fully sign out, clear client storage, and wipe caches before returning to the index
- harden the battle question UI so choices are selectable with pointer, keyboard, and screen readers while resetting state between questions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce1e1ed3688329a3453c0b1b4c293b