### PR TITLE
Remove question progress bar and smooth meter animation

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -244,6 +244,13 @@ button:focus-visible {
   width: 100%;
 }
 
+.meter__progress .progress__fill {
+  left: 0;
+  right: auto;
+  width: 0%;
+  transition: width 0.5s ease;
+}
+
 @keyframes meter-pop {
   0% {
     opacity: 0;

--- a/css/question.css
+++ b/css/question.css
@@ -74,11 +74,12 @@
   opacity: 0;
   transform: translateY(10px);
   transition: opacity 0.3s ease, transform 0.3s ease;
+  justify-content: center;
 }
 
 #question .top-bar.show {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   visibility: visible;
   opacity: 1;
   transform: translateY(0);
@@ -86,26 +87,6 @@
 
 #question .top-bar.show + .question-text {
   padding-top: 12px;
-}
-
-#question .progress-wrap {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  width: 100%;
-}
-
-#question .progress {
-  --progress-gradient-start: #36dc36;
-  --progress-gradient-end: #00b600;
-
-  width: 100%;
-  height: 16px;
-}
-
-#question .progress__fill {
-  width: 0%;
-  transition: width 0.5s ease-in-out;
 }
 
 #question .streak-label {

--- a/html/battle.html
+++ b/html/battle.html
@@ -69,18 +69,7 @@
       <section class="card card--question">
         <img class="streak-icon" src="../images/questions/streak.svg" alt="Streak" />
         <div class="top-bar">
-          <div class="progress-wrap">
-            <p class="streak-label"></p>
-            <div
-              class="progress"
-              role="progressbar"
-              aria-valuemin="0"
-              aria-valuemax="100"
-              aria-valuenow="0"
-            >
-              <span class="progress__fill" aria-hidden="true"></span>
-            </div>
-          </div>
+          <p class="streak-label"></p>
         </div>
         <p class="title question-text text-large text-dark"></p>
         <div class="choices"></div>

--- a/js/battle.js
+++ b/js/battle.js
@@ -75,12 +75,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const questionText = questionBox.querySelector('.question-text');
   const choicesEl = questionBox.querySelector('.choices');
   const topBar = questionBox.querySelector('.top-bar');
-  const progressBar =
-    questionBox.querySelector('.progress-bar') ||
-    questionBox.querySelector('.progress');
-  const progressFill =
-    questionBox.querySelector('.progress-fill') ||
-    questionBox.querySelector('.progress__fill');
   const streakLabel = questionBox.querySelector('.streak-label');
   const streakIcon = questionBox.querySelector('.streak-icon');
   const bannerAccuracyValue = document.querySelector('[data-banner-accuracy]');
@@ -685,37 +679,22 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function updateStreak() {
-    const percent = Math.min(streak / STREAK_GOAL, 1) * 100;
+    if (!streakLabel) {
+      return;
+    }
     if (streak > 0) {
       topBar?.classList.add('show');
-      progressBar?.classList.add('with-label');
-      if (progressFill) {
-        void progressFill.offsetWidth;
-        progressFill.style.width = percent + '%';
-      }
       if (streakMaxed) {
-        if (progressFill) {
-          progressFill.style.background = '#FF6A00';
-        }
         streakLabel.textContent = '2x Attack';
         streakLabel.style.color = '#FF6A00';
         streakLabel.classList.remove('show');
         void streakLabel.offsetWidth;
         streakLabel.classList.add('show');
-        if (progressFill && streakIcon && !streakIconShown) {
-          progressFill.addEventListener(
-            'transitionend',
-            () => {
-              streakIcon.classList.add('show');
-            },
-            { once: true }
-          );
+        if (streakIcon && !streakIconShown) {
+          streakIcon.classList.add('show');
           streakIconShown = true;
         }
       } else {
-        if (progressFill) {
-          progressFill.style.background = '#006AFF';
-        }
         streakLabel.style.color = '#006AFF';
         streakLabel.textContent = `${streak} in a row`;
         streakLabel.classList.remove('show');
@@ -728,11 +707,6 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     } else {
       topBar?.classList.remove('show');
-      progressBar?.classList.remove('with-label');
-      if (progressFill) {
-        progressFill.style.width = '0%';
-        progressFill.style.background = '#006AFF';
-      }
       streakLabel.classList.remove('show');
       if (streakIcon) {
         streakIcon.classList.remove('show');


### PR DESCRIPTION
## Summary
- remove the question streak progress bar markup and related styles/script handling
- simplify battle streak updates to work without the progress bar
- update the super attack meter to always animate in from the left when shown

## Testing
- no automated tests were run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d4b89cfa348329aa74e8f50c1fe3c5