### PR TITLE
Refine battle transition scale animations

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -125,13 +125,13 @@ body:not(.is-preloading) .battle-link__image {
 
 .battle-link.is-battle-transition .battle-link__image {
   animation:
-    battle-link-scale-down 0.6s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+    battle-link-scale-down 1s cubic-bezier(0.22, 1, 0.36, 1) forwards;
   animation-delay: 0.12s;
   filter: drop-shadow(0 0 0 rgba(0, 196, 255, 0));
 }
 
 .hero.is-battle-transition {
-  animation: hero-pop-out 0.65s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation: hero-pop-out 1s cubic-bezier(0.22, 1, 0.36, 1) forwards;
 }
 
 @keyframes hero-float {
@@ -185,19 +185,19 @@ body:not(.is-preloading) .battle-link__image {
     opacity: 1;
   }
   20% {
-    transform: translate(-50%, calc(-1 * var(--hero-float-range, 32px) + 6px)) scale(0.95);
+    transform: translate(-50%, calc(-1 * var(--hero-float-range, 32px) - 4px)) scale(1.05);
     opacity: 1;
   }
-  48% {
-    transform: translate(-50%, calc(-1 * var(--hero-float-range, 32px) - 4px)) scale(1.07);
+  50% {
+    transform: translate(-50%, calc(-1 * var(--hero-float-range, 32px) - 12px)) scale(1.1);
     opacity: 1;
   }
-  78% {
-    transform: translate(-50%, calc(-1 * var(--hero-float-range, 32px) - 24px)) scale(1.24);
-    opacity: 1;
+  70% {
+    transform: translate(-50%, calc(-1 * var(--hero-float-range, 32px) - 6px)) scale(0.92);
+    opacity: 0.82;
   }
   100% {
-    transform: translate(-50%, calc(-1 * var(--hero-float-range, 32px) - 44px)) scale(1.34);
+    transform: translate(-50%, calc(-1 * var(--hero-float-range, 32px) + 4px)) scale(0.72);
     opacity: 0;
   }
 }
@@ -205,23 +205,23 @@ body:not(.is-preloading) .battle-link__image {
 @keyframes battle-link-glow {
   0%,
   30% {
-    transform: translate3d(0, 0, 0) scale(1) rotate(0deg);
+    transform: translate3d(0, 0, 0) scale(1);
     filter: drop-shadow(0 0 0 rgba(0, 196, 255, 0));
   }
   45% {
-    transform: translate3d(0, 0, 0) scale(1.05) rotate(3deg);
+    transform: translate3d(0, 0, 0) scale(1);
     filter: drop-shadow(0 0 18px rgba(0, 196, 255, 0.55));
   }
   60% {
-    transform: translate3d(0, 0, 0) scale(1.03) rotate(-2deg);
+    transform: translate3d(0, 0, 0) scale(1);
     filter: drop-shadow(0 0 12px rgba(0, 196, 255, 0.38));
   }
   75% {
-    transform: translate3d(0, 0, 0) scale(1.04) rotate(2deg);
+    transform: translate3d(0, 0, 0) scale(1);
     filter: drop-shadow(0 0 14px rgba(0, 196, 255, 0.32));
   }
   100% {
-    transform: translate3d(0, 0, 0) scale(1) rotate(0deg);
+    transform: translate3d(0, 0, 0) scale(1);
     filter: drop-shadow(0 0 0 rgba(0, 196, 255, 0));
   }
 }
@@ -231,13 +231,13 @@ body:not(.is-preloading) .battle-link__image {
     transform: translate3d(0, 0, 0) scale(1);
     opacity: 1;
   }
-  55% {
-    transform: translate3d(0, 0, 0) scale(1.06);
-    opacity: 1;
-  }
-  72% {
+  50% {
     transform: translate3d(0, 0, 0) scale(1.08);
     opacity: 1;
+  }
+  60% {
+    transform: translate3d(0, 0, 0) scale(1.05);
+    opacity: 0.96;
   }
   100% {
     transform: translate3d(0, 0, 0) scale(0.62);


### PR DESCRIPTION
## Summary
- extend the battle link scale-down animation so it briefly swells for 0.5s before shrinking and fading out
- adjust the hero battle transition animation to follow the same swell-then-shrink timing for a cohesive exit

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d56e05c2a083298cb5078290378acd