### PR TITLE
Adjust battle launch timing and animation

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -5,8 +5,6 @@ const PROGRESS_STORAGE_KEY = 'reefRangersProgress';
 const GUEST_SESSION_KEY = 'reefRangersGuestSession';
 const MIN_PRELOAD_DURATION_MS = 2000;
 const HERO_CARD_POP_DURATION_MS = 450;
-const BATTLE_INTRO_POP_IN_DURATION_MS = 600;
-const BATTLE_INTRO_POP_OUT_DURATION_MS = 450;
 const BATTLE_TRANSITION_PAUSE_MS = 1000;
 
 // Gentle idle motion caps (pixels)
@@ -130,22 +128,11 @@ const wait = (ms) =>
   });
 
 const runBattleIntroSequence = async () => {
-  const intro = document.querySelector('[data-battle-intro]');
   const battleCard = document.querySelector('[data-battle-card]');
   const heroImage = document.querySelector('.hero');
-
-  if (!intro) {
-    return false;
-  }
-
-  const introImage = intro.querySelector('.battle-intro__image');
   const prefersReducedMotion =
     typeof window.matchMedia === 'function' &&
     window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-
-  intro.classList.toggle('is-reduced-motion', prefersReducedMotion);
-  intro.classList.remove('is-visible');
-  intro.setAttribute('aria-hidden', 'true');
 
   const playAnimationClass = async (element, className, durationMs) => {
     if (!element) {
@@ -159,6 +146,7 @@ const runBattleIntroSequence = async () => {
 
     return new Promise((resolve) => {
       let resolved = false;
+
       const cleanup = () => {
         if (resolved) {
           return;
@@ -189,106 +177,20 @@ const runBattleIntroSequence = async () => {
 
   const pause = () => wait(BATTLE_TRANSITION_PAUSE_MS);
 
-  const heroAnimated = await playAnimationClass(
-    heroImage,
-    'is-battle-transition',
-    HERO_CARD_POP_DURATION_MS
-  );
+  await pause();
 
-  if (heroAnimated) {
-    await pause();
-  }
+  const [heroAnimated, cardAnimated] = await Promise.all([
+    playAnimationClass(heroImage, 'is-battle-transition', HERO_CARD_POP_DURATION_MS),
+    playAnimationClass(
+      battleCard,
+      'is-battle-transition',
+      HERO_CARD_POP_DURATION_MS
+    ),
+  ]);
 
-  const cardAnimated = await playAnimationClass(
-    battleCard,
-    'is-battle-transition',
-    HERO_CARD_POP_DURATION_MS
-  );
+  await pause();
 
-  if (cardAnimated) {
-    await pause();
-  }
-
-  intro.classList.add('is-visible');
-  intro.setAttribute('aria-hidden', 'false');
-
-  const playIntroImageAnimation = async (mode) => {
-    if (!introImage) {
-      return false;
-    }
-
-    if (prefersReducedMotion) {
-      if (mode === 'in') {
-        introImage.style.transform = 'scale(1)';
-        introImage.style.opacity = '1';
-      } else {
-        introImage.style.transform = 'scale(0.2)';
-        introImage.style.opacity = '0';
-      }
-      return true;
-    }
-
-    const className = mode === 'in' ? 'is-pop-in' : 'is-pop-out';
-    const durationMs =
-      mode === 'in'
-        ? BATTLE_INTRO_POP_IN_DURATION_MS
-        : BATTLE_INTRO_POP_OUT_DURATION_MS;
-
-    return new Promise((resolve) => {
-      const handleAnimationEnd = (event) => {
-        if (event.target !== introImage) {
-          return;
-        }
-        introImage.removeEventListener('animationend', handleAnimationEnd);
-        if (mode === 'out') {
-          introImage.classList.remove(className);
-        }
-        resolve(true);
-      };
-
-      const finalize = () => {
-        introImage.removeEventListener('animationend', handleAnimationEnd);
-        if (mode === 'out') {
-          introImage.classList.remove(className);
-        }
-        resolve(true);
-      };
-
-      introImage.addEventListener('animationend', handleAnimationEnd);
-
-      if (mode === 'out') {
-        introImage.classList.remove('is-pop-in');
-      } else {
-        introImage.classList.remove('is-pop-out');
-      }
-
-      void introImage.offsetWidth;
-      introImage.classList.add(className);
-
-      window.setTimeout(finalize, durationMs + 100);
-    });
-  };
-
-  const introAnimatedIn = await playIntroImageAnimation('in');
-
-  if (introAnimatedIn) {
-    await pause();
-  }
-
-  await playIntroImageAnimation('out');
-
-  intro.classList.remove('is-visible');
-  intro.setAttribute('aria-hidden', 'true');
-
-  if (introImage) {
-    introImage.classList.remove('is-pop-in', 'is-pop-out');
-    if (prefersReducedMotion) {
-      introImage.style.removeProperty('transform');
-      introImage.style.removeProperty('opacity');
-    }
-  }
-
-  return true;
+  return heroAnimated || cardAnimated;
 };
 
 (async () => {


### PR DESCRIPTION
## Summary
- wait one second after the battle CTA click before running the landing hero and card pop animations
- trigger the hero and battle card pop-out animations together and pause another second before navigation
- simplify the intro sequence logic now that the battle overlay is no longer used

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d4880b1e9c8329b8de1958b96569ec