### PR TITLE
Update battle completion card to new design

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -338,8 +338,32 @@ button:focus-visible {
 }
 
 .card .enemy-image {
-  width: 220px;
-  height: 220px;
+  width: 200px;
+  height: 200px;
+  object-fit: contain;
+}
+
+.meter--level-up {
+  padding: 0;
+  background-color: transparent;
+  gap: 12px;
+}
+
+.meter--level-up .meter__heading {
+  font-size: var(--subtitle-font-size);
+  font-weight: var(--subtitle-font-weight);
+  color: var(--title-color);
+}
+
+.meter--level-up .meter__progress {
+  display: none;
+}
+
+.meter--level-up .meter__icon {
+  position: static;
+  width: 160px;
+  height: auto;
+  max-width: 100%;
 }
 
 .card .battle-stats {

--- a/html/battle.html
+++ b/html/battle.html
@@ -119,31 +119,27 @@
       aria-hidden="true"
       tabindex="-1"
     >
-      <section class="battle-card battle-card--pop battle-complete-card">
+      <section class="card card--pop battle-complete-card">
         <div class="battle-info">
-          <p id="battle-complete-title" class="battle-title">Battle<br />Complete</p>
+          <p id="battle-complete-title" class="battle-title">Monster Defeated</p>
         </div>
         <img
           class="enemy-image"
           src="../images/battle/monster_battle_1_1.png"
-          alt="Enemy defeated in battle"
+          alt="Enemy preparing for the next battle"
         />
-        <p class="battle-goals-title">Battle Goals</p>
-        <div class="battle-stats">
-          <div class="battle-stat" data-goal="accuracy">
-            <span class="stat-label">Accuracy</span>
-            <span class="stat-value summary-accuracy">
-              <span class="stat-value-text">0%</span>
-            </span>
+        <div class="meter meter--visible meter--level-up">
+          <p class="meter__heading text-small text-dark">Level Up</p>
+          <div class="progress meter__progress" role="presentation" aria-hidden="true">
+            <span class="progress__fill" aria-hidden="true"></span>
           </div>
-          <div class="battle-stat" data-goal="time">
-            <span class="stat-label">Time</span>
-            <span class="stat-value summary-time">
-              <span class="stat-value-text">0s</span>
-            </span>
-          </div>
+          <img
+            class="meter__icon"
+            src="../images/meter/chest.png"
+            alt="Treasure chest level-up reward"
+          />
         </div>
-        <button type="button" class="btn-primary next-mission-btn" data-action="next">Next Mission</button>
+        <button type="button" class="btn-primary next-mission-btn" data-action="next">Next Battle</button>
       </section>
     </div>
     <div id="battle-message">

--- a/js/battle.js
+++ b/js/battle.js
@@ -1569,20 +1569,21 @@ document.addEventListener('DOMContentLoaded', () => {
       completeEnemyImg.src = monsterImg.src;
       if (monster.name) {
         completeEnemyImg.alt = win
-          ? `${monster.name} defeated in battle`
+          ? `${monster.name} defeated`
           : `${monster.name} preparing for the next battle`;
+      } else {
+        completeEnemyImg.alt = win
+          ? 'Enemy defeated'
+          : 'Enemy preparing for the next battle';
       }
     }
 
-    const goalsAchieved = win && accuracyGoalMet && timeGoalMet;
+    const goalsAchieved = win;
 
-    if (win && goalsAchieved) {
-      const monsterName =
-        typeof monster?.name === 'string' ? monster.name.trim() : '';
-      const victoryName = monsterName || 'Monster';
-      setBattleCompleteTitleLines(victoryName, 'Defeated!');
+    if (win) {
+      setBattleCompleteTitleLines('Monster Defeated');
     } else {
-      setBattleCompleteTitleLines('Keep', 'Practicing!');
+      setBattleCompleteTitleLines('Keep Practicing');
     }
 
     battleGoalsMet = goalsAchieved;
@@ -1591,8 +1592,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     if (nextMissionBtn) {
-      nextMissionBtn.textContent = battleGoalsMet ? 'Next Mission' : 'Try Again';
-      nextMissionBtn.dataset.action = battleGoalsMet ? 'next' : 'retry';
+      nextMissionBtn.textContent = win ? 'Next Battle' : 'Try Again';
+      nextMissionBtn.dataset.action = win ? 'next' : 'retry';
     }
 
     const showCompleteMessage = () => {
@@ -1655,9 +1656,9 @@ document.addEventListener('DOMContentLoaded', () => {
       completeMessage.classList.remove('show');
       completeMessage.setAttribute('aria-hidden', 'true');
     }
-    setBattleCompleteTitleLines('Battle', 'Complete');
+    setBattleCompleteTitleLines('Monster Defeated');
     if (nextMissionBtn) {
-      nextMissionBtn.textContent = 'Next Mission';
+      nextMissionBtn.textContent = 'Next Battle';
       nextMissionBtn.dataset.action = 'next';
     }
     if (summaryAccuracyValue) {


### PR DESCRIPTION
## Summary
- restyle the battle completion modal to show the new Monster Defeated/Keep Practicing card with a level-up meter
- ensure the level-up reward uses the shared meter component styling within the card layout
- update the battle flow logic to set the new titles, button labels, and enemy alt text when a battle ends

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5eeb567a88329bbdab316c59a7f17