### PR TITLE
Add dev control to trigger battle loss

### DIFF
--- a/html/battle.html
+++ b/html/battle.html
@@ -22,6 +22,9 @@
     <button type="button" class="battle-dev-controls__btn" data-dev-end-battle>
       End Battle
     </button>
+    <button type="button" class="battle-dev-controls__btn" data-dev-lose-battle>
+      Lose Battle
+    </button>
     <button type="button" class="battle-dev-controls__btn" data-dev-reset-level>
       Reset Level 1
     </button>

--- a/js/battle.js
+++ b/js/battle.js
@@ -81,6 +81,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const bannerTimeValue = document.querySelector('[data-banner-time]');
   const setStreakButton = document.querySelector('[data-dev-set-streak]');
   const endBattleButton = document.querySelector('[data-dev-end-battle]');
+  const loseBattleButton = document.querySelector('[data-dev-lose-battle]');
   const resetLevelButton = document.querySelector('[data-dev-reset-level]');
   const logOutButton = document.querySelector('[data-dev-log-out]');
   const devControls = document.querySelector('.battle-dev-controls');
@@ -1368,6 +1369,21 @@ document.addEventListener('DOMContentLoaded', () => {
     streak = targetStreak;
     streakMaxed = false;
     dispatchStreakMeterUpdate(true);
+  });
+
+  loseBattleButton?.addEventListener('click', () => {
+    if (battleEnded) {
+      return;
+    }
+    const previousHealth = hero.health;
+    hero.health = 0;
+    hero.damage = Math.max(hero.damage, previousHealth);
+    updateHeroHealthDisplay();
+    updateHealthBars();
+    document.dispatchEvent(new Event('close-question'));
+    window.setTimeout(() => {
+      endBattle(false, { waitForHpDrain: heroHpFill });
+    }, 0);
   });
 
   endBattleButton?.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add a "Lose Battle" developer control button to the battle page
- wire the button to zero the hero's health and immediately trigger the defeat flow

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d5f5af80a0832998ba231bef53e662