### PR TITLE
Update asset paths after image folder reorganization

### DIFF
--- a/html/battle.html
+++ b/html/battle.html
@@ -105,7 +105,7 @@
           </div>
           <img
             class="meter__icon"
-            src="../images/meter/sword.png"
+            src="../images/complete/sword.png"
             data-meter-icon
             alt=""
             aria-hidden="true"
@@ -131,7 +131,7 @@
           </div>
           <img
             class="meter__icon"
-            src="../images/meter/chest.png"
+            src="../images/complete/chest.png"
             alt="Treasure chest level-up reward"
           />
         </div>

--- a/js/question.js
+++ b/js/question.js
@@ -69,14 +69,14 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   if (meterIcon) {
-    const swordPath = resolveAssetPath('images/meter/sword.png');
+    const swordPath = resolveAssetPath('images/complete/sword.png');
     if (swordPath) {
       meterIcon.src = swordPath;
     }
   }
 
   const getButtonIconPath = (iconType) =>
-    resolveAssetPath(`images/questions/button/${iconType}.svg`);
+    resolveAssetPath(`images/questions/${iconType}.svg`);
 
   let submitLocked = false;
 

--- a/sw.js
+++ b/sw.js
@@ -23,7 +23,7 @@ const OFFLINE_ASSETS = [
   'images/characters/shellfin_level_1.png',
   'images/battle/battle_time.png',
   'images/battle/monster_battle_1_1.png',
-  'images/meter/sword.png',
+  'images/complete/sword.png',
   'images/questions/shield.svg',
   './data/levels.json',
   './data/player.json',


### PR DESCRIPTION
## Summary
- update question meter icon to load from the new complete image folder
- adjust question button icon lookup to match the flattened questions directory
- refresh service worker cache list to reference the relocated sword asset

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6bfa104208329bec03141eb467645