### PR TITLE
Keep answer button styled while locking after submission

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -142,6 +142,11 @@ button.result.incorrect {
   --btn-gradient-end: #e20000;
 }
 
+button.button--locked {
+  pointer-events: none;
+  cursor: default;
+}
+
 button:hover {
   transform: translateY(-2px);
   background-image: linear-gradient(

--- a/js/question.js
+++ b/js/question.js
@@ -32,9 +32,20 @@ document.addEventListener('DOMContentLoaded', () => {
     ? assetBase.slice(0, -1)
     : assetBase;
 
+  let submitLocked = false;
+
   const setSubmitDisabled = (isDisabled) => {
+    submitLocked = false;
+    button.classList.remove('button--locked');
     button.disabled = isDisabled;
     button.setAttribute('aria-disabled', isDisabled ? 'true' : 'false');
+  };
+
+  const lockSubmit = () => {
+    submitLocked = true;
+    button.disabled = false;
+    button.classList.add('button--locked');
+    button.setAttribute('aria-disabled', 'true');
   };
 
   const hideMeter = () => {
@@ -151,12 +162,16 @@ document.addEventListener('DOMContentLoaded', () => {
   setSubmitDisabled(true);
 
   button.addEventListener('click', () => {
+    if (submitLocked) {
+      return;
+    }
+
     const choice = choicesContainer.querySelector('.choice.selected');
     if (!choice) {
       return;
     }
 
-    setSubmitDisabled(true);
+    lockSubmit();
     const isCorrect = choice.dataset.correct === 'true';
 
     clearChoiceSelections();


### PR DESCRIPTION
## Summary
- prevent repeat submissions by locking the answer button after it is used instead of disabling it
- add a locked state that keeps the result styling while blocking further clicks
- ensure the locked state is cleared when the next question is displayed

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d4b8425bb08329a4dc81a039a32e76