### PR TITLE
Fix malformed level configuration JSON

### DIFF
--- a/data/levels.json
+++ b/data/levels.json
@@ -29,6 +29,8 @@
           "attackSprite": {
             "basic": "/mathmonsters/images/characters/enemy_attack.png"
           }
+        }
+      }
     },
     {
       "battleLevel": 2,
@@ -59,6 +61,8 @@
           "attackSprite": {
             "basic": "/mathmonsters/images/characters/enemy_attack.png"
           }
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add missing closing braces to the level configuration JSON so it parses correctly
- ensure battle data can be loaded so hero and monster metadata display again

## Testing
- node scripts/validate-data.js

------
https://chatgpt.com/codex/tasks/task_e_68d6c729a30083299c4b33fe3feb514d