### PR TITLE
Reduce battle icon pulsation intensity

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -172,16 +172,16 @@ body:not(.is-preloading) .battle-link__image {
     transform: translate3d(0, 0, 0) scale(1);
   }
   20% {
-    transform: translate3d(0, -10px, 0) scale(1.03);
+    transform: translate3d(0, -5px, 0) scale(1.015);
   }
   40% {
-    transform: translate3d(0, 0, 0) scale(0.99);
+    transform: translate3d(0, 0, 0) scale(0.995);
   }
   55% {
-    transform: translate3d(0, -6px, 0) scale(1.02);
+    transform: translate3d(0, -3px, 0) scale(1.01);
   }
   70% {
-    transform: translate3d(0, 0, 0) scale(0.995);
+    transform: translate3d(0, 0, 0) scale(0.9975);
   }
   100% {
     transform: translate3d(0, 0, 0) scale(1);
@@ -193,7 +193,7 @@ body:not(.is-preloading) .battle-link__image {
     filter: drop-shadow(0 0 0 rgba(0, 196, 255, 0));
   }
   45% {
-    filter: drop-shadow(0 0 22px rgba(0, 196, 255, 0.6));
+    filter: drop-shadow(0 0 11px rgba(0, 196, 255, 0.3));
   }
   100% {
     filter: drop-shadow(0 0 0 rgba(0, 196, 255, 0));


### PR DESCRIPTION
## Summary
- tone down the battle link animation bounce by halving its translation and scale changes
- soften the battle icon glow by reducing drop shadow strength

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d493b5f14883298b013b1dc4df5286