### PR TITLE
Use scale-down animation for card closing

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -293,7 +293,7 @@ button:focus-visible {
 }
 
 .card--closing {
-  animation: card-close 0.45s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  animation: card-close 1s cubic-bezier(0.22, 1, 0.36, 1) forwards;
 }
 
 .card .battle-info {
@@ -434,14 +434,18 @@ button:focus-visible {
 @keyframes card-close {
   0% {
     opacity: 1;
-    transform: translateY(0) scale(1);
+    transform: scale(1);
   }
-  45% {
-    opacity: 0.85;
-    transform: translateY(8px) scale(0.97);
+  50% {
+    opacity: 1;
+    transform: scale(1.08);
+  }
+  60% {
+    opacity: 0.96;
+    transform: scale(1.05);
   }
   100% {
     opacity: 0;
-    transform: translateY(24px) scale(0.9);
+    transform: scale(0.62);
   }
 }


### PR DESCRIPTION
## Summary
- update the global card closing animation to reuse the scale-down timing used on the landing page
- adjust the animation keyframes to match the battle link scale-down effect for a consistent close transition

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5953894a88329973c0e46cb17eeef