### PR TITLE
Limit preloader logo to 200px across entry screens

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -448,8 +448,10 @@ body:not(.is-preloading) main.landing {
 }
 
 .preloader__logo {
-  width: 300px;
-  height: 300px;
+  width: min(200px, 45vw);
+  height: min(200px, 45vw);
+  max-width: 200px;
+  max-height: 200px;
   object-fit: contain;
 }
 

--- a/css/signin.css
+++ b/css/signin.css
@@ -34,8 +34,10 @@ body {
 }
 
 .preloader__logo {
-  width: clamp(160px, 40vw, 220px);
-  height: clamp(160px, 40vw, 220px);
+  width: min(200px, 45vw);
+  height: min(200px, 45vw);
+  max-width: 200px;
+  max-height: 200px;
   object-fit: contain;
 }
 
@@ -192,8 +194,8 @@ body {
     max-width: none;
   }
   .preloader__logo {
-    width: clamp(140px, 35vw, 180px);
-    height: clamp(140px, 35vw, 180px);
+    width: min(200px, 60vw);
+    height: min(200px, 60vw);
   }
 }
 .visually-hidden {

--- a/html/register.html
+++ b/html/register.html
@@ -29,8 +29,8 @@
         class="preloader__logo"
         src="../images/brand/logo.png"
         alt="Reef Rangers logo"
-        width="300"
-        height="300"
+        width="200"
+        height="200"
       />
       <h1 class="preloader__headline title">Register</h1>
         Create your Reef Rangers account to track progress and earn rewards.

--- a/html/signin.html
+++ b/html/signin.html
@@ -22,8 +22,8 @@
         class="preloader__logo"
         src="../images/brand/logo.png"
         alt="Reef Rangers logo"
-        width="300"
-        height="300"
+        width="200"
+        height="200"
       />
       <h1 class="preloader__headline title">Sign In</h1>
         Continue your underwater adventure by signing in to your account.

--- a/html/welcome.html
+++ b/html/welcome.html
@@ -25,8 +25,8 @@
         class="preloader__logo"
         src="../images/brand/logo.png"
         alt="Reef Rangers logo"
-        width="300"
-        height="300"
+        width="200"
+        height="200"
       />
       <h1 class="preloader__headline title">Turn math into an epic adventure!</h1>
       <div class="preloader__actions">

--- a/index.html
+++ b/index.html
@@ -27,8 +27,8 @@
       class="preloader__logo"
       src="./images/brand/logo.png"
       alt="Reef Rangers logo"
-      width="300"
-      height="300"
+      width="200"
+      height="200"
     />
     <p class="preloader__text">Loading</p>
     <div class="preloader__spinner" aria-hidden="true"></div>


### PR DESCRIPTION
## Summary
- cap the preloader logo styles at 200px so the brand mark renders consistently across welcome, sign-in, register, and loading views
- update the corresponding HTML image dimensions to reinforce the new maximum size

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d48e6147288329ab327832dd9c3390