### PR TITLE
Replace landing card with battle link image

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -67,6 +67,41 @@ body:not(.is-preloading) main.landing {
   pointer-events: none;
 }
 
+.battle-link {
+  position: absolute;
+  left: 50%;
+  bottom: calc(24px + var(--viewport-bottom-offset, 0px));
+  bottom: calc(
+    24px + var(--viewport-bottom-offset, 0px) +
+    constant(safe-area-inset-bottom)
+  );
+  bottom: calc(
+    24px + var(--viewport-bottom-offset, 0px) +
+    env(safe-area-inset-bottom, 0px)
+  );
+  transform: translateX(-50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 6;
+  text-decoration: none;
+}
+
+.battle-link:focus-visible {
+  outline: 3px solid #fff;
+  outline-offset: 6px;
+  border-radius: 24px;
+}
+
+.battle-link__image {
+  display: block;
+  width: min(420px, calc(100vw - 64px));
+  max-width: 360px;
+  height: auto;
+  border-radius: 24px;
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.35);
+}
+
 .hero.is-battle-transition {
   animation: hero-pop-out 0.45s cubic-bezier(0.16, 1, 0.3, 1) forwards;
   will-change: transform, opacity;

--- a/index.html
+++ b/index.html
@@ -51,29 +51,20 @@
       alt="Shellfin ready for battle"
     />
 
-    <section
-      class="card card--home"
+    <a
+      class="battle-link"
       data-battle-card
-      aria-live="polite"
+      href="html/battle.html"
+      aria-label="Enter the battle"
     >
-      <div class="battle-info">
-        <p class="subtitle" data-battle-math>Math Mission</p>
-        <p class="title" data-battle-title>Battle 1</p>
-      </div>
-      <div
-        class="progress progress--green"
-        data-battle-progress
-        role="progressbar"
-        aria-valuenow="0"
-        aria-valuemin="0"
-        aria-valuemax="100"
-      >
-        <span class="progress__fill" aria-hidden="true"></span>
-      </div>
-      <button class="battle-btn" type="button" data-battle-button>
-        Let's Battle
-      </button>
-    </section>
+      <img
+        class="battle-link__image"
+        src="./images/battle/battle.png"
+        alt="Enter the battle"
+        width="350"
+        height="350"
+      />
+    </a>
   </main>
   <div class="battle-intro" data-battle-intro aria-hidden="true">
     <img


### PR DESCRIPTION
## Summary
- replace the landing battle card with a direct image link to the battle page
- add styling for the new battle link to anchor it near the bottom of the screen

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4801e525883299289a45ce43ee03f