### PR TITLE
Polish battle entry animations

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -24,6 +24,10 @@ main.landing {
   will-change: opacity, transform, filter;
 }
 
+main.landing.is-battle-transition {
+  animation: landing-battle-shift 0.6s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
 body.is-preloading {
   overflow: hidden;
 }
@@ -65,6 +69,7 @@ body:not(.is-preloading) main.landing {
   image-rendering: auto;
   z-index: 2;
   pointer-events: none;
+  will-change: transform, opacity;
 }
 
 .battle-link {
@@ -93,6 +98,15 @@ body:not(.is-preloading) main.landing {
   border-radius: 24px;
 }
 
+body.is-battle-transition {
+  cursor: progress;
+}
+
+body.is-battle-transition .landing,
+body.is-battle-transition .bubbles {
+  pointer-events: none;
+}
+
 .battle-link__image {
   display: block;
   width: min(420px, calc(100vw - 64px));
@@ -105,17 +119,23 @@ body:not(.is-preloading) main.landing {
 
 body:not(.is-preloading) .battle-link__image {
   animation:
-    battle-link-glow 3.6s ease-in-out infinite;
+    battle-link-glow 3.75s cubic-bezier(0.45, 0, 0.1, 1) infinite;
+  animation-delay: 2s;
+}
+
+.battle-link.is-battle-transition {
+  pointer-events: none;
 }
 
 .battle-link.is-battle-transition .battle-link__image {
-  animation: battle-link-squish-out 0.55s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation:
+    battle-link-pop-out 0.55s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation-delay: 0.16s;
   filter: drop-shadow(0 0 0 rgba(0, 196, 255, 0));
 }
 
 .hero.is-battle-transition {
-  animation: hero-pop-out 0.45s cubic-bezier(0.16, 1, 0.3, 1) forwards;
-  will-change: transform, opacity;
+  animation: hero-pop-out 0.65s cubic-bezier(0.22, 1, 0.36, 1) forwards;
 }
 
 @keyframes hero-float {
@@ -149,6 +169,18 @@ body:not(.is-preloading) .battle-link__image {
     animation: none;
     opacity: 0;
   }
+
+  main.landing.is-battle-transition {
+    animation: none;
+    transform: translate3d(0, 0, 0);
+    filter: none;
+  }
+
+  .bubbles.is-battle-transition {
+    animation: none;
+    transform: translateX(-50%);
+    opacity: 0;
+  }
 }
 
 @keyframes hero-pop-out {
@@ -156,48 +188,105 @@ body:not(.is-preloading) .battle-link__image {
     transform: translate(-50%, calc(-1 * var(--hero-float-range, 32px))) scale(1);
     opacity: 1;
   }
-  60% {
-    transform: translate(-50%, calc(-1 * var(--hero-float-range, 32px))) scale(1.14);
+  20% {
+    transform: translate(-50%, calc(-1 * var(--hero-float-range, 32px) + 6px)) scale(0.95);
+    opacity: 1;
+  }
+  48% {
+    transform: translate(-50%, calc(-1 * var(--hero-float-range, 32px) - 4px)) scale(1.07);
+    opacity: 1;
+  }
+  78% {
+    transform: translate(-50%, calc(-1 * var(--hero-float-range, 32px) - 24px)) scale(1.24);
     opacity: 1;
   }
   100% {
-    transform: translate(-50%, calc(-1 * var(--hero-float-range, 32px))) scale(1.28);
+    transform: translate(-50%, calc(-1 * var(--hero-float-range, 32px) - 44px)) scale(1.34);
     opacity: 0;
   }
 }
 
 @keyframes battle-link-glow {
   0% {
+    transform: translate3d(0, 0, 0) scale(1);
     filter: drop-shadow(0 0 0 rgba(0, 196, 255, 0));
   }
-  45% {
-    filter: drop-shadow(0 0 20px rgba(0, 196, 255, 0.6));
+  18% {
+    transform: translate3d(0, 4px, 0) scale(0.97);
+    filter: drop-shadow(0 6px 12px rgba(0, 196, 255, 0.14));
+  }
+  36% {
+    transform: translate3d(0, -12px, 0) scale(1.08);
+    filter: drop-shadow(0 14px 26px rgba(0, 196, 255, 0.55));
+  }
+  52% {
+    transform: translate3d(0, 5px, 0) scale(0.96);
+    filter: drop-shadow(0 10px 18px rgba(0, 196, 255, 0.28));
+  }
+  68% {
+    transform: translate3d(0, -6px, 0) scale(1.03);
+    filter: drop-shadow(0 10px 16px rgba(0, 196, 255, 0.18));
   }
   100% {
+    transform: translate3d(0, 0, 0) scale(1);
     filter: drop-shadow(0 0 0 rgba(0, 196, 255, 0));
   }
 }
 
-@keyframes battle-link-squish-out {
+@keyframes battle-link-pop-out {
   0% {
     transform: translate3d(0, 0, 0) scale(1);
     opacity: 1;
+    filter: drop-shadow(0 0 0 rgba(0, 196, 255, 0));
   }
-  30% {
-    transform: translate3d(0, 8px, 0) scale(1.08, 0.82);
+  14% {
+    transform: translate3d(0, 4px, 0) scale(0.94);
+    filter: drop-shadow(0 6px 12px rgba(0, 196, 255, 0.2));
   }
-  65% {
-    transform: translate3d(0, -12px, 0) scale(0.92, 1.1);
+  40% {
+    transform: translate3d(0, -6px, 0) scale(1.05);
+    filter: drop-shadow(0 16px 28px rgba(0, 196, 255, 0.45));
+  }
+  72% {
+    transform: translate3d(0, -18px, 0) scale(1.22);
+    filter: drop-shadow(0 20px 36px rgba(0, 196, 255, 0.6));
   }
   100% {
-    transform: translate3d(0, 24px, 0) scale(0.72, 0.35);
+    transform: translate3d(0, -36px, 0) scale(1.35);
+    opacity: 0;
+    filter: drop-shadow(0 0 0 rgba(0, 196, 255, 0));
+  }
+}
+
+@keyframes landing-battle-shift {
+  0% {
+    transform: translate3d(0, 0, 0) scale(1);
+    filter: none;
+  }
+  36% {
+    transform: translate3d(0, -6px, 0) scale(1.01);
+    filter: saturate(1.05) brightness(1.02);
+  }
+  100% {
+    transform: translate3d(0, -14px, 0) scale(1.03);
+    filter: saturate(1.12) brightness(1.05);
+  }
+}
+
+@keyframes bubble-field-fade {
+  0% {
+    transform: translate3d(-50%, 0, 0);
+    opacity: 1;
+  }
+  100% {
+    transform: translate3d(-50%, 18px, 0);
     opacity: 0;
   }
 }
 
 .card--home.is-battle-transition {
   will-change: transform, opacity;
-  animation: card-pop-out 0.45s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  animation: card-pop-out 0.58s cubic-bezier(0.22, 1, 0.36, 1) forwards;
 }
 
 @keyframes card-pop-out {
@@ -205,11 +294,16 @@ body:not(.is-preloading) .battle-link__image {
     transform: translateX(-50%) scale(1);
     opacity: 1;
   }
-  55% {
-    transform: translateX(-50%) scale(1.08);
+  25% {
+    transform: translateX(-50%) scale(0.95);
+    opacity: 1;
+  }
+  58% {
+    transform: translateX(-50%) scale(1.07);
+    opacity: 1;
   }
   100% {
-    transform: translateX(-50%) scale(0.85);
+    transform: translateX(-50%) scale(0.83);
     opacity: 0;
   }
 }
@@ -251,6 +345,11 @@ body:not(.is-preloading) .battle-link__image {
   overflow: visible;
   pointer-events: none;
   z-index: 1;
+  will-change: transform, opacity;
+}
+
+.bubbles.is-battle-transition {
+  animation: bubble-field-fade 0.5s ease forwards;
 }
 
 /* ---- Realistic bubbles ----

--- a/js/index.js
+++ b/js/index.js
@@ -4,7 +4,8 @@ const VISITED_VALUE = 'true';
 const PROGRESS_STORAGE_KEY = 'reefRangersProgress';
 const GUEST_SESSION_KEY = 'reefRangersGuestSession';
 const MIN_PRELOAD_DURATION_MS = 2000;
-const HERO_CARD_POP_DURATION_MS = 450;
+const HERO_POP_OUT_DURATION_MS = 650;
+const BATTLE_CARD_POP_DURATION_MS = 710;
 
 // Gentle idle motion caps (pixels)
 const HERO_FLOAT_MIN_PX = 5;   // tiny but visible
@@ -124,6 +125,9 @@ const startLandingExperience = () => {
 const runBattleIntroSequence = async () => {
   const battleCard = document.querySelector('[data-battle-card]');
   const heroImage = document.querySelector('.hero');
+  const landing = document.querySelector('main.landing');
+  const bubbles = document.querySelector('.bubbles');
+  const pageBody = document.body;
   const prefersReducedMotion =
     typeof window.matchMedia === 'function' &&
     window.matchMedia('(prefers-reduced-motion: reduce)').matches;
@@ -169,16 +173,28 @@ const runBattleIntroSequence = async () => {
     });
   };
 
+  if (pageBody) {
+    pageBody.classList.add('is-battle-transition');
+  }
+
+  if (landing) {
+    landing.classList.add('is-battle-transition');
+  }
+
+  if (bubbles) {
+    bubbles.classList.add('is-battle-transition');
+  }
+
   const heroAnimated = await playAnimationClass(
     heroImage,
     'is-battle-transition',
-    HERO_CARD_POP_DURATION_MS
+    HERO_POP_OUT_DURATION_MS
   );
 
   const cardAnimated = await playAnimationClass(
     battleCard,
     'is-battle-transition',
-    HERO_CARD_POP_DURATION_MS
+    BATTLE_CARD_POP_DURATION_MS
   );
 
   return heroAnimated || cardAnimated;


### PR DESCRIPTION
## Summary
- tune the battle link idle loop for a single playful bounce and glow after a 2s lead-in
- smooth the homepage-to-battle handoff by choreographing hero, link, and bubble exit animations with staged timing
- add JS hooks so the body, landing scene, and bubbles adopt the new transition states when entering battle

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4bb0cdcf483299cfdee4860585001