### PR TITLE
Limit battle dialogue to level one and adjust reward overlay

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -424,7 +424,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(0, 0, 0, 0.8);
+  background: transparent;
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
@@ -439,10 +439,12 @@ body {
 
 body.is-reward-active > *:not(.reward-overlay) {
   visibility: hidden;
+  display: none !important;
 }
 
 body.is-reward-active .reward-overlay {
   visibility: visible;
+  pointer-events: auto;
 }
 
 .reward-overlay__image {

--- a/css/question.css
+++ b/css/question.css
@@ -25,20 +25,23 @@
 }
 
 #question .question-dialogue {
+  position: absolute;
+  left: 50%;
+  top: 50%;
   width: min(420px, 100%);
   text-align: left;
   opacity: 0;
-  transform: translateY(12px);
+  transform: translate(-50%, calc(-50% - 8px));
   transition: opacity 0.3s ease, transform 0.3s ease;
   pointer-events: none;
   --dialogue-tail-offset: 38%;
-  align-self: center;
-  margin: 0 auto 20px;
+  margin: 0;
+  z-index: 1;
 }
 
 #question .question-dialogue.is-visible {
   opacity: 1;
-  transform: translateY(0);
+  transform: translate(-50%, calc(-50% - 20px));
 }
 
 #question .question-dialogue__text {

--- a/js/battle.js
+++ b/js/battle.js
@@ -1392,7 +1392,21 @@ document.addEventListener('DOMContentLoaded', () => {
       choicesEl.appendChild(div);
     });
     questionBox.classList.add('show');
-    document.dispatchEvent(new CustomEvent('question-opened'));
+
+    const resolvedBattleLevel = (() => {
+      if (Number.isFinite(currentBattleLevel)) {
+        return currentBattleLevel;
+      }
+
+      const preloadedLevel = Number(window.preloadedData?.level?.battleLevel);
+      return Number.isFinite(preloadedLevel) ? preloadedLevel : null;
+    })();
+
+    document.dispatchEvent(
+      new CustomEvent('question-opened', {
+        detail: { battleLevel: resolvedBattleLevel },
+      })
+    );
   }
 
   function dispatchStreakMeterUpdate(correct) {

--- a/js/question.js
+++ b/js/question.js
@@ -566,7 +566,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   document.addEventListener('close-question', closeQuestion);
 
-  document.addEventListener('question-opened', () => {
+  document.addEventListener('question-opened', (event) => {
     button.classList.remove('result', 'correct', 'incorrect');
     button.textContent = 'Submit';
     clearChoiceSelections();
@@ -576,10 +576,16 @@ document.addEventListener('DOMContentLoaded', () => {
       questionBox.classList.remove('closing');
     }
 
-    if (!hasShownQuestionIntro) {
+    const rawLevel = Number(event?.detail?.battleLevel);
+    const sanitizedLevel = Number.isFinite(rawLevel)
+      ? Math.max(1, Math.round(rawLevel))
+      : 1;
+    const isLevelOne = sanitizedLevel === 1;
+
+    if (!hasShownQuestionIntro && isLevelOne) {
+      hasShownQuestionIntro = true;
       setQuestionCardHidden(true);
       Promise.resolve(playQuestionIntro()).then(() => {
-        hasShownQuestionIntro = true;
         if (!isQuestionOverlayActive()) {
           return;
         }
@@ -588,6 +594,7 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
 
+    hasShownQuestionIntro = hasShownQuestionIntro || !isLevelOne;
     clearQuestionIntroTimeouts();
     hideQuestionIntro({ immediate: true });
     revealQuestionCard();


### PR DESCRIPTION
## Summary
- hide battle interface during the reward overlay so the background stays visible
- center the dialogue bubble on the battle screen and offset it upward for clarity
- send the current battle level with the question-opened event and restrict the intro dialogue to level 1 battles

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d753b00dc08329964054fb8558b2f5