### PR TITLE
Remove iOS tap highlight from buttons

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -127,6 +127,7 @@ button {
   cursor: pointer;
   transition: transform 0.25s ease, box-shadow 0.25s ease,
     background-image 0.25s ease;
+  -webkit-tap-highlight-color: transparent;
 }
 
 button.result {


### PR DESCRIPTION
## Summary
- disable the default tap highlight on buttons to prevent the brief white flash after pressing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5bdd0bef483299166190beae926bd