### PR TITLE
Normalize attack sprite configuration

### DIFF
--- a/data/levels.json
+++ b/data/levels.json
@@ -12,25 +12,21 @@
           "id": "shellfin",
           "sprite": "/mathmonsters/images/characters/shellfin_level_1.png",
           "name": "Shellfin",
-          "basicAttack": "/mathmonsters/images/characters/shellfin_attack_1.png",
-          "superAttack": "/mathmonsters/images/characters/shellfin_attack_1.png",
           "attack": 1,
           "health": 3,
           "damage": 0,
-          "attackSprites": {
-            "basic": "/mathmonsters/images/characters/shellfin_attack_1.png",
-            "super": "/mathmonsters/images/characters/shellfin_attack_1.png"
+          "attackSprite": {
+            "basic": "/mathmonsters/images/characters/shellfin_attack_1.png"
           }
         },
         "enemy": {
           "id": "octomurk",
           "sprite": "/mathmonsters/images/battle/monster_battle_1_1.png",
           "name": "Octomurk",
-          "basicAttack": "/mathmonsters/images/characters/enemy_attack.png",
           "attack": 1,
           "health": 20,
           "damage": 0,
-          "attackSprites": {
+          "attackSprite": {
             "basic": "/mathmonsters/images/characters/enemy_attack.png"
           }
         }
@@ -51,9 +47,8 @@
           "attack": 2,
           "health": 6,
           "damage": 0,
-          "attackSprites": {
-            "basic": "/mathmonsters/images/characters/shellfin_attack_1.png",
-            "super": "/mathmonsters/images/characters/shellfin_attack_1.png"
+          "attackSprite": {
+            "basic": "/mathmonsters/images/characters/shellfin_attack_1.png"
           }
         },
         "enemy": {
@@ -63,7 +58,7 @@
           "attack": 2,
           "health": 40,
           "damage": 0,
-          "attackSprites": {
+          "attackSprite": {
             "basic": "/mathmonsters/images/characters/enemy_attack.png"
           }
         }


### PR DESCRIPTION
## Summary
- update level data to use the consolidated `attackSprite` mapping instead of legacy basic/super attack fields
- enhance attack sprite normalization in the loader and battle scripts to accept both legacy and new formats while deduplicating paths

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d6c28185408329b5eb5047ada6f0f8