### PR TITLE
Adjust landing transition timing and update battle effects

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -60,11 +60,11 @@ body {
   position: absolute;
   top: 50%;
   left: 50%;
-  width: min(220px, 45vw);
-  max-width: 320px;
+  width: 200px;
+  height: 200px;
   pointer-events: none;
   opacity: 0;
-  transform: translate(-50%, -50%) scale(0.25);
+  transform: translate(-50%, -50%);
   transform-origin: center;
   will-change: transform, opacity;
   z-index: 15;
@@ -82,19 +82,19 @@ body {
 @keyframes attack-playful {
   0% {
     opacity: 0;
-    transform: translate(-50%, -50%) scale(0.3) rotate(-12deg);
+    transform: translate(-50%, -50%) rotate(-12deg);
   }
   45% {
     opacity: 1;
-    transform: translate(-50%, -50%) scale(1.08) rotate(8deg);
+    transform: translate(-50%, -50%) rotate(8deg);
   }
   70% {
     opacity: 1;
-    transform: translate(-50%, -50%) scale(0.95) rotate(-5deg);
+    transform: translate(-50%, -50%) rotate(-5deg);
   }
   100% {
     opacity: 1;
-    transform: translate(-50%, -50%) scale(1) rotate(0deg);
+    transform: translate(-50%, -50%) rotate(0deg);
   }
 }
 

--- a/css/index.css
+++ b/css/index.css
@@ -118,11 +118,6 @@ body.is-battle-transition .bubbles {
   filter: drop-shadow(0 0 0 rgba(0, 196, 255, 0));
 }
 
-body:not(.is-preloading) .battle-link__image {
-  animation:
-    battle-link-glow 3.6s ease-in-out infinite;
-}
-
 .battle-link.is-battle-transition .battle-link__image {
   animation:
     battle-link-scale-down 1s cubic-bezier(0.22, 1, 0.36, 1) forwards;
@@ -199,30 +194,6 @@ body:not(.is-preloading) .battle-link__image {
   100% {
     transform: translate(-50%, calc(-1 * var(--hero-float-range, 32px) + 4px)) scale(0.72);
     opacity: 0;
-  }
-}
-
-@keyframes battle-link-glow {
-  0%,
-  30% {
-    transform: translate3d(0, 0, 0) scale(1);
-    filter: drop-shadow(0 0 0 rgba(0, 196, 255, 0));
-  }
-  45% {
-    transform: translate3d(0, 0, 0) scale(1);
-    filter: drop-shadow(0 0 18px rgba(0, 196, 255, 0.55));
-  }
-  60% {
-    transform: translate3d(0, 0, 0) scale(1);
-    filter: drop-shadow(0 0 12px rgba(0, 196, 255, 0.38));
-  }
-  75% {
-    transform: translate3d(0, 0, 0) scale(1);
-    filter: drop-shadow(0 0 14px rgba(0, 196, 255, 0.32));
-  }
-  100% {
-    transform: translate3d(0, 0, 0) scale(1);
-    filter: drop-shadow(0 0 0 rgba(0, 196, 255, 0));
   }
 }
 

--- a/js/index.js
+++ b/js/index.js
@@ -6,6 +6,7 @@ const GUEST_SESSION_KEY = 'reefRangersGuestSession';
 const MIN_PRELOAD_DURATION_MS = 2000;
 const HERO_SCALE_DOWN_DURATION_MS = 600;
 const BATTLE_LINK_EXIT_DURATION_MS = 600;
+const BATTLE_TRANSITION_BUFFER_MS = 400;
 
 // Gentle idle motion caps (pixels)
 const HERO_FLOAT_MIN_PX = 5;   // tiny but visible
@@ -199,6 +200,13 @@ const runBattleIntroSequence = async () => {
   }
 
   const results = await Promise.all(animationPromises);
+
+  if (!prefersReducedMotion && BATTLE_TRANSITION_BUFFER_MS > 0) {
+    await new Promise((resolve) =>
+      window.setTimeout(resolve, BATTLE_TRANSITION_BUFFER_MS)
+    );
+  }
+
   return results.some(Boolean);
 };
 


### PR DESCRIPTION
## Summary
- remove the landing page battle button glow animation and its unused keyframes
- add a short buffer before redirecting to the battle scene so exit animations finish
- keep battle attack effect sprites at a fixed 200x200 size without scaling during animation

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d57e26c03c8329811a5d17783bb093