### PR TITLE
Refactor shared progress helpers for leaner bundles

### DIFF
--- a/html/battle.html
+++ b/html/battle.html
@@ -167,10 +167,11 @@
       </div>
     </div>
     <script src="../js/pwa.js" defer data-pwa-root=".."></script>
-    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-    <script src="../js/supabaseClient.js"></script>
-    <script src="../js/loader.js"></script>
-    <script src="../js/battle.js"></script>
-    <script src="../js/question.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2" defer></script>
+    <script src="../js/supabaseClient.js" defer></script>
+    <script src="../js/utils/progress.js" defer></script>
+    <script src="../js/loader.js" defer></script>
+    <script src="../js/battle.js" defer></script>
+    <script src="../js/question.js" defer></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -105,6 +105,7 @@
   <script src="js/pwa.js" defer data-pwa-root="."></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2" defer></script>
   <script src="js/supabaseClient.js" defer></script>
+  <script src="js/utils/progress.js" defer></script>
   <script src="js/index.js" defer></script>
 </body>
 </html>

--- a/js/battle.js
+++ b/js/battle.js
@@ -7,6 +7,21 @@ const BATTLE_PAGE_MODE_PARAM = 'mode';
 const BATTLE_PAGE_MODE_PLAY = 'play';
 const ENEMY_DEFEAT_ANIMATION_DELAY = 2000;
 
