### PR TITLE
Adjust landing intro positions

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -74,6 +74,11 @@ body:not(.is-preloading) main.landing {
   z-index: 2;
   pointer-events: none;
   will-change: transform, opacity;
+  transition: left 0.7s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.hero.is-side-position {
+  left: clamp(120px, 28vw, 260px);
 }
 
 .hero.is-exiting {
@@ -86,7 +91,8 @@ body:not(.is-preloading) main.landing {
   top: 45%;
   max-width: min(320px, 70vw);
   max-height: min(320px, 70vh);
-  transform: translate(220%, -50%);
+  transform: translate(-50%, calc(-50% - var(--enemy-drop-distance, 22vh)))
+    scale(1.04);
   transform-origin: 50% 85%;
   opacity: 0;
   transition: transform 0.9s cubic-bezier(0.16, 1, 0.3, 1),
@@ -97,7 +103,7 @@ body:not(.is-preloading) main.landing {
 }
 
 .enemy.is-visible {
-  transform: translate(-50%, -50%);
+  transform: translate(-50%, -50%) scale(1);
   opacity: 1;
 }
 

--- a/js/index.js
+++ b/js/index.js
@@ -186,6 +186,7 @@ const runBattleIntroSequence = async () => {
   };
 
   if (prefersReducedMotion) {
+    heroImage.classList.add('is-side-position');
     showEnemy();
     showBattleIntro();
     const exitDuration = beginExitAnimations();
@@ -201,6 +202,7 @@ const runBattleIntroSequence = async () => {
   }
 
   await wait(HERO_TO_ENEMY_DELAY_MS);
+  heroImage.classList.add('is-side-position');
   showEnemy();
 
   await wait(ENEMY_ENTRANCE_DURATION_MS + BATTLE_CALL_INTRO_OFFSET_MS);


### PR DESCRIPTION
## Summary
- add a side-position state so the hero slides toward the left before the battle call
- tweak the monster entrance to drop into place on the right while keeping the sprite centered
- trigger the new hero positioning in both animated and reduced-motion intro flows

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5ecefce088329b14836cd6cc445a7