### PR TITLE
Adjust hero speech dialogue presentation

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -156,7 +156,8 @@ body:not(.is-preloading) main.landing {
   left: 50%;
   transform: translate(-50%, -8px);
   max-width: min(520px, 90vw);
-  text-align: center;
+  text-align: left;
+  align-items: flex-start;
   opacity: 0;
   pointer-events: none;
   z-index: 3;
@@ -164,16 +165,8 @@ body:not(.is-preloading) main.landing {
 }
 
 .landing__hero-speech::after {
-  content: '';
-  position: absolute;
-  left: 50%;
-  bottom: -18px;
-  width: 28px;
-  height: 28px;
-  border-radius: 4px;
-  background: inherit;
-  transform: translateX(-50%) rotate(45deg);
-  box-shadow: 0 18px 36px rgba(0, 27, 65, 0.18);
+  content: none;
+  display: none;
 }
 
 .landing__hero-speech.is-visible {
@@ -190,10 +183,8 @@ body:not(.is-preloading) main.landing {
 }
 
 .landing__hero-speech-text[data-typing='true']::after {
-  content: '▌';
-  display: inline-block;
-  margin-left: 4px;
-  animation: hero-speech-caret 0.8s steps(1, end) infinite;
+  content: none;
+  animation: none;
 }
 
 .landing__hero-speech-text[data-typing='false']::after,

--- a/js/index.js
+++ b/js/index.js
@@ -15,7 +15,8 @@ const BATTLE_CALL_POP_OUT_DURATION_MS = 450;
 const REDUCED_MOTION_SEQUENCE_DURATION_MS = 300;
 const CENTER_IMAGE_HOLD_DURATION_MS = 1000;
 const LEVEL_ONE_SPEECH_DELAY_MS = 2000;
-const LEVEL_ONE_SPEECH_CHARACTER_INTERVAL_MS = 45;
+const LEVEL_ONE_SPEECH_CHARACTER_INTERVAL_MS = 90;
+const LEVEL_ONE_SPEECH_SENTENCE_PAUSE_MS = 1000;
 const LEVEL_ONE_SPEECH_TEXT =
   "Hi! I\u2019m Shellfin. Uh-oh\u2026 monsters are here! Can you help me stop them?";
 
@@ -350,13 +351,15 @@ const playLevelOneHeroSpeech = ({
           return;
         }
 
-        textElement.textContent += characters[index];
+        const currentCharacter = characters[index];
+        textElement.textContent += currentCharacter;
         index += 1;
 
-        window.setTimeout(
-          typeNextCharacter,
-          Math.max(0, LEVEL_ONE_SPEECH_CHARACTER_INTERVAL_MS)
-        );
+        const baseDelay = Math.max(0, LEVEL_ONE_SPEECH_CHARACTER_INTERVAL_MS);
+        const sentencePause =
+          currentCharacter === '.' ? LEVEL_ONE_SPEECH_SENTENCE_PAUSE_MS : 0;
+
+        window.setTimeout(typeNextCharacter, baseDelay + sentencePause);
       };
 
       typeNextCharacter();


### PR DESCRIPTION
## Summary
- slow the hero speech typing cadence with a one second pause after periods
- update the dialogue bubble styling to remove the caret and bottom pointer
- left align the hero speech content for a more traditional dialogue layout

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7060cb8a0832982071f4321ac2e35