+const progressUtils =
+  (typeof globalThis !== 'undefined' && globalThis.mathMonstersProgress) || null;
+
+if (!progressUtils) {
+  throw new Error('Progress utilities are not available.');
+}
+
+const {
+  isPlainObject,
+  normalizeExperienceMap,
+  mergeExperienceMaps,
+  readExperienceForLevel,
+  computeExperienceProgress,
+} = progressUtils;
+
 const isDevControlsHiddenMode = () => {
   if (typeof window === 'undefined' || typeof window.location === 'undefined') {
     return false;
@@ -173,78 +188,6 @@ document.addEventListener('DOMContentLoaded', () => {
     Math.max(DEFAULT_STREAK_GOAL, MIN_STREAK_GOAL),
     MAX_STREAK_GOAL
   );
-
-  const isPlainObject = (value) =>
-    Boolean(value) && typeof value === 'object' && !Array.isArray(value);
-
-  const normalizeExperienceMap = (source) => {
-    if (!isPlainObject(source)) {
-      return {};
-    }
-
-    const normalized = {};
-    Object.entries(source).forEach(([key, value]) => {
-      const levelKey = String(key).trim();
-      const numericValue = Number(value);
-      if (!levelKey) {
-        return;
-      }
-      if (!Number.isFinite(numericValue)) {
-        return;
-      }
-      normalized[levelKey] = Math.max(0, Math.round(numericValue));
-    });
-    return normalized;
-  };
-
-  const mergeExperienceMaps = (base, extra) => {
-    const merged = { ...normalizeExperienceMap(base) };
-    const additional = normalizeExperienceMap(extra);
-
-    Object.entries(additional).forEach(([key, value]) => {
-      merged[key] = value;
-    });
-
-    return merged;
-  };
-
-  const readExperienceForLevel = (experienceMap, level) => {
-    if (!isPlainObject(experienceMap)) {
-      return 0;
-    }
-
-    const numericLevel = Number(level);
-    if (Number.isFinite(numericLevel) && numericLevel in experienceMap) {
-      const direct = Number(experienceMap[numericLevel]);
-      if (Number.isFinite(direct)) {
-        return Math.max(0, direct);
-      }
-    }
-
-    const levelKey = String(level);
-    if (!levelKey) {
-      return 0;
-    }
-    const value = Number(experienceMap[levelKey]);
-    return Number.isFinite(value) ? Math.max(0, value) : 0;
-  };
-
-  const computeExperienceProgress = (earned, requirement) => {
-    const safeEarned = Number.isFinite(earned) ? Math.max(0, Math.round(earned)) : 0;
-    const safeRequirement = Number.isFinite(requirement)
-      ? Math.max(0, Math.round(requirement))
-      : 0;
-    const totalWithBase = safeRequirement + 1;
-    const earnedWithBase = Math.min(totalWithBase, safeEarned + 1);
-    const ratio = totalWithBase > 0 ? Math.min(1, earnedWithBase / totalWithBase) : 0;
-    const text = `${earnedWithBase} of ${totalWithBase}`;
-    return {
-      ratio,
-      text,
-      earnedDisplay: earnedWithBase,
-      totalDisplay: totalWithBase,
-    };
-  };
 
   let questions = [];
   let questionIds = [];

--- a/js/index.js
+++ b/js/index.js
@@ -23,6 +23,21 @@ const BATTLE_PAGE_MODE_PLAY = 'play';
 
 let battleRedirectUrl = BATTLE_PAGE_URL;
 
+const progressUtils =
+  (typeof globalThis !== 'undefined' && globalThis.mathMonstersProgress) || null;
+
+if (!progressUtils) {
+  throw new Error('Progress utilities are not available.');
+}
+
+const {
+  isPlainObject,
+  normalizeExperienceMap,
+  mergeExperienceMaps,
+  readExperienceForLevel,
+  computeExperienceProgress,
+} = progressUtils;
+
 const buildBattleUrl = (mode) => {
   if (!mode) {
     return BATTLE_PAGE_URL;
@@ -255,79 +270,6 @@ const getNow = () =>
   typeof performance !== 'undefined' && typeof performance.now === 'function'
     ? performance.now()
     : Date.now();
-
-const isPlainObject = (value) =>
-  Boolean(value) && typeof value === 'object' && !Array.isArray(value);
-
-const normalizeExperienceMap = (source) => {
-  if (!isPlainObject(source)) {
-    return {};
-  }
-
-  const normalized = {};
-  Object.entries(source).forEach(([key, value]) => {
-    const levelKey = String(key).trim();
-    const numericValue = Number(value);
-    if (!levelKey) {
-      return;
-    }
-    if (!Number.isFinite(numericValue)) {
-      return;
-    }
-    normalized[levelKey] = Math.max(0, Math.round(numericValue));
-  });
-  return normalized;
-};
-
-const mergeExperienceMaps = (base, extra) => {
-  const merged = { ...normalizeExperienceMap(base) };
-  const additional = normalizeExperienceMap(extra);
-
-  Object.entries(additional).forEach(([key, value]) => {
-    merged[key] = value;
-  });
-
-  return merged;
-};
-
-const readExperienceForLevel = (experienceMap, level) => {
-  if (!isPlainObject(experienceMap)) {
-    return 0;
-  }
-
-  const normalizedLevel = Number(level);
-  if (Number.isFinite(normalizedLevel) && normalizedLevel in experienceMap) {
-    const direct = Number(experienceMap[normalizedLevel]);
-    if (Number.isFinite(direct)) {
-      return Math.max(0, direct);
-    }
-  }
-
-  const levelKey = String(level);
-  if (!levelKey) {
-    return 0;
-  }
-  const value = Number(experienceMap[levelKey]);
-  return Number.isFinite(value) ? Math.max(0, value) : 0;
-};
-
-const computeExperienceProgress = (earned, requirement) => {
-  const safeEarned = Number.isFinite(earned) ? Math.max(0, Math.round(earned)) : 0;
-  const safeRequirement = Number.isFinite(requirement)
-    ? Math.max(0, Math.round(requirement))
-    : 0;
-  const totalWithBase = safeRequirement + 1;
-  const earnedWithBase = Math.min(totalWithBase, safeEarned + 1);
-  const ratio = totalWithBase > 0 ? Math.min(1, earnedWithBase / totalWithBase) : 0;
-  const text = `${earnedWithBase} of ${totalWithBase}`;
-
-  return {
-    ratio,
-    text,
-    earned: earnedWithBase,
-    total: totalWithBase,
-  };
-};
 
 const sanitizeAssetPath = (path) => {
   if (typeof path !== 'string') {

--- a/js/loader.js
+++ b/js/loader.js
@@ -85,6 +85,15 @@ const determineAssetBasePath = () => {
 
 const ASSET_BASE_PATH = determineAssetBasePath();
 
+const progressUtils =
+  (typeof globalThis !== 'undefined' && globalThis.mathMonstersProgress) || null;
+
+if (!progressUtils) {
+  throw new Error('Progress utilities are not available.');
+}
+
+const { isPlainObject, normalizeExperienceMap, mergeExperienceMaps } = progressUtils;
+
 const normalizeAssetPath = (inputPath) => {
   if (typeof inputPath !== 'string') {
     return null;
@@ -145,40 +154,6 @@ const resolveDataPath = (path) => {
     : `data/${trimmed.replace(/^\/+/, '')}`;
 
   return normalizeAssetPath(normalized);
-};
-
-const isPlainObject = (value) =>
-  Boolean(value) && typeof value === 'object' && !Array.isArray(value);
-
-const normalizeExperienceMap = (source) => {
-  if (!isPlainObject(source)) {
-    return {};
-  }
-
-  const normalized = {};
-  Object.entries(source).forEach(([key, value]) => {
-    const levelKey = String(key).trim();
-    const numericValue = Number(value);
-    if (!levelKey) {
-      return;
-    }
-    if (!Number.isFinite(numericValue)) {
-      return;
-    }
-    normalized[levelKey] = Math.max(0, Math.round(numericValue));
-  });
-  return normalized;
-};
-
-const mergeExperienceMaps = (base, extra) => {
-  const merged = { ...normalizeExperienceMap(base) };
-  const additional = normalizeExperienceMap(extra);
-
-  Object.entries(additional).forEach(([key, value]) => {
-    merged[key] = value;
-  });
-
-  return merged;
 };
 
 const readStoredProgress = () => {

--- a/js/utils/progress.js
+++ b/js/utils/progress.js
@@ -1,0 +1,100 @@
+(() => {
+  const globalScope =
+    typeof globalThis !== 'undefined'
+      ? globalThis
+      : typeof window !== 'undefined'
+      ? window
+      : typeof self !== 'undefined'
+      ? self
+      : {};
+
+  const isPlainObject = (value) =>
+    Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+
+  const normalizeExperienceMap = (source) => {
+    if (!isPlainObject(source)) {
+      return {};
+    }
+
+    const normalized = {};
+    Object.entries(source).forEach(([key, value]) => {
+      const levelKey = String(key).trim();
+      const numericValue = Number(value);
+      if (!levelKey || !Number.isFinite(numericValue)) {
+        return;
+      }
+      normalized[levelKey] = Math.max(0, Math.round(numericValue));
+    });
+    return normalized;
+  };
+
+  const mergeExperienceMaps = (base, extra) => {
+    const merged = { ...normalizeExperienceMap(base) };
+    const additional = normalizeExperienceMap(extra);
+
+    Object.entries(additional).forEach(([key, value]) => {
+      merged[key] = value;
+    });
+
+    return merged;
+  };
+
+  const readExperienceForLevel = (experienceMap, level) => {
+    if (!isPlainObject(experienceMap)) {
+      return 0;
+    }
+
+    const numericLevel = Number(level);
+    if (Number.isFinite(numericLevel) && numericLevel in experienceMap) {
+      const direct = Number(experienceMap[numericLevel]);
+      if (Number.isFinite(direct)) {
+        return Math.max(0, direct);
+      }
+    }
+
+    const levelKey = String(level);
+    if (!levelKey) {
+      return 0;
+    }
+    const value = Number(experienceMap[levelKey]);
+    return Number.isFinite(value) ? Math.max(0, value) : 0;
+  };
+
+  const computeExperienceProgress = (earned, requirement) => {
+    const safeEarned = Number.isFinite(earned) ? Math.max(0, Math.round(earned)) : 0;
+    const safeRequirement = Number.isFinite(requirement)
+      ? Math.max(0, Math.round(requirement))
+      : 0;
+
+    const totalWithBase = safeRequirement + 1;
+    const earnedWithBase = Math.min(totalWithBase, safeEarned + 1);
+    const ratio = totalWithBase > 0 ? Math.min(1, earnedWithBase / totalWithBase) : 0;
+
+    return {
+      ratio,
+      text: `${earnedWithBase} of ${totalWithBase}`,
+      earned: earnedWithBase,
+      total: totalWithBase,
+      earnedDisplay: earnedWithBase,
+      totalDisplay: totalWithBase,
+    };
+  };
+
+  const existing =
+    (globalScope && typeof globalScope.mathMonstersProgress === 'object'
+      ? globalScope.mathMonstersProgress
+      : null) || {};
+
+  const progressUtils = Object.freeze({
+    ...existing,
+    isPlainObject,
+    normalizeExperienceMap,
+    mergeExperienceMaps,
+    readExperienceForLevel,
+    computeExperienceProgress,
+  });
+
+  if (globalScope) {
+    globalScope.mathMonstersProgress = progressUtils;
+  }
+})();


### PR DESCRIPTION
## Summary
- add a shared `mathMonstersProgress` utility so experience helpers only ship once
- update landing, loader, and battle scripts to consume the shared helpers
- load the shared helpers (and defer battle scripts) from the HTML entry points for faster startup

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6f354f744832998b733429f8e2854