### PR TITLE
Allow toggling question choices

### DIFF
--- a/js/question.js
+++ b/js/question.js
@@ -175,6 +175,12 @@ document.addEventListener('DOMContentLoaded', () => {
       event.stopPropagation();
     }
 
+    if (choice.classList.contains('selected')) {
+      clearChoiceSelections();
+      setSubmitDisabled(true);
+      return;
+    }
+
     activateChoice(choice);
   };
 


### PR DESCRIPTION
## Summary
- allow question card choices to be toggled off by clicking an already-selected option
- keep submit button disabled when no choice is selected

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d55cc296cc8329a224dfe0b82d20eb