### PR TITLE
Fix battle asset path resolution and shrink dev controls

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -305,11 +305,11 @@ body {
 
 .battle-dev-controls {
   position: fixed;
-  top: 12px;
-  right: 12px;
+  top: 8px;
+  right: 8px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 4px;
   padding: 0;
   background: none;
   border: none;
@@ -322,14 +322,14 @@ body {
 }
 
 .battle-dev-controls__btn {
-  border: 1px solid #b9c1ce;
-  background: #ffffff;
+  border: 1px solid rgba(29, 36, 51, 0.25);
+  background: rgba(255, 255, 255, 0.7);
   color: #1d2433;
-  border-radius: 0;
-  padding: 6px 10px;
+  border-radius: 2px;
+  padding: 2px 6px;
   font: inherit;
-  font-size: 14px;
-  line-height: 1.2;
+  font-size: 11px;
+  line-height: 1.1;
   cursor: pointer;
   box-shadow: none;
   text-transform: none;

--- a/js/battle.js
+++ b/js/battle.js
@@ -348,24 +348,49 @@ document.addEventListener('DOMContentLoaded', () => {
     const battleProgress =
       data.battleVariables ?? data.player?.battleVariables ?? {};
 
+    const assetBasePath = (() => {
+      const globalBase =
+        typeof window?.mathMonstersAssetBase === 'string'
+          ? window.mathMonstersAssetBase.trim()
+          : '';
+      if (globalBase) {
+        return globalBase;
+      }
+      return '..';
+    })();
+
     const resolveAssetPath = (path) => {
-      if (typeof path !== 'string' || path.trim().length === 0) {
+      if (typeof path !== 'string') {
         return null;
       }
+
       const trimmed = path.trim();
-      if (/^https?:\/\//i.test(trimmed)) {
+      if (!trimmed) {
+        return null;
+      }
+
+      if (/^https?:\/\//i.test(trimmed) || /^data:/i.test(trimmed)) {
         return trimmed;
       }
-      if (trimmed.startsWith('../')) {
+
+      if (trimmed.startsWith('../') || trimmed.startsWith('./')) {
         return trimmed;
       }
-      if (trimmed.startsWith('./')) {
-        return `../${trimmed.slice(2)}`;
-      }
+
       if (trimmed.startsWith('/')) {
-        return `..${trimmed}`;
+        return trimmed;
       }
-      return `../${trimmed}`;
+
+      const normalizedBase = assetBasePath.endsWith('/')
+        ? assetBasePath.slice(0, -1)
+        : assetBasePath;
+      const normalizedPath = trimmed.replace(/^\/+/, '');
+
+      if (!normalizedBase || normalizedBase === '.') {
+        return normalizedPath;
+      }
+
+      return `${normalizedBase}/${normalizedPath}`;
     };
 
     currentBattleLevel =


### PR DESCRIPTION
## Summary
- update the battle asset resolver to respect normalized paths provided by the loader and prevent duplicated `mathmonsters` segments
- tighten up the battle dev control button styles so they stay small and unobtrusive during gameplay

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d4866b8aac83298138c5228c33589f