### PR TITLE
Fix question progress selectors in battle scene

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -72,8 +72,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const questionText = questionBox.querySelector('.question-text');
   const choicesEl = questionBox.querySelector('.choices');
   const topBar = questionBox.querySelector('.top-bar');
-  const progressBar = questionBox.querySelector('.progress-bar');
-  const progressFill = questionBox.querySelector('.progress-fill');
+  const progressBar =
+    questionBox.querySelector('.progress-bar') ||
+    questionBox.querySelector('.progress');
+  const progressFill =
+    questionBox.querySelector('.progress-fill') ||
+    questionBox.querySelector('.progress__fill');
   const streakLabel = questionBox.querySelector('.streak-label');
   const streakIcon = questionBox.querySelector('.streak-icon');
   const bannerAccuracyValue = document.querySelector('[data-banner-accuracy]');
@@ -587,17 +591,21 @@ document.addEventListener('DOMContentLoaded', () => {
     const percent = Math.min(streak / STREAK_GOAL, 1) * 100;
     if (streak > 0) {
       topBar?.classList.add('show');
-      progressBar.classList.add('with-label');
-      void progressFill.offsetWidth;
-      progressFill.style.width = percent + '%';
+      progressBar?.classList.add('with-label');
+      if (progressFill) {
+        void progressFill.offsetWidth;
+        progressFill.style.width = percent + '%';
+      }
       if (streakMaxed) {
-        progressFill.style.background = '#FF6A00';
+        if (progressFill) {
+          progressFill.style.background = '#FF6A00';
+        }
         streakLabel.textContent = '2x Attack';
         streakLabel.style.color = '#FF6A00';
         streakLabel.classList.remove('show');
         void streakLabel.offsetWidth;
         streakLabel.classList.add('show');
-        if (streakIcon && !streakIconShown) {
+        if (progressFill && streakIcon && !streakIconShown) {
           progressFill.addEventListener(
             'transitionend',
             () => {
@@ -608,7 +616,9 @@ document.addEventListener('DOMContentLoaded', () => {
           streakIconShown = true;
         }
       } else {
-        progressFill.style.background = '#006AFF';
+        if (progressFill) {
+          progressFill.style.background = '#006AFF';
+        }
         streakLabel.style.color = '#006AFF';
         streakLabel.textContent = `${streak} in a row`;
         streakLabel.classList.remove('show');
@@ -621,9 +631,11 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     } else {
       topBar?.classList.remove('show');
-      progressBar.classList.remove('with-label');
-      progressFill.style.width = '0%';
-      progressFill.style.background = '#006AFF';
+      progressBar?.classList.remove('with-label');
+      if (progressFill) {
+        progressFill.style.width = '0%';
+        progressFill.style.background = '#006AFF';
+      }
       streakLabel.classList.remove('show');
       if (streakIcon) {
         streakIcon.classList.remove('show');


### PR DESCRIPTION
## Summary
- update the battle question progress selectors to match the markup used on the page
- guard streak UI updates so they handle missing progress elements gracefully

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cf37e6bb6c832986aa6fe5d2925790