### PR TITLE
Animate attack impact during battles

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -56,6 +56,48 @@ body {
   transform-origin: center;
 }
 
+.attack-effect {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: min(220px, 45vw);
+  max-width: 320px;
+  pointer-events: none;
+  opacity: 0;
+  transform: translate(-50%, -50%) scale(0.25);
+  transform-origin: center;
+  will-change: transform, opacity;
+  z-index: 15;
+  filter: drop-shadow(0 6px 14px rgba(0, 0, 0, 0.35));
+}
+
+.attack-effect.attack-effect--show {
+  animation: attack-pop 0.45s cubic-bezier(0.32, 0.72, 0, 1) forwards;
+}
+
+.attack-effect.attack-effect--visible {
+  opacity: 1;
+}
+
+@keyframes attack-pop {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.2);
+  }
+  45% {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1.15);
+  }
+  75% {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.85);
+  }
+}
+
 #monster-stats {
   top: 25%;
   left: 35%;
@@ -218,7 +260,8 @@ body {
 
 @media (prefers-reduced-motion: reduce) {
   #battle-monster,
-  #battle-shellfin {
+  #battle-shellfin,
+  .attack-effect {
     opacity: 1;
     filter: none;
     animation: none !important;
@@ -229,6 +272,10 @@ body {
     transform: none;
     filter: none;
     transition: none;
+  }
+
+  .attack-effect.attack-effect--visible {
+    opacity: 1;
   }
 }
 

--- a/data/levels.json
+++ b/data/levels.json
@@ -14,7 +14,11 @@
           "name": "Shellfin",
           "attack": 1,
           "health": 3,
-          "damage": 0
+          "damage": 0,
+          "attackSprites": {
+            "basic": "/mathmonsters/images/characters/shellfin_attack_basic_1.png",
+            "super": "/mathmonsters/images/characters/shellfin_attack_super_1.png"
+          }
         },
         "enemy": {
           "id": "octomurk",
@@ -22,7 +26,10 @@
           "name": "Octomurk",
           "attack": 1,
           "health": 20,
-          "damage": 0
+          "damage": 0,
+          "attackSprites": {
+            "basic": "/mathmonsters/images/characters/shellfin_attack_basic_2.png"
+          }
         }
       }
     },
@@ -40,7 +47,11 @@
           "name": "Shellfin",
           "attack": 2,
           "health": 6,
-          "damage": 0
+          "damage": 0,
+          "attackSprites": {
+            "basic": "/mathmonsters/images/characters/shellfin_attack_basic_1.png",
+            "super": "/mathmonsters/images/characters/shellfin_attack_super_1.png"
+          }
         },
         "enemy": {
           "id": "octomurk",
@@ -48,7 +59,10 @@
           "name": "Octomurk",
           "attack": 2,
           "health": 40,
-          "damage": 0
+          "damage": 0,
+          "attackSprites": {
+            "basic": "/mathmonsters/images/characters/shellfin_attack_basic_2.png"
+          }
         }
       }
     }

--- a/html/battle.html
+++ b/html/battle.html
@@ -36,6 +36,22 @@
       src="../images/characters/shellfin_level_1.png"
       alt="Shellfin"
     />
+    <img
+      id="monster-attack-effect"
+      class="attack-effect"
+      src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=="
+      alt=""
+      aria-hidden="true"
+      decoding="async"
+    />
+    <img
+      id="hero-attack-effect"
+      class="attack-effect"
+      src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=="
+      alt=""
+      aria-hidden="true"
+      decoding="async"
+    />
     <div id="monster-stats" class="stat-box">
       <div class="name text-small text-white"></div>
       <div

--- a/js/battle.js
+++ b/js/battle.js
@@ -57,8 +57,11 @@ document.addEventListener('DOMContentLoaded', () => {
   if (!landingVisited) {
     return;
   }
+  const battleField = document.getElementById('battle');
   const monsterImg = document.getElementById('battle-monster');
   const heroImg = document.getElementById('battle-shellfin');
+  const monsterAttackEffect = document.getElementById('monster-attack-effect');
+  const heroAttackEffect = document.getElementById('hero-attack-effect');
   const prefersReducedMotion = window.matchMedia(
     '(prefers-reduced-motion: reduce)'
   ).matches;
@@ -137,8 +140,21 @@ document.addEventListener('DOMContentLoaded', () => {
   let battleLevelAdvanced = false;
   let battleGoalsMet = false;
 
-  const hero = { attack: 1, health: 5, gems: 0, damage: 0, name: 'Hero' };
-  const monster = { attack: 1, health: 5, damage: 0, name: 'Monster' };
+  const hero = {
+    attack: 1,
+    health: 5,
+    gems: 0,
+    damage: 0,
+    name: 'Hero',
+    attackSprites: {},
+  };
+  const monster = {
+    attack: 1,
+    health: 5,
+    damage: 0,
+    name: 'Monster',
+    attackSprites: {},
+  };
 
   const markBattleReady = (img) => {
     if (!img) {
@@ -146,6 +162,79 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     img.classList.remove('slide-in');
     img.classList.add('battle-ready');
+  };
+
+  const ATTACK_EFFECT_DELAY_MS = 220;
+
+  const clearAttackEffectAnimation = (effectEl) => {
+    if (!effectEl) {
+      return;
+    }
+    effectEl.classList.remove('attack-effect--show');
+    effectEl.classList.remove('attack-effect--visible');
+  };
+
+  [heroAttackEffect, monsterAttackEffect].forEach((effectEl) => {
+    if (!effectEl) {
+      return;
+    }
+    effectEl.addEventListener('animationend', () => {
+      clearAttackEffectAnimation(effectEl);
+    });
+    effectEl.addEventListener('animationcancel', () => {
+      clearAttackEffectAnimation(effectEl);
+    });
+  });
+
+  const selectAttackSprite = (sprites, { superAttack = false } = {}) => {
+    if (!sprites || typeof sprites !== 'object') {
+      return null;
+    }
+
+    if (superAttack) {
+      return sprites.super || sprites.basic || null;
+    }
+
+    return sprites.basic || sprites.super || null;
+  };
+
+  const playAttackEffect = (targetImg, effectEl, sprites, options = {}) => {
+    if (!battleField || !targetImg || !effectEl) {
+      return;
+    }
+
+    const sprite = selectAttackSprite(sprites, options);
+    if (!sprite) {
+      return;
+    }
+
+    window.requestAnimationFrame(() => {
+      if (!battleField || !targetImg || !effectEl) {
+        return;
+      }
+
+      const battleRect = battleField.getBoundingClientRect();
+      const targetRect = targetImg.getBoundingClientRect();
+      const centerX = targetRect.left + targetRect.width / 2 - battleRect.left;
+      const centerY = targetRect.top + targetRect.height / 2 - battleRect.top;
+
+      effectEl.src = sprite;
+      effectEl.style.left = `${centerX}px`;
+      effectEl.style.top = `${centerY}px`;
+
+      effectEl.classList.remove('attack-effect--show');
+      effectEl.classList.remove('attack-effect--visible');
+      void effectEl.offsetWidth;
+
+      if (prefersReducedMotion) {
+        effectEl.classList.add('attack-effect--visible');
+        window.setTimeout(() => {
+          effectEl.classList.remove('attack-effect--visible');
+        }, 250);
+      } else {
+        effectEl.classList.add('attack-effect--show');
+      }
+    });
   };
 
   if (prefersReducedMotion) {
@@ -396,6 +485,27 @@ document.addEventListener('DOMContentLoaded', () => {
       return `${normalizedBase}/${normalizedPath}`;
     };
 
+    const isPlainObject = (value) =>
+      Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+
+    const normalizeAttackSprites = (sprites, fallback = {}) => {
+      const allowedKeys = ['basic', 'super'];
+      const source = {
+        ...(isPlainObject(fallback) ? fallback : {}),
+        ...(isPlainObject(sprites) ? sprites : {}),
+      };
+      const result = {};
+
+      allowedKeys.forEach((key) => {
+        const resolved = resolveAssetPath(source[key]);
+        if (resolved) {
+          result[key] = resolved;
+        }
+      });
+
+      return result;
+    };
+
     currentBattleLevel =
       typeof progressData.battleLevel === 'number'
         ? progressData.battleLevel
@@ -452,6 +562,14 @@ document.addEventListener('DOMContentLoaded', () => {
       hero.gems = heroData.gems;
     }
 
+    const heroAttackSprites = normalizeAttackSprites(
+      heroData.attackSprites,
+      hero.attackSprites
+    );
+    if (Object.keys(heroAttackSprites).length > 0) {
+      hero.attackSprites = heroAttackSprites;
+    }
+
     const heroSprite = resolveAssetPath(heroData.sprite);
     if (heroSprite && heroImg) {
       heroImg.src = heroSprite;
@@ -464,6 +582,14 @@ document.addEventListener('DOMContentLoaded', () => {
     monster.health = Number(enemyData.health) || monster.health;
     monster.damage = Number(enemyData.damage) || monster.damage;
     monster.name = enemyData.name || monster.name;
+
+    const monsterAttackSprites = normalizeAttackSprites(
+      enemyData.attackSprites,
+      monster.attackSprites
+    );
+    if (Object.keys(monsterAttackSprites).length > 0) {
+      monster.attackSprites = monsterAttackSprites;
+    }
 
     const monsterSprite = resolveAssetPath(enemyData.sprite);
     if (monsterSprite && monsterImg) {
@@ -768,7 +894,17 @@ document.addEventListener('DOMContentLoaded', () => {
     if (battleEnded) {
       return;
     }
+    const useSuperAttack = streakMaxed;
     heroImg.classList.add('attack');
+    const effectDelay = prefersReducedMotion ? 0 : ATTACK_EFFECT_DELAY_MS;
+    window.setTimeout(() => {
+      if (battleEnded) {
+        return;
+      }
+      playAttackEffect(monsterImg, monsterAttackEffect, hero.attackSprites, {
+        superAttack: useSuperAttack,
+      });
+    }, effectDelay);
     const handler = (e) => {
       if (e.animationName !== 'hero-attack') return;
       heroImg.classList.remove('attack');
@@ -810,6 +946,13 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
       }
       monsterImg.classList.add('attack');
+      const effectDelay = prefersReducedMotion ? 0 : ATTACK_EFFECT_DELAY_MS;
+      window.setTimeout(() => {
+        if (battleEnded) {
+          return;
+        }
+        playAttackEffect(heroImg, heroAttackEffect, monster.attackSprites);
+      }, effectDelay);
       const handler = (e) => {
         if (e.animationName !== 'monster-attack') return;
         monsterImg.classList.remove('attack');


### PR DESCRIPTION
## Summary
- add dedicated impact image elements and animation styling to the battle scene
- enrich level data and loader parsing to surface hero and enemy attack sprite paths
- trigger basic or super attack impact effects for hero and monster attacks based on the current streak

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d4b76d2d2c8329b9a9cd1ae2a45909