### PR TITLE
Adjust intro sprite spacing and alignment

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -12,6 +12,10 @@ body {
   overflow: hidden;
 }
 
+:root {
+  --intro-sprite-offset: clamp(150px, 22vw, 280px);
+}
+
 main.landing {
   position: relative;
   width: 100%;
@@ -78,7 +82,7 @@ body:not(.is-preloading) main.landing {
 }
 
 .hero.is-side-position {
-  left: clamp(120px, 28vw, 260px);
+  left: calc(50% - var(--intro-sprite-offset));
 }
 
 .hero.is-exiting {
@@ -87,7 +91,7 @@ body:not(.is-preloading) main.landing {
 
 .enemy {
   position: absolute;
-  left: calc(50% + clamp(96px, 14vw, 180px));
+  left: calc(50% + var(--intro-sprite-offset));
   top: 45%;
   max-width: min(320px, 70vw);
   max-height: min(320px, 70vh);


### PR DESCRIPTION
## Summary
- define a shared intro sprite offset custom property for the landing scene
- center the hero and enemy sprites evenly around the midpoint using the shared offset
- increase the offset to provide additional space between both sprites during the intro

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5efb517cc832994c57e0c299d7c6b