### PR TITLE
Fix home card pop animation translation

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -117,14 +117,14 @@ body:not(.is-preloading) main.landing {
 
 @keyframes card-pop-out {
   0% {
-    transform: scale(1);
+    transform: translateX(-50%) scale(1);
     opacity: 1;
   }
   55% {
-    transform: scale(1.08);
+    transform: translateX(-50%) scale(1.08);
   }
   100% {
-    transform: scale(0.85);
+    transform: translateX(-50%) scale(0.85);
     opacity: 0;
   }
 }


### PR DESCRIPTION
## Summary
- ensure the home battle card's pop-out animation preserves its centered position
- update the keyframe transforms to include the translateX offset when scaling

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cf38278434832993febf3ee0684dbc