### PR TITLE
Use global orange progress bar for battle health

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -147,20 +147,14 @@ body {
   }
 }
 
-.hp-bar {
+.stat-box .battle-health {
   width: 130px;
   height: 12px;
-  border: 1px solid #fff;
-  border-radius: 4px;
   margin-top: 4px;
-  overflow: hidden;
 }
 
-.hp-fill {
-  background: #FFBB00;
+.stat-box .battle-health .progress__fill {
   height: 100%;
-  width: 100%;
-  transition: width 0.5s ease-in-out;
 }
 
 #battle-shellfin.attack {

--- a/html/battle.html
+++ b/html/battle.html
@@ -38,11 +38,31 @@
     />
     <div id="monster-stats" class="stat-box">
       <div class="name"></div>
-      <div class="hp-bar"><div class="hp-fill"></div></div>
+      <div
+        class="progress progress--orange battle-health"
+        role="progressbar"
+        aria-valuemin="0"
+        aria-valuemax="100"
+        aria-valuenow="100"
+        aria-label="Monster health"
+        style="--progress-value: 1"
+      >
+        <span class="progress__fill" aria-hidden="true"></span>
+      </div>
     </div>
     <div id="shellfin-stats" class="stat-box">
       <div class="name"></div>
-      <div class="hp-bar"><div class="hp-fill"></div></div>
+      <div
+        class="progress progress--orange battle-health"
+        role="progressbar"
+        aria-valuemin="0"
+        aria-valuemax="100"
+        aria-valuenow="100"
+        aria-label="Hero health"
+        style="--progress-value: 1"
+      >
+        <span class="progress__fill" aria-hidden="true"></span>
+      </div>
     </div>
   </div>
     <div id="question">

--- a/js/battle.js
+++ b/js/battle.js
@@ -62,8 +62,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const prefersReducedMotion = window.matchMedia(
     '(prefers-reduced-motion: reduce)'
   ).matches;
-  const monsterHpFill = document.querySelector('#monster-stats .hp-fill');
-  const heroHpFill = document.querySelector('#shellfin-stats .hp-fill');
+  const monsterHpBar = document.querySelector('#monster-stats .battle-health');
+  const monsterHpFill = monsterHpBar?.querySelector('.progress__fill') ?? null;
+  const heroHpBar = document.querySelector('#shellfin-stats .battle-health');
+  const heroHpFill = heroHpBar?.querySelector('.progress__fill') ?? null;
   const monsterNameEl = document.querySelector('#monster-stats .name');
   const heroNameEl = document.querySelector('#shellfin-stats .name');
   const monsterStats = document.getElementById('monster-stats');
@@ -480,6 +482,12 @@ document.addEventListener('DOMContentLoaded', () => {
     if (monsterHealthVal) monsterHealthVal.textContent = monster.health;
     if (heroNameEl) heroNameEl.textContent = hero.name;
     if (monsterNameEl) monsterNameEl.textContent = monster.name;
+    if (heroHpBar && hero.name) {
+      heroHpBar.setAttribute('aria-label', `${hero.name} health`);
+    }
+    if (monsterHpBar && monster.name) {
+      monsterHpBar.setAttribute('aria-label', `${monster.name} health`);
+    }
     if (completeEnemyImg && monster.name) {
       completeEnemyImg.alt = `${monster.name} ready for battle`;
     }
@@ -494,10 +502,26 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function updateHealthBars() {
-    const heroPercent = ((hero.health - hero.damage) / hero.health) * 100;
-    const monsterPercent = ((monster.health - monster.damage) / monster.health) * 100;
-    heroHpFill.style.width = heroPercent + '%';
-    monsterHpFill.style.width = monsterPercent + '%';
+    const heroPercent =
+      hero.health > 0 ? ((hero.health - hero.damage) / hero.health) * 100 : 0;
+    const monsterPercent =
+      monster.health > 0
+        ? ((monster.health - monster.damage) / monster.health) * 100
+        : 0;
+    updateHealthBar(heroHpBar, heroHpFill, heroPercent);
+    updateHealthBar(monsterHpBar, monsterHpFill, monsterPercent);
+  }
+
+  function updateHealthBar(barEl, fillEl, percent) {
+    const clampedPercent = Math.max(0, Math.min(100, Number(percent) || 0));
+    if (barEl) {
+      barEl.style.setProperty('--progress-value', `${clampedPercent / 100}`);
+      barEl.setAttribute('aria-valuenow', `${Math.round(clampedPercent)}`);
+      barEl.setAttribute('aria-valuetext', `${Math.round(clampedPercent)}%`);
+    }
+    if (fillEl) {
+      fillEl.style.width = `${clampedPercent}%`;
+    }
   }
 
   function waitForHealthDrain(fillEl) {


### PR DESCRIPTION
## Summary
- replace the battle health bar markup with the shared global progress bar using the orange theme
- update battle styles to size the global progress bar for the stat panels
- adjust battle logic to drive the new progress bars and keep accessibility labels up to date

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d48e032f60832998c93bd8ea8ca984