### PR TITLE
Render landing battle badge with CSS

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -56,163 +56,291 @@ body:not(.is-preloading) main.landing {
   }
 }
 
-.hero {
-  position: absolute;
-  left: 50%;
-  top: var(--hero-top, 0px);
-  animation: hero-float 3.5s ease-in-out 1.35s infinite;
-  max-width: 300px;
-  max-height: 300px;
-  transform: translate(-50%, calc(-1 * var(--hero-float-range, 32px)));
-  transform-origin: 50% 90%;
-  --hero-float-range: 32px;
-  --hero-float-duration: 3.5s;
-  image-rendering: auto;
-  z-index: 2;
-  pointer-events: none;
-  will-change: transform, opacity;
-}
-
-.battle-link {
-  position: absolute;
-  left: 50%;
-  bottom: calc(24px + var(--viewport-bottom-offset, 0px));
-  bottom: calc(
-    24px + var(--viewport-bottom-offset, 0px) +
-    constant(safe-area-inset-bottom)
-  );
-  bottom: calc(
-    24px + var(--viewport-bottom-offset, 0px) +
-    env(safe-area-inset-bottom, 0px)
-  );
-  transform: translateX(-50%);
-  display: inline-flex;
+.battle-cast {
+  --battle-cast-hero-shift: clamp(120px, 18vw, 260px);
+  position: relative;
+  width: 100%;
+  min-height: inherit;
+  display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 6;
-  text-decoration: none;
+  padding: clamp(32px, 8vh, 96px) clamp(24px, 8vw, 96px);
+  pointer-events: none;
+  z-index: 2;
 }
 
-.battle-link:focus-visible {
-  outline: 3px solid #fff;
-  outline-offset: 6px;
-  border-radius: 24px;
-}
-
-body.is-battle-transition {
-  cursor: progress;
-}
-
-body.is-battle-transition .landing,
-body.is-battle-transition .bubbles {
+.battle-cast__hero,
+.battle-cast__enemy {
+  position: absolute;
+  top: 52%;
+  transform: translate3d(-50%, -50%, 0);
+  display: flex;
+  align-items: center;
+  justify-content: center;
   pointer-events: none;
 }
 
-.battle-link__image {
-  display: block;
-  width: min(420px, calc(100vw - 64px));
-  max-width: 250px;
-  height: auto;
-  transform-origin: 50% 90%;
-  will-change: transform, filter;
-  filter: drop-shadow(0 0 0 rgba(0, 196, 255, 0));
+.battle-cast__hero {
+  left: 50%;
+  transition: transform 0.9s cubic-bezier(0.16, 1, 0.3, 1);
+  will-change: transform;
+  z-index: 3;
 }
 
-.battle-link.is-battle-transition .battle-link__image {
-  animation:
-    battle-link-scale-down 1s cubic-bezier(0.22, 1, 0.36, 1) forwards;
-  animation-delay: 0.12s;
-  filter: drop-shadow(0 0 0 rgba(0, 196, 255, 0));
+.battle-cast.is-enemy-present .battle-cast__hero {
+  transform: translate3d(calc(-50% - var(--battle-cast-hero-shift)), -50%, 0);
+}
+
+.battle-cast__enemy {
+  right: clamp(20px, 10vw, 200px);
+  transform: translate3d(140%, -50%, 0);
+  transition: transform 0.9s cubic-bezier(0.16, 1, 0.3, 1);
+  will-change: transform;
+  z-index: 2;
+}
+
+.battle-cast__enemy.is-visible {
+  transform: translate3d(0, -50%, 0);
+}
+
+.hero,
+.enemy {
+  width: min(320px, 42vw);
+  max-width: 320px;
+  height: auto;
+  image-rendering: auto;
+}
+
+.hero {
+  --hero-direction: -1;
+  --hero-float-range: 32px;
+  --hero-float-duration: 3.5s;
+  animation: hero-float var(--hero-float-duration, 3.5s) ease-in-out 1.35s infinite;
+  transform: translate3d(0, calc(-1 * var(--hero-float-range, 32px)), 0)
+    scaleX(var(--hero-direction, 1))
+    scale(1);
+  transform-origin: 50% 90%;
+  pointer-events: none;
+  will-change: transform, opacity;
+  z-index: 3;
+}
+
+.battle-cast.is-enemy-present .hero {
+  --hero-direction: 1;
 }
 
 .hero.is-battle-transition {
-  animation: hero-battle-scale-down 1s cubic-bezier(0.22, 1, 0.36, 1) forwards;
-  animation-delay: 0.12s;
+  animation: hero-battle-exit 0.65s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+.enemy {
+  --enemy-direction: -1;
+  opacity: 0;
+  transform: scaleX(var(--enemy-direction, 1)) scale(0.92);
+  transform-origin: 50% 90%;
+  pointer-events: none;
+  will-change: transform, opacity;
+  filter: drop-shadow(0 18px 24px rgba(0, 0, 0, 0.25));
+  transition: opacity 0.45s ease, transform 0.45s ease;
+}
+
+.enemy.is-visible {
+  opacity: 1;
+  transform: scaleX(var(--enemy-direction, 1)) scale(1);
+}
+
+.enemy.is-battle-transition {
+  animation: enemy-battle-exit 0.65s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+.battle-time {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: min(320px, 68vw);
+  max-width: min(420px, 72vw);
+  padding: clamp(16px, 4vw, 32px) clamp(36px, 8vw, 72px);
+  border-radius: 999px;
+  border: 4px solid rgba(255, 255, 255, 0.85);
+  background:
+    radial-gradient(120% 120% at 50% 10%, rgba(255, 255, 255, 0.65), transparent 70%),
+    linear-gradient(160deg, #ffe169 10%, #ff9f1c 55%, #ff5d8f 100%);
+  color: #14223f;
+  font-size: clamp(2rem, 6vw, 3.8rem);
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-align: center;
+  line-height: 1;
+  white-space: nowrap;
+  text-shadow: 0 4px 0 rgba(255, 255, 255, 0.6), 0 8px 24px rgba(0, 0, 0, 0.35);
+  box-shadow:
+    0 12px 28px rgba(0, 0, 0, 0.35),
+    inset 0 -6px 0 rgba(0, 0, 0, 0.15);
+  transform: translate(-50%, -50%) scale(0.6);
+  opacity: 0;
+  font-family: var(--font-family-rounded);
+  user-select: none;
+  pointer-events: none;
+  will-change: transform, opacity;
+  z-index: 5;
+}
+
+.battle-time.is-visible {
+  animation: battle-time-pop 0.55s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+.battle-time.is-battle-transition {
+  animation: battle-time-exit 0.5s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+@media (max-width: 640px) {
+  .battle-cast {
+    --battle-cast-hero-shift: clamp(80px, 28vw, 160px);
+  }
+
+  .battle-cast__enemy {
+    right: clamp(12px, 18vw, 140px);
+  }
+
+  .battle-time {
+    min-width: min(260px, 70vw);
+    padding: clamp(12px, 3.5vw, 24px) clamp(28px, 7vw, 52px);
+    font-size: clamp(1.8rem, 8vw, 3.2rem);
+  }
 }
 
 @keyframes hero-float {
   0% {
-    transform: translate(-50%, calc(-1 * var(--hero-float-range, 32px)));
+    transform: translate3d(0, calc(-1 * var(--hero-float-range, 32px)), 0)
+      scaleX(var(--hero-direction, 1))
+      scale(1);
   }
   50% {
-    transform: translate(-50%, var(--hero-float-range, 32px));
+    transform: translate3d(0, var(--hero-float-range, 32px), 0)
+      scaleX(var(--hero-direction, 1))
+      scale(1);
   }
   100% {
-    transform: translate(-50%, calc(-1 * var(--hero-float-range, 32px)));
+    transform: translate3d(0, calc(-1 * var(--hero-float-range, 32px)), 0)
+      scaleX(var(--hero-direction, 1))
+      scale(1);
+  }
+}
+
+@keyframes hero-battle-exit {
+  0% {
+    transform: translate3d(0, calc(-1 * var(--hero-float-range, 32px)), 0)
+      scaleX(var(--hero-direction, 1))
+      scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: translate3d(0, calc(-1 * var(--hero-float-range, 32px)), 0)
+      scaleX(var(--hero-direction, 1))
+      scale(1.08);
+    opacity: 1;
+  }
+  60% {
+    transform: translate3d(0, calc(-1 * var(--hero-float-range, 32px)), 0)
+      scaleX(var(--hero-direction, 1))
+      scale(1.05);
+    opacity: 0.96;
+  }
+  100% {
+    transform: translate3d(0, calc(-1 * var(--hero-float-range, 32px)), 0)
+      scaleX(var(--hero-direction, 1))
+      scale(0.62);
+    opacity: 0;
+  }
+}
+
+@keyframes enemy-battle-exit {
+  0% {
+    transform: scaleX(var(--enemy-direction, 1)) scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scaleX(var(--enemy-direction, 1)) scale(1.08);
+    opacity: 1;
+  }
+  60% {
+    transform: scaleX(var(--enemy-direction, 1)) scale(1.05);
+    opacity: 0.96;
+  }
+  100% {
+    transform: scaleX(var(--enemy-direction, 1)) scale(0.62);
+    opacity: 0;
+  }
+}
+
+@keyframes battle-time-pop {
+  0% {
+    transform: translate(-50%, -50%) scale(0.6);
+    opacity: 0;
+  }
+  60% {
+    transform: translate(-50%, -50%) scale(1.05);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes battle-time-exit {
+  0% {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(0.5);
+    opacity: 0;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .battle-cast__hero,
+  .battle-cast__enemy {
+    transition: none;
+  }
+
+  .battle-cast__enemy,
+  .battle-cast__enemy.is-visible {
+    transform: translate3d(0, -50%, 0);
+  }
+
   .hero {
     animation: none;
-    transform: translate(-50%, 0);
+    transform: scaleX(var(--hero-direction, 1)) scale(1);
   }
 
-  .hero.is-battle-transition {
-    opacity: 0;
-  }
-
-  body:not(.is-preloading) .battle-link__image {
-    animation: none;
-    filter: none;
-  }
-
-  .battle-link.is-battle-transition .battle-link__image {
+  .hero.is-battle-transition,
+  .enemy.is-battle-transition,
+  .battle-time.is-battle-transition {
     animation: none;
     opacity: 0;
   }
 
-  main.landing.is-battle-transition {
-    animation: none;
-    transform: translate3d(0, 0, 0);
-    filter: none;
+  .enemy {
+    transition: none;
+    opacity: 1;
+    transform: scaleX(var(--enemy-direction, 1)) scale(1);
   }
 
-  .bubbles.is-battle-transition {
+  .battle-time {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 1;
+  }
+
+  .battle-time.is-visible {
     animation: none;
-    transform: translateX(-50%);
-    opacity: 0;
   }
 }
-
-@keyframes hero-battle-scale-down {
-  0% {
-    transform: translate(-50%, calc(-1 * var(--hero-float-range, 32px))) scale(1);
-    opacity: 1;
-  }
-  50% {
-    transform: translate(-50%, calc(-1 * var(--hero-float-range, 32px))) scale(1.08);
-    opacity: 1;
-  }
-  60% {
-    transform: translate(-50%, calc(-1 * var(--hero-float-range, 32px))) scale(1.05);
-    opacity: 0.96;
-  }
-  100% {
-    transform: translate(-50%, calc(-1 * var(--hero-float-range, 32px))) scale(0.62);
-    opacity: 0;
-  }
-}
-
-@keyframes battle-link-scale-down {
-  0% {
-    transform: translate3d(0, 0, 0) scale(1);
-    opacity: 1;
-  }
-  50% {
-    transform: translate3d(0, 0, 0) scale(1.08);
-    opacity: 1;
-  }
-  60% {
-    transform: translate3d(0, 0, 0) scale(1.05);
-    opacity: 0.96;
-  }
-  100% {
-    transform: translate3d(0, 0, 0) scale(0.62);
-    opacity: 0;
-  }
-}
-
 @keyframes landing-battle-shift {
   0% {
     transform: translate3d(0, 0, 0) scale(1);
@@ -444,82 +572,6 @@ body.is-battle-transition .bubbles {
   100% { --ty: -110vh;              --sx: 1.06; --sy: 1.06; opacity: 0; }
 }
 
-.battle-intro {
-  position: fixed;
-  left: var(--battle-intro-left, 50%);
-  top: var(--battle-intro-top, 50%);
-  transform: translate(-50%, -50%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  pointer-events: none;
-  opacity: 0;
-  visibility: hidden;
-  z-index: 3;
-}
-
-.battle-intro__image {
-  width: min(350px, 90vw);
-  height: min(350px, 90vw);
-  object-fit: contain;
-  transform: scale(0.2);
-  transform-origin: center;
-  opacity: 0;
-}
-
-.battle-intro.is-visible {
-  opacity: 1;
-  visibility: visible;
-}
-
-.battle-intro__image.is-pop-in {
-  animation: battle-intro-pop 0.6s cubic-bezier(0.16, 1, 0.3, 1) forwards;
-}
-
-.battle-intro__image.is-pop-out {
-  animation: battle-intro-pop-out 0.45s cubic-bezier(0.16, 1, 0.3, 1) forwards;
-}
-
-@keyframes battle-intro-pop {
-  0% {
-    transform: scale(0.2);
-    opacity: 0;
-  }
-  60% {
-    transform: scale(1.12);
-    opacity: 1;
-  }
-  100% {
-    transform: scale(1);
-    opacity: 1;
-  }
-}
-
-@keyframes battle-intro-pop-out {
-  0% {
-    transform: scale(1);
-    opacity: 1;
-  }
-  40% {
-    transform: scale(1.08);
-    opacity: 1;
-  }
-  100% {
-    transform: scale(0.2);
-    opacity: 0;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .battle-intro {
-    transition: none;
-  }
-
-  .battle-intro__image {
-    transform: scale(1);
-    opacity: 1;
-  }
-}
 
 /* Organic horizontal meander tied to --drift */
 @keyframes bubble-drift {

--- a/index.html
+++ b/index.html
@@ -45,36 +45,28 @@
       <span class="bubble" style="--size: 18px; --duration: 6.4s; --delay: 0.5s;"></span>
     </div>
 
-    <img
-      class="hero"
-      src="./images/characters/shellfin_level_1.png"
-      alt="Shellfin ready for battle"
-    />
-
-    <a
-      class="battle-link"
-      data-battle-link
-      href="html/battle.html"
-      aria-label="Enter the battle"
-    >
-      <img
-        class="battle-link__image"
-        src="./images/battle/battle.png"
-        alt="Enter the battle"
-        width="350"
-        height="350"
-      />
-    </a>
+    <div class="battle-cast" data-battle-cast>
+      <div class="battle-cast__hero" data-hero-container>
+        <img
+          class="hero"
+          data-hero
+          src="./images/characters/shellfin_level_1.png"
+          alt="Shellfin ready for battle"
+        />
+      </div>
+      <div class="battle-cast__enemy" data-enemy-container>
+        <img
+          class="enemy"
+          data-enemy
+          src="./images/battle/monster_battle_1_1.png"
+          alt="Enemy ready for battle"
+        />
+      </div>
+      <div class="battle-time" data-battle-time role="img" aria-label="Battle time">
+        <span aria-hidden="true">Battle Time!</span>
+      </div>
+    </div>
   </main>
-  <div class="battle-intro" data-battle-intro aria-hidden="true">
-    <img
-      class="battle-intro__image"
-      src="./images/battle/battle.png"
-      alt="Battle begins"
-      width="350"
-      height="350"
-    />
-  </div>
   <script>
     window.SUPABASE_URL = 'https://jxlxpumcoihfapmrsaqd.supabase.co';
     window.SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imp4bHhwdW1jb2loZmFwbXJzYXFkIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTc0MjE3MDcsImV4cCI6MjA3Mjk5NzcwN30.PJiDPZ_Dqli_42isJexeYgsf0ebWbCSOwHtR7lsQTN0';


### PR DESCRIPTION
## Summary
- replace the landing "battle time" image element with an accessible CSS-rendered badge to avoid committing binary assets
- style the badge with gradients, shadows, and responsive typography while keeping the original animation hooks intact
- drop the unused battle_time.png preload entry so the sequence no longer references the removed file

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5b7a7c17c832992ca6af552d5077e