### PR TITLE
Align dialogue box sizing with card

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -296,15 +296,19 @@ button:focus-visible {
 }
 
 .dialogue-box {
+  width: 420px;
+  max-width: 100%;
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
   gap: 12px;
-  padding: 24px 28px;
+  padding: 24px;
   border-radius: 24px;
   background: rgba(255, 255, 255, 0.95);
   box-shadow: 0 24px 60px rgba(0, 27, 65, 0.25);
   color: rgba(39, 43, 52, 0.95);
   line-height: 1.4;
+  opacity: 0;
 }
 .card--pop {
   animation: pop-in 0.4s ease-out forwards;

--- a/css/index.css
+++ b/css/index.css
@@ -155,7 +155,7 @@ body:not(.is-preloading) main.landing {
   top: clamp(18%, 32vh, 44%);
   left: 50%;
   transform: translate(-50%, -8px);
-  max-width: min(520px, 90vw);
+  max-width: min(420px, 100%);
   text-align: left;
   align-items: flex-start;
   opacity: 0;


### PR DESCRIPTION
## Summary
- align the shared dialogue box component with the card width and sizing
- match the hero speech bubble max-width to the card for mobile consistency

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d71fc8358c83298485cf76338101eb