### PR TITLE
Animate enemy defeat on battle results

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -415,6 +415,98 @@ body {
   margin-top: 0;
 }
 
+.battle-complete-card {
+  position: relative;
+}
+
+.battle-complete-card__meter {
+  width: 100%;
+}
+
+.battle-complete-card__meter .meter__heading {
+  margin: 0;
+  font-size: var(--title-font-size);
+  font-weight: var(--title-font-weight);
+  color: var(--title-color);
+}
+
+.battle-complete-card__meter-subtitle {
+  margin: 0;
+  font-size: var(--subtitle-font-size);
+  font-weight: var(--subtitle-font-weight);
+  color: var(--subtitle-color);
+}
+
+.battle-complete-card__enemy {
+  position: relative;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.battle-complete-card .enemy-image {
+  transition: filter 0.4s ease, opacity 0.4s ease;
+}
+
+.battle-complete-card .enemy-image.enemy-image--defeated {
+  filter: saturate(0);
+  opacity: 0.1;
+}
+
+.battle-complete-card .enemy-defeat-overlay {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.4);
+  opacity: 0;
+  width: 140px;
+  max-width: 70%;
+  z-index: 1;
+  pointer-events: none;
+}
+
+.battle-complete-card .enemy-defeat-overlay img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+@keyframes enemy-defeat-check-pop {
+  0% {
+    transform: translate(-50%, -50%) scale(0.4);
+    opacity: 0;
+  }
+
+  60% {
+    transform: translate(-50%, -50%) scale(1.15);
+    opacity: 1;
+  }
+
+  100% {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 1;
+  }
+}
+
+.battle-complete-card .enemy-defeat-overlay--visible {
+  animation: enemy-defeat-check-pop 0.45s ease-out forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .battle-complete-card .enemy-image {
+    transition: none;
+  }
+
+  .battle-complete-card .enemy-defeat-overlay {
+    transform: translate(-50%, -50%) scale(1);
+  }
+
+  .battle-complete-card .enemy-defeat-overlay--visible {
+    animation: none;
+    opacity: 1;
+  }
+}
+
 
 .battle-dev-controls {
   position: fixed;

--- a/html/battle.html
+++ b/html/battle.html
@@ -120,16 +120,9 @@
       tabindex="-1"
     >
       <section class="card card--pop battle-complete-card">
-        <div class="battle-info">
-          <p id="battle-complete-title" class="battle-title">Monster Defeated</p>
-        </div>
-        <img
-          class="enemy-image"
-          src="../images/battle/monster_battle_1_1.png"
-          alt="Enemy preparing for the next battle"
-        />
-        <div class="meter meter--visible meter--level-up">
-          <p class="meter__heading text-small text-dark">Level Up</p>
+        <div class="meter meter--visible meter--level-up battle-complete-card__meter">
+          <p id="battle-complete-title" class="meter__heading battle-title">Monster Defeated</p>
+          <p class="battle-complete-card__meter-subtitle subtitle">Level Up</p>
           <div class="progress meter__progress" role="presentation" aria-hidden="true">
             <span class="progress__fill" aria-hidden="true"></span>
           </div>
@@ -138,6 +131,16 @@
             src="../images/meter/chest.png"
             alt="Treasure chest level-up reward"
           />
+        </div>
+        <div class="battle-complete-card__enemy">
+          <img
+            class="enemy-image"
+            src="../images/battle/monster_battle_1_1.png"
+            alt="Enemy preparing for the next battle"
+          />
+          <div class="enemy-defeat-overlay" data-enemy-defeat-overlay aria-hidden="true">
+            <img src="../images/complete/check.svg" alt="" />
+          </div>
         </div>
         <button type="button" class="btn-primary next-mission-btn" data-action="next">Next Battle</button>
       </section>

--- a/js/battle.js
+++ b/js/battle.js
@@ -94,6 +94,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const completeMessage = document.getElementById('complete-message');
   const battleCompleteTitle = completeMessage?.querySelector('#battle-complete-title');
   const completeEnemyImg = completeMessage?.querySelector('.enemy-image');
+  const enemyDefeatOverlay = completeMessage?.querySelector('[data-enemy-defeat-overlay]');
   const summaryAccuracyStat = completeMessage?.querySelector('[data-goal="accuracy"]');
   const summaryTimeStat = completeMessage?.querySelector('[data-goal="time"]');
   const summaryAccuracyValue = summaryAccuracyStat?.querySelector('.summary-accuracy');
@@ -133,6 +134,7 @@ document.addEventListener('DOMContentLoaded', () => {
   let battleLevelAdvanced = false;
   let battleGoalsMet = false;
   let heroSuperAttackBase = null;
+  let enemyDefeatAnimationTimeout = null;
 
   const hero = {
     attack: 1,
@@ -452,6 +454,29 @@ document.addEventListener('DOMContentLoaded', () => {
     valueEl.textContent = '';
     valueEl.appendChild(span);
     return span;
+  }
+
+  function resetEnemyDefeatAnimation() {
+    if (enemyDefeatAnimationTimeout !== null) {
+      window.clearTimeout(enemyDefeatAnimationTimeout);
+      enemyDefeatAnimationTimeout = null;
+    }
+    if (completeEnemyImg) {
+      completeEnemyImg.classList.remove('enemy-image--defeated');
+    }
+    if (enemyDefeatOverlay) {
+      enemyDefeatOverlay.classList.remove('enemy-defeat-overlay--visible');
+    }
+  }
+
+  function applyEnemyDefeatStyles() {
+    if (completeEnemyImg) {
+      completeEnemyImg.classList.add('enemy-image--defeated');
+    }
+    if (enemyDefeatOverlay) {
+      enemyDefeatOverlay.classList.add('enemy-defeat-overlay--visible');
+    }
+    enemyDefeatAnimationTimeout = null;
   }
 
   function applyGoalResult(valueEl, textSpan, text, met) {
@@ -1521,6 +1546,7 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
     battleEnded = true;
+    resetEnemyDefeatAnimation();
     resetSuperAttackBoost();
     devControls?.classList.add('battle-dev-controls--hidden');
     document.dispatchEvent(new Event('close-question'));
@@ -1605,6 +1631,15 @@ document.addEventListener('DOMContentLoaded', () => {
       if (typeof completeMessage.focus === 'function') {
         completeMessage.focus();
       }
+      if (win) {
+        if (prefersReducedMotion) {
+          applyEnemyDefeatStyles();
+        } else {
+          enemyDefeatAnimationTimeout = window.setTimeout(() => {
+            applyEnemyDefeatStyles();
+          }, 1000);
+        }
+      }
     };
 
     const waitForHpDrainEl =
@@ -1656,6 +1691,7 @@ document.addEventListener('DOMContentLoaded', () => {
       completeMessage.classList.remove('show');
       completeMessage.setAttribute('aria-hidden', 'true');
     }
+    resetEnemyDefeatAnimation();
     setBattleCompleteTitleLines('Monster Defeated');
     if (nextMissionBtn) {
       nextMissionBtn.textContent = 'Next Battle';


### PR DESCRIPTION
## Summary
- add an overlay checkmark element to the battle results card for enemy defeat feedback
- style the battle completion card to desaturate the enemy sprite and pop in the new overlay with reduced-motion fallbacks
- update the battle flow to schedule the defeat animation one second after a hero victory and reset state between battles
- move the battle completion title and chest icon inside the shared meter component for consistency with global styles

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5f4f03b6c8329b3f7a9ae064d73f8