### PR TITLE
Delay battle attacks and add meter icon

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -232,6 +232,7 @@ button:focus-visible {
   justify-content: center;
   gap: 12px;
   text-align: center;
+  position: relative;
 }
 
 .meter--visible {
@@ -257,6 +258,14 @@ button:focus-visible {
   right: auto;
   width: 0%;
   transition: width 0.5s ease;
+}
+
+.meter__icon {
+  position: absolute;
+  right: 40px;
+  bottom: 20px;
+  max-width: 100%;
+  height: auto;
 }
 
 @keyframes meter-pop {

--- a/html/battle.html
+++ b/html/battle.html
@@ -100,6 +100,12 @@
           >
             <span class="progress__fill" aria-hidden="true"></span>
           </div>
+          <img
+            class="meter__icon"
+            src="../images/meter/swords.png"
+            alt=""
+            aria-hidden="true"
+          />
         </div>
         <button type="button" disabled aria-disabled="true">Submit</button>
       </section>

--- a/js/battle.js
+++ b/js/battle.js
@@ -211,6 +211,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const ANSWER_LINGER_MS = 4000;
   const QUESTION_CLOSE_GAP_MS = 300;
   const PRE_ATTACK_DELAY_MS = 1000;
+  const POST_CLOSE_ATTACK_DELAY_MS = 1000;
   const ATTACK_EFFECT_HOLD_MS = prefersReducedMotion ? 0 : 1000;
   const ATTACK_SHAKE_DURATION_MS = prefersReducedMotion ? 0 : 1000;
   const POST_ATTACK_RESUME_DELAY_MS = 1000;
@@ -1341,7 +1342,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (!battleEnded) {
         attackFn();
       }
-    }, PRE_ATTACK_DELAY_MS);
+    }, PRE_ATTACK_DELAY_MS + POST_CLOSE_ATTACK_DELAY_MS);
   };
 
   document.addEventListener('answer-submitted', (e) => {


### PR DESCRIPTION
## Summary
- delay hero and monster battle attacks by an extra second after the question card closes
- add the swords sprite to the global meter and position it in the bottom-right corner

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5a686fbf083298d5ab7a7a3cecf3d