### PR TITLE
Align data assets with available sprites

### DIFF
--- a/data/levels.json
+++ b/data/levels.json
@@ -21,7 +21,7 @@
         },
         "enemy": {
           "id": "octomurk",
-          "sprite": "/mathmonsters/images/battle/monster_battle_1.png",
+          "sprite": "/mathmonsters/images/battle/monster_battle_1_1.png",
           "name": "Octomurk",
           "attack": 1,
           "health": 20,
@@ -50,7 +50,7 @@
         },
         "enemy": {
           "id": "octomurk",
-          "sprite": "/mathmonsters/images/battle/monster_battle_2.png",
+          "sprite": "/mathmonsters/images/battle/monster_battle_1_2.png",
           "name": "Octomurk",
           "attack": 2,
           "health": 40,
@@ -71,7 +71,7 @@
         "streakGoal": 3,
         "hero": {
           "id": "shellfin",
-          "sprite": "/mathmonsters/images/characters/shellfin_level_2.png",
+          "sprite": "/mathmonsters/images/characters/shellfin_attack_basic_1.png",
           "name": "Shellfin",
           "attack": 3,
           "health": 9,
@@ -79,7 +79,7 @@
         },
         "enemy": {
           "id": "octomurk",
-          "sprite": "/mathmonsters/images/battle/monster_battle_2.png",
+          "sprite": "/mathmonsters/images/battle/monster_battle_1_3.png",
           "name": "Octomurk",
           "attack": 3,
           "health": 60,
@@ -96,11 +96,11 @@
           "file": "questions/level_4_questions.json"
         },
         "accuracyGoal": 0.8,
-        "timeGoalSeconds":240,
+        "timeGoalSeconds": 240,
         "streakGoal": 3,
         "hero": {
           "id": "shellfin",
-          "sprite": "/mathmonsters/images/characters/shellfin_level_2.png",
+          "sprite": "/mathmonsters/images/characters/shellfin_attack_basic_2.png",
           "name": "Shellfin",
           "attack": 4,
           "health": 12,
@@ -108,7 +108,7 @@
         },
         "enemy": {
           "id": "octomurk",
-          "sprite": "/mathmonsters/images/battle/monster_battle_2.png",
+          "sprite": "/mathmonsters/images/battle/monster_battle_1_1.png",
           "name": "Octomurk",
           "attack": 4,
           "health": 80,
@@ -129,7 +129,7 @@
         "streakGoal": 3,
         "hero": {
           "id": "shellfin",
-          "sprite": "/mathmonsters/images/characters/shellfin_level_2.png",
+          "sprite": "/mathmonsters/images/characters/shellfin_attack_super_1.png",
           "name": "Shellfin",
           "attack": 5,
           "health": 15,
@@ -137,7 +137,7 @@
         },
         "enemy": {
           "id": "octomurk",
-          "sprite": "/mathmonsters/images/battle/monster_battle_2.png",
+          "sprite": "/mathmonsters/images/battle/monster_battle_1_2.png",
           "name": "Octomurk",
           "attack": 5,
           "health": 100,
@@ -158,7 +158,7 @@
         "streakGoal": 3,
         "hero": {
           "id": "shellfin",
-          "sprite": "/mathmonsters/images/characters/shellfin_level_6.png",
+          "sprite": "/mathmonsters/images/characters/shellfin_attack_super_1.png",
           "name": "Shellfin",
           "attack": 6,
           "health": 18,
@@ -166,7 +166,7 @@
         },
         "enemy": {
           "id": "octomurk",
-          "sprite": "/mathmonsters/images/battle/monster_battle_6.png",
+          "sprite": "/mathmonsters/images/battle/monster_battle_1_3.png",
           "name": "Octomurk",
           "attack": 6,
           "health": 120,

--- a/data/variables.json
+++ b/data/variables.json
@@ -19,35 +19,33 @@
         "battleLevel": 3,
         "hero": {
           "id": "shellfin",
-          "sprite": "/mathmonsters/images/characters/shellfin_level_3.png"
+          "sprite": "/mathmonsters/images/characters/shellfin_attack_basic_1.png"
         }
       },
       {
         "battleLevel": 4,
         "hero": {
           "id": "shellfin",
-          "sprite": "/mathmonsters/images/characters/shellfin_level_4.png"
+          "sprite": "/mathmonsters/images/characters/shellfin_attack_basic_2.png"
         }
       },
       {
         "battleLevel": 5,
         "hero": {
           "id": "shellfin",
-          "sprite": "/mathmonsters/images/characters/shellfin_level_5.png"
+          "sprite": "/mathmonsters/images/characters/shellfin_attack_super_1.png"
         }
       },
       {
         "battleLevel": 6,
         "hero": {
           "id": "shellfin",
-          "sprite": "/mathmonsters/images/characters/shellfin_level_6.png"
+          "sprite": "/mathmonsters/images/characters/shellfin_attack_super_1.png"
         }
       }
     ]
   },
   "progress": {
-    "currentStreak": 0,
-    "accuracy": 0.0,
     "timeRemainingSeconds": null,
     "battleLevel": 1
   }

--- a/scripts/validate-data.js
+++ b/scripts/validate-data.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const projectRoot = path.resolve(__dirname, '..');
+const dataDir = path.join(projectRoot, 'data');
+const questionsDir = path.join(dataDir, 'questions');
+
+function loadJson(filePath) {
+  const absolutePath = path.isAbsolute(filePath)
+    ? filePath
+    : path.join(projectRoot, filePath);
+  try {
+    const raw = fs.readFileSync(absolutePath, 'utf8');
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Failed to load JSON from ${absolutePath}: ${error.message}`);
+  }
+}
+
+function resolveAssetToDisk(assetPath) {
+  if (typeof assetPath !== 'string') {
+    return null;
+  }
+
+  let cleaned = assetPath.trim();
+  if (!cleaned) {
+    return null;
+  }
+
+  cleaned = cleaned.replace(/[?#].*$/, '');
+
+  if (/^(?:https?:)?\/\//i.test(cleaned) || cleaned.startsWith('data:')) {
+    return null;
+  }
+
+  if (cleaned.startsWith('/mathmonsters/')) {
+    cleaned = cleaned.slice('/mathmonsters/'.length);
+  }
+
+  cleaned = cleaned.replace(/^\/+/, '');
+
+  if (!cleaned) {
+    return projectRoot;
+  }
+
+  return path.join(projectRoot, cleaned);
+}
+
+function checkAssetExists(assetPath, context, issues) {
+  const diskPath = resolveAssetToDisk(assetPath);
+  if (!diskPath) {
+    return;
+  }
+  if (!fs.existsSync(diskPath)) {
+    issues.push(`${context}: referenced asset not found -> ${assetPath}`);
+  }
+}
+
+function validateQuestionSet(fileName, issues) {
+  const absolutePath = path.join(questionsDir, fileName);
+  if (!fs.existsSync(absolutePath)) {
+    issues.push(`Question file missing: ${fileName}`);
+    return;
+  }
+
+  let data;
+  try {
+    const raw = fs.readFileSync(absolutePath, 'utf8');
+    data = JSON.parse(raw);
+  } catch (error) {
+    issues.push(`Failed to parse questions JSON (${fileName}): ${error.message}`);
+    return;
+  }
+
+  const questions = Array.isArray(data)
+    ? data
+    : Array.isArray(data?.questions)
+    ? data.questions
+    : [];
+
+  if (!questions.length) {
+    issues.push(`No questions found in ${fileName}`);
+    return;
+  }
+
+  const seenIds = new Set();
+  questions.forEach((question, index) => {
+    const prefix = `${fileName} [question ${index + 1}]`;
+    if (typeof question?.id !== 'number') {
+      issues.push(`${prefix}: missing numeric id`);
+    } else if (seenIds.has(question.id)) {
+      issues.push(`${prefix}: duplicate id ${question.id}`);
+    } else {
+      seenIds.add(question.id);
+    }
+
+    if (typeof question?.question !== 'string' || !question.question.trim()) {
+      issues.push(`${prefix}: missing question text`);
+    }
+
+    if (!Array.isArray(question?.options) || question.options.length === 0) {
+      issues.push(`${prefix}: options array is missing or empty`);
+    } else if (
+      typeof question.answer !== 'undefined' &&
+      !question.options.some((option) => option === question.answer)
+    ) {
+      issues.push(`${prefix}: answer is not one of the provided options`);
+    }
+  });
+}
+
+function validateLevels(issues) {
+  const levelsPath = path.join(dataDir, 'levels.json');
+  const levelsData = loadJson(levelsPath);
+  const levels = Array.isArray(levelsData?.levels) ? levelsData.levels : [];
+
+  levels.forEach((level, index) => {
+    const label = `Level ${index + 1}`;
+    const battle = level?.battle ?? {};
+    const hero = battle.hero ?? {};
+    const enemy = battle.enemy ?? {};
+
+    if (battle?.questionReference?.file) {
+      validateQuestionSet(battle.questionReference.file.replace(/^questions\//, ''), issues);
+    } else {
+      issues.push(`${label}: missing questionReference.file`);
+    }
+
+    checkAssetExists(hero.sprite, `${label} hero sprite`, issues);
+    checkAssetExists(enemy.sprite, `${label} enemy sprite`, issues);
+  });
+}
+
+function validateVariables(issues) {
+  const variablesPath = path.join(dataDir, 'variables.json');
+  const variablesData = loadJson(variablesPath);
+  const battles = Array.isArray(variablesData?.user?.battles)
+    ? variablesData.user.battles
+    : [];
+
+  battles.forEach((battle) => {
+    const level = typeof battle?.battleLevel === 'number' ? battle.battleLevel : 'unknown';
+    const hero = battle?.hero ?? {};
+    checkAssetExists(hero.sprite, `Variables battleLevel ${level} hero sprite`, issues);
+  });
+}
+
+function main() {
+  const issues = [];
+  try {
+    validateLevels(issues);
+    validateVariables(issues);
+  } catch (error) {
+    issues.push(error.message);
+  }
+
+  if (issues.length) {
+    console.error('Validation issues found:');
+    issues.forEach((issue) => {
+      console.error(` - ${issue}`);
+    });
+    process.exitCode = 1;
+  } else {
+    console.log('All data references look good.');
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- update level configurations to point hero and enemy sprites at existing image assets
- align stored user battle metadata with the adjusted hero art for each level
- add a validation script that checks level, variable, and question data for missing assets or malformed entries
- remove unused progress tracking fields from the stored variables data

## Testing
- node scripts/validate-data.js

------
https://chatgpt.com/codex/tasks/task_e_68cf3a84b0188329b9e08d6c973a6c7e