### PR TITLE
Remove unused gems tracking from battle hero state

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -275,7 +275,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const hero = {
     attack: 1,
     health: 5,
-    gems: 0,
     damage: 0,
     name: 'Hero',
     attackSprites: {},
@@ -1028,10 +1027,6 @@ document.addEventListener('DOMContentLoaded', () => {
     hero.health = Number(heroData.health) || hero.health;
     hero.damage = Number(heroData.damage) || hero.damage;
     hero.name = heroData.name || hero.name;
-    if (typeof heroData.gems === 'number') {
-      hero.gems = heroData.gems;
-    }
-
     const heroAttackSprites = normalizeAttackSprites(hero, heroData);
     if (Object.keys(heroAttackSprites).length > 0) {
       hero.attackSprites = heroAttackSprites;

--- a/js/loader.js
+++ b/js/loader.js
@@ -266,8 +266,6 @@ const readStoredProgress = () => {
     }
 
     const resolveAssetPath = (path) => normalizeAssetPath(path);
-    const isPlainObject = (value) =>
-      Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 
     const normalizeAttackSprites = (...spriteSources) => {
       const result = {};


### PR DESCRIPTION
## Summary
- remove the unused `gems` property from the hero configuration in the battle script

## Testing
- node scripts/validate-data.js

------
https://chatgpt.com/codex/tasks/task_e_68d6eec9517c8329b345788c93e695b1