### PR TITLE
Align dialogue box padding with card

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -16,6 +16,7 @@
   --button-text-color: #ffffff;
   --button-hover-gradient-start: #33aaff;
   --button-hover-gradient-end: #1a73ff;
+  --surface-padding: 24px;
 }
 
 html {
@@ -285,7 +286,7 @@ button:focus-visible {
   max-width: 100%;
   background: #ffffff;
   border-radius: 12px;
-  padding: 24px;
+  padding: var(--surface-padding, 24px);
   box-sizing: border-box;
   box-shadow: 0 18px 36px rgba(0, 0, 0, 0.25);
   text-align: center;
@@ -302,7 +303,7 @@ button:focus-visible {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  padding: 24px;
+  padding: var(--surface-padding, 24px);
   border-radius: 24px;
   background: rgba(255, 255, 255, 0.95);
   box-shadow: 0 24px 60px rgba(0, 27, 65, 0.25);


### PR DESCRIPTION
## Summary
- add a shared --surface-padding custom property for card-style surfaces
- update the card and dialogue box styles to use the shared padding value so their spacing matches

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d725e2ab308329bc210ba02afaa65b