### PR TITLE
Adjust battle and question UI styles

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -92,7 +92,7 @@ body {
 }
 
 .stat-box .name {
-  font-size: var(--text-size-medium);
+  font-size: var(--text-size-small);
   color: var(--text-color-light);
 }
 
@@ -104,7 +104,7 @@ body {
   position: relative;
   display: flex;
   align-items: center;
-  font-size: var(--text-size-medium);
+  font-size: var(--text-size-small);
   color: var(--text-color-light);
 }
 
@@ -149,7 +149,7 @@ body {
 
 .stat-box .battle-health {
   width: 130px;
-  height: 12px;
+  height: 16px;
   margin-top: 4px;
   background-color: rgba(255, 255, 255, 0.2);
   border: 1px solid rgba(255, 255, 255, 0.9);

--- a/css/global.css
+++ b/css/global.css
@@ -136,6 +136,22 @@ button:hover {
   );
 }
 
+button:disabled {
+  color: #272b34;
+  background-image: none;
+  background-color: #F4F6FA;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+button:disabled:hover {
+  background-image: none;
+  background-color: #F4F6FA;
+  transform: none;
+  box-shadow: none;
+}
+
 button:focus-visible {
   outline: 3px solid rgba(255, 255, 255, 0.7);
   outline-offset: 3px;

--- a/css/question.css
+++ b/css/question.css
@@ -32,7 +32,7 @@
 
 #question .card--question .title {
   width: 100%;
-  text-align: left;
+  text-align: center;
 }
 
 #question h1 {
@@ -45,7 +45,8 @@
   margin: 0;
   color: var(--text-color-dark);
   width: 100%;
-  padding-top: 16px;
+  padding: 12px 0;
+  text-align: center;
 }
 
 #question button {
@@ -53,10 +54,17 @@
 }
 
 #question button:disabled {
-  --btn-gradient-start: #d2d8e2;
-  --btn-gradient-end: #d2d8e2;
-  --btn-text-color: #272b34;
+  background-color: #F4F6FA;
+  background-image: none;
+  color: #272b34;
   cursor: not-allowed;
+  transform: none;
+}
+
+#question button:disabled:hover {
+  background-color: #F4F6FA;
+  background-image: none;
+  transform: none;
 }
 
 #question .top-bar {
@@ -77,7 +85,7 @@
 }
 
 #question .top-bar.show + .question-text {
-  padding-top: 0;
+  padding-top: 12px;
 }
 
 #question .progress-wrap {
@@ -149,14 +157,14 @@
 }
 
 #question .choice {
-  background: #F4F6FA;
+  background: transparent;
   border-radius: 12px;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   width: 100%;
-  border: 3px solid transparent;
+  border: 2px solid rgba(0, 0, 0, 0.08);
   cursor: pointer;
   padding: 16px;
   box-sizing: border-box;

--- a/html/battle.html
+++ b/html/battle.html
@@ -37,7 +37,7 @@
       alt="Shellfin"
     />
     <div id="monster-stats" class="stat-box">
-      <div class="name text-medium text-white"></div>
+      <div class="name text-small text-white"></div>
       <div
         class="progress progress--orange battle-health"
         role="progressbar"
@@ -51,7 +51,7 @@
       </div>
     </div>
     <div id="shellfin-stats" class="stat-box">
-      <div class="name text-medium text-white"></div>
+      <div class="name text-small text-white"></div>
       <div
         class="progress progress--orange battle-health"
         role="progressbar"


### PR DESCRIPTION
## Summary
- set battle stat box typography to the small type scale and align health bars to the 16px spec
- center the battle question title, update choice styling, and refresh disabled button appearance
- ensure disabled buttons share the neutral fill and hoverless state across the app

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68d4a0f94d948329a077dcce3058f38f