### PR TITLE
Animate battle link bounce and pop

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -106,10 +106,13 @@ body:not(.is-preloading) main.landing {
 body:not(.is-preloading) .battle-link__image {
   animation:
     battle-link-glow 3.6s ease-in-out infinite;
+  animation-delay: 2s;
 }
 
 .battle-link.is-battle-transition .battle-link__image {
-  animation: battle-link-squish-out 0.55s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation:
+    battle-link-pop-out 0.45s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  animation-delay: 0.12s;
   filter: drop-shadow(0 0 0 rgba(0, 196, 255, 0));
 }
 
@@ -167,30 +170,37 @@ body:not(.is-preloading) .battle-link__image {
 }
 
 @keyframes battle-link-glow {
-  0% {
+  0%,
+  35% {
+    transform: translate3d(0, 0, 0) scale(1);
     filter: drop-shadow(0 0 0 rgba(0, 196, 255, 0));
   }
-  45% {
-    filter: drop-shadow(0 0 20px rgba(0, 196, 255, 0.6));
+  50% {
+    transform: translate3d(0, -10px, 0) scale(1.07);
+    filter: drop-shadow(0 0 20px rgba(0, 196, 255, 0.55));
   }
+  65% {
+    transform: translate3d(0, 5px, 0) scale(0.97);
+    filter: drop-shadow(0 0 12px rgba(0, 196, 255, 0.3));
+  }
+  80%,
   100% {
+    transform: translate3d(0, 0, 0) scale(1);
     filter: drop-shadow(0 0 0 rgba(0, 196, 255, 0));
   }
 }
 
-@keyframes battle-link-squish-out {
+@keyframes battle-link-pop-out {
   0% {
     transform: translate3d(0, 0, 0) scale(1);
     opacity: 1;
   }
-  30% {
-    transform: translate3d(0, 8px, 0) scale(1.08, 0.82);
-  }
-  65% {
-    transform: translate3d(0, -12px, 0) scale(0.92, 1.1);
+  60% {
+    transform: translate3d(0, 0, 0) scale(1.14);
+    opacity: 1;
   }
   100% {
-    transform: translate3d(0, 24px, 0) scale(0.72, 0.35);
+    transform: translate3d(0, 0, 0) scale(1.28);
     opacity: 0;
   }
 }


### PR DESCRIPTION
## Summary
- refine the battle link glow loop so it performs a single synchronized bounce with a 2s lead-in
- synchronize the battle link exit animation with the hero pop-out using a delayed pop animation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4bb0cdcf483299cfdee4860585001