### PR TITLE
Revamp landing hero layout

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -55,6 +55,65 @@ body:not(.is-preloading) main.landing {
   filter: none;
 }
 
+.landing__hero-info {
+  position: absolute;
+  top: clamp(48px, 18vh, 180px);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  width: min(360px, 88vw);
+  padding: 0 12px;
+  text-align: center;
+  z-index: 3;
+}
+
+.landing__hero-name,
+.landing__hero-level {
+  margin: 0;
+}
+
+.landing__hero-level {
+  opacity: 0.85;
+}
+
+.landing__hero-progress {
+  --progress-gradient-start: #36dc36;
+  --progress-gradient-end: #00b600;
+
+  height: 18px;
+  width: 100%;
+  background-color: rgba(255, 255, 255, 0.25);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.25);
+  -webkit-backdrop-filter: blur(6px);
+  backdrop-filter: blur(6px);
+}
+
+.landing__hero-progress .progress__fill::after {
+  inset: 3px 5px 0 5px;
+}
+
+.landing__actions {
+  position: absolute;
+  left: 50%;
+  bottom: calc(24px + var(--viewport-bottom-offset, 0px));
+  bottom: calc(
+    24px + var(--viewport-bottom-offset, 0px) + constant(safe-area-inset-bottom)
+  );
+  bottom: calc(
+    24px + var(--viewport-bottom-offset, 0px) + env(safe-area-inset-bottom, 0px)
+  );
+  transform: translateX(-50%);
+  width: min(360px, calc(100vw - 32px));
+  z-index: 3;
+}
+
+.landing__battle-button {
+  box-shadow: 0 18px 32px rgba(0, 58, 128, 0.35);
+}
+
 @media (prefers-reduced-motion: reduce) {
   main.landing {
     transition: none;

--- a/index.html
+++ b/index.html
@@ -45,11 +45,38 @@
       <span class="bubble" style="--size: 18px; --duration: 6.4s; --delay: 0.5s;"></span>
     </div>
 
+    <section class="landing__hero-info" aria-live="polite">
+      <p class="landing__hero-name text-large text-white" data-hero-name>
+        Shellfin
+      </p>
+      <p class="landing__hero-level text-small text-white" data-hero-level>
+        Level 1
+      </p>
+      <div
+        class="progress landing__hero-progress"
+        role="progressbar"
+        aria-label="Level progress"
+        aria-valuemin="0"
+        aria-valuemax="100"
+        aria-valuenow="0"
+        aria-valuetext="0 of 0 experience"
+        data-battle-progress
+      >
+        <div class="progress__fill" aria-hidden="true"></div>
+      </div>
+    </section>
+
     <img
       class="hero"
       src="./images/characters/shellfin_level_1.png"
       alt="Shellfin ready for battle"
     />
+
+    <div class="landing__actions">
+      <button class="landing__battle-button" type="button" data-battle-button>
+        Battle
+      </button>
+    </div>
 
     <img
       class="enemy"


### PR DESCRIPTION
## Summary
- Add a hero overview section to the landing page with a progress bar and battle call-to-action.
- Style the landing layout so hero details and the battle button sit above and below the floating sprite.
- Populate the new UI elements from the existing preview data and require a manual button press before starting the battle intro.

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d6efb3abc48329999a3971c13a2267