### PR TITLE
Enhance landing battle link animations

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -98,6 +98,20 @@ body:not(.is-preloading) main.landing {
   width: min(420px, calc(100vw - 64px));
   max-width: 250px;
   height: auto;
+  transform-origin: 50% 90%;
+  will-change: transform, filter;
+  filter: drop-shadow(0 0 0 rgba(0, 196, 255, 0));
+}
+
+body:not(.is-preloading) .battle-link__image {
+  animation:
+    battle-link-bounce 2.8s cubic-bezier(0.25, 0.75, 0.25, 1) infinite,
+    battle-link-glow 3.6s ease-in-out infinite;
+}
+
+.battle-link.is-battle-transition .battle-link__image {
+  animation: battle-link-squish-out 0.55s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  filter: drop-shadow(0 0 0 rgba(0, 196, 255, 0));
 }
 
 .hero.is-battle-transition {
@@ -126,6 +140,16 @@ body:not(.is-preloading) main.landing {
   .hero.is-battle-transition {
     opacity: 0;
   }
+
+  body:not(.is-preloading) .battle-link__image {
+    animation: none;
+    filter: none;
+  }
+
+  .battle-link.is-battle-transition .battle-link__image {
+    animation: none;
+    opacity: 0;
+  }
 }
 
 @keyframes hero-pop-out {
@@ -139,6 +163,56 @@ body:not(.is-preloading) main.landing {
   }
   100% {
     transform: translate(-50%, calc(-1 * var(--hero-float-range, 32px))) scale(1.28);
+    opacity: 0;
+  }
+}
+
+@keyframes battle-link-bounce {
+  0% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  20% {
+    transform: translate3d(0, -10px, 0) scale(1.03);
+  }
+  40% {
+    transform: translate3d(0, 0, 0) scale(0.99);
+  }
+  55% {
+    transform: translate3d(0, -6px, 0) scale(1.02);
+  }
+  70% {
+    transform: translate3d(0, 0, 0) scale(0.995);
+  }
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+}
+
+@keyframes battle-link-glow {
+  0% {
+    filter: drop-shadow(0 0 0 rgba(0, 196, 255, 0));
+  }
+  45% {
+    filter: drop-shadow(0 0 22px rgba(0, 196, 255, 0.6));
+  }
+  100% {
+    filter: drop-shadow(0 0 0 rgba(0, 196, 255, 0));
+  }
+}
+
+@keyframes battle-link-squish-out {
+  0% {
+    transform: translate3d(0, 0, 0) scale(1);
+    opacity: 1;
+  }
+  30% {
+    transform: translate3d(0, 8px, 0) scale(1.08, 0.82);
+  }
+  65% {
+    transform: translate3d(0, -12px, 0) scale(0.92, 1.1);
+  }
+  100% {
+    transform: translate3d(0, 24px, 0) scale(0.72, 0.35);
     opacity: 0;
   }
 }

--- a/js/index.js
+++ b/js/index.js
@@ -5,7 +5,6 @@ const PROGRESS_STORAGE_KEY = 'reefRangersProgress';
 const GUEST_SESSION_KEY = 'reefRangersGuestSession';
 const MIN_PRELOAD_DURATION_MS = 2000;
 const HERO_CARD_POP_DURATION_MS = 450;
-const BATTLE_TRANSITION_PAUSE_MS = 1000;
 
 // Gentle idle motion caps (pixels)
 const HERO_FLOAT_MIN_PX = 5;   // tiny but visible
@@ -122,11 +121,6 @@ const startLandingExperience = () => {
   }
 };
 
-const wait = (ms) =>
-  new Promise((resolve) => {
-    window.setTimeout(resolve, ms);
-  });
-
 const runBattleIntroSequence = async () => {
   const battleCard = document.querySelector('[data-battle-card]');
   const heroImage = document.querySelector('.hero');
@@ -175,20 +169,17 @@ const runBattleIntroSequence = async () => {
     });
   };
 
-  const pause = () => wait(BATTLE_TRANSITION_PAUSE_MS);
+  const heroAnimated = await playAnimationClass(
+    heroImage,
+    'is-battle-transition',
+    HERO_CARD_POP_DURATION_MS
+  );
 
-  await pause();
-
-  const [heroAnimated, cardAnimated] = await Promise.all([
-    playAnimationClass(heroImage, 'is-battle-transition', HERO_CARD_POP_DURATION_MS),
-    playAnimationClass(
-      battleCard,
-      'is-battle-transition',
-      HERO_CARD_POP_DURATION_MS
-    ),
-  ]);
-
-  await pause();
+  const cardAnimated = await playAnimationClass(
+    battleCard,
+    'is-battle-transition',
+    HERO_CARD_POP_DURATION_MS
+  );
 
   return heroAnimated || cardAnimated;
 };


### PR DESCRIPTION
## Summary
- add an idle bounce and glow animation to the landing battle call-to-action, respecting reduced-motion preferences
- sequence the hero pop-out before a new squish-out exit for the battle link and remove the previous delay from the transition

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d48da801848329a6b34c9d495588f5