### PR TITLE
Refine dialogue boxes and reward overlay

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -437,6 +437,14 @@ body {
   visibility: visible;
 }
 
+body.is-reward-active > *:not(.reward-overlay) {
+  visibility: hidden;
+}
+
+body.is-reward-active .reward-overlay {
+  visibility: visible;
+}
+
 .reward-overlay__image {
   width: 250px;
   height: 250px;
@@ -496,13 +504,6 @@ body {
 
 .battle-complete-card__meter .meter__heading {
   margin: 0;
-}
-
-.battle-complete-card__meter [data-level-progress-text] {
-  margin: 0;
-  font-size: var(--subtitle-font-size);
-  font-weight: var(--subtitle-font-weight);
-  color: var(--title-color);
 }
 
 .battle-complete-card__enemy {

--- a/css/global.css
+++ b/css/global.css
@@ -343,7 +343,6 @@ button:focus-visible {
   height: calc(var(--dialogue-tail-size, 18px) * 1.2);
   background: rgba(255, 255, 255, 0.95);
   border-radius: 6px;
-  box-shadow: 0 14px 28px rgba(0, 27, 65, 0.25);
   transform: translateX(-50%) rotate(45deg);
 }
 .card--pop {

--- a/css/index.css
+++ b/css/index.css
@@ -152,7 +152,7 @@ body:not(.is-preloading) main.landing {
 
 .landing__hero-speech {
   position: absolute;
-  top: calc(clamp(18%, 32vh, 44%) - 40px);
+  top: calc(clamp(18%, 32vh, 44%) - 60px);
   left: 50%;
   transform: translate(-50%, -8px);
   max-width: min(420px, 100%);
@@ -173,7 +173,7 @@ body:not(.is-preloading) main.landing {
 .landing__hero-speech-text {
   margin: 0;
   width: 100%;
-  font-size: clamp(18px, 3.8vw, 22px);
+  font-size: var(--text-size-medium);
   color: rgba(39, 43, 52, 0.95);
   letter-spacing: 0.01em;
 }

--- a/css/question.css
+++ b/css/question.css
@@ -25,13 +25,15 @@
 }
 
 #question .question-dialogue {
-  width: 100%;
+  width: min(420px, 100%);
   text-align: left;
   opacity: 0;
   transform: translateY(12px);
   transition: opacity 0.3s ease, transform 0.3s ease;
   pointer-events: none;
   --dialogue-tail-offset: 38%;
+  align-self: center;
+  margin: 0 auto 20px;
 }
 
 #question .question-dialogue.is-visible {
@@ -44,6 +46,7 @@
   font-size: var(--text-size-medium);
   color: var(--text-color-dark);
   text-align: left;
+  letter-spacing: 0.01em;
 }
 
 #question .card--question.card--hidden {

--- a/html/battle.html
+++ b/html/battle.html
@@ -152,7 +152,6 @@
             alt="Treasure chest level-up reward"
           />
           <p class="meter__heading text-small text-dark">Level Up</p>
-          <p data-level-progress-text>1 of 1</p>
           <div
             class="progress meter__progress"
             role="progressbar"

--- a/js/battle.js
+++ b/js/battle.js
@@ -169,9 +169,6 @@ document.addEventListener('DOMContentLoaded', () => {
     '.battle-complete-card__meter .meter__progress'
   );
   const levelProgressFill = levelProgressMeter?.querySelector('.progress__fill');
-  const levelProgressText = completeMessage?.querySelector(
-    '[data-level-progress-text]'
-  );
   const rewardOverlay = document.querySelector('[data-reward-overlay]');
   const rewardSprite = rewardOverlay?.querySelector('[data-reward-sprite]');
 
@@ -261,6 +258,7 @@ document.addEventListener('DOMContentLoaded', () => {
     clearRewardAnimation();
     rewardOverlay.classList.remove('reward-overlay--visible');
     rewardOverlay.setAttribute('aria-hidden', 'true');
+    document.body?.classList.remove('is-reward-active');
     rewardSprite.classList.remove(
       'reward-overlay__image--pop-in',
       'reward-overlay__image--shrink',
@@ -278,6 +276,7 @@ document.addEventListener('DOMContentLoaded', () => {
     clearRewardAnimation();
     rewardOverlay.classList.add('reward-overlay--visible');
     rewardOverlay.setAttribute('aria-hidden', 'false');
+    document.body?.classList.add('is-reward-active');
     rewardSprite.classList.remove(
       'reward-overlay__image--pop-in',
       'reward-overlay__image--shrink',
@@ -400,9 +399,6 @@ document.addEventListener('DOMContentLoaded', () => {
       levelProgressMeter.style.setProperty('--progress-value', `${clampedRatio}`);
     }
 
-    if (levelProgressText) {
-      levelProgressText.textContent = progress.text;
-    }
 
     const requirementMet =
       levelExperienceRequirement > 0 && sanitizedEarned >= levelExperienceRequirement;

--- a/js/index.js
+++ b/js/index.js
@@ -20,7 +20,7 @@ const LEVEL_ONE_SPEECH_SEQUENCE = [
   { text: 'Hi! I’m Shellfin.', pauseAfterMs: 1000 },
   { text: ' Uh-oh…', pauseAfterMs: 1000 },
   { text: ' monsters are here!', pauseAfterMs: 1000 },
-  { text: ' Can you help me stop them?', pauseAfterMs: 2000 },
+  { text: ' Can you help me stop them?', pauseAfterMs: 4000 },
 ];
 
 const buildSpeechCharacters = (segments = []) =>

--- a/js/question.js
+++ b/js/question.js
@@ -61,7 +61,7 @@ document.addEventListener('DOMContentLoaded', () => {
     { text: 'Answer a question to attack!', pauseAfterMs: 1000 },
     { text: ' Get it right and', pauseAfterMs: 1000 },
     { text: '—POW!', pauseAfterMs: 1000 },
-    { text: '—your hero fights back!', pauseAfterMs: 2000 },
+    { text: '—your hero fights back!', pauseAfterMs: 4000 },
   ];
 
   const buildDialogueCharacters = (segments = []) =>


### PR DESCRIPTION
## Summary
- align the landing and battle dialogue boxes, including consistent typography and positioning
- lengthen the typing sequence pause on both dialogue boxes and remove the tilted tail shadow
- simplify the battle completion UI by hiding level progress text and isolating the reward overlay view

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d74d6685f08329856e6756fe7fa948