### PR TITLE
Delay battle overlay until question begins

### DIFF
--- a/css/question.css
+++ b/css/question.css
@@ -3,7 +3,7 @@
   inset: 0;
   width: 100%;
   height: 100%;
-  background: rgba(0, 0, 0, 0.3);
+  background-color: transparent;
   display: flex;
   justify-content: center;
   align-items: flex-end;
@@ -12,8 +12,12 @@
   box-sizing: border-box;
   opacity: 0;
   visibility: hidden;
-  transition: opacity 0.3s ease;
+  transition: opacity 0.3s ease, background-color 0.3s ease;
   z-index: 20;
+}
+
+#question.question--with-overlay {
+  background-color: rgba(0, 0, 0, 0.3);
 }
 
 #question .question__content {

--- a/js/question.js
+++ b/js/question.js
@@ -55,6 +55,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const questionIntroText = questionIntro?.querySelector(
     '[data-question-dialogue-text]'
   );
+  const QUESTION_OVERLAY_CLASS = 'question--with-overlay';
   const QUESTION_INTRO_DELAY_MS = 200;
   const QUESTION_INTRO_CHARACTER_INTERVAL_MS = 70;
   const QUESTION_INTRO_SEQUENCE = [
@@ -449,10 +450,30 @@ document.addEventListener('DOMContentLoaded', () => {
     );
   });
 
-  const isQuestionOverlayActive = () =>
+  const isQuestionContainerActive = () =>
     Boolean(questionBox) &&
     questionBox.classList.contains('show') &&
     !questionBox.classList.contains('closing');
+
+  const isQuestionOverlayActive = () =>
+    isQuestionContainerActive() &&
+    questionBox.classList.contains(QUESTION_OVERLAY_CLASS);
+
+  const enableQuestionOverlay = () => {
+    if (!questionBox) {
+      return;
+    }
+
+    questionBox.classList.add(QUESTION_OVERLAY_CLASS);
+  };
+
+  const disableQuestionOverlay = () => {
+    if (!questionBox) {
+      return;
+    }
+
+    questionBox.classList.remove(QUESTION_OVERLAY_CLASS);
+  };
 
   const setQuestionCardHidden = (hidden) => {
     if (!questionCard) {
@@ -475,6 +496,12 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   const revealQuestionCard = () => {
+    if (!isQuestionContainerActive()) {
+      return;
+    }
+
+    enableQuestionOverlay();
+
     if (!isQuestionOverlayActive()) {
       return;
     }
@@ -495,6 +522,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (questionBox) {
         questionBox.classList.remove('closing');
         questionBox.classList.remove('show');
+        questionBox.classList.remove(QUESTION_OVERLAY_CLASS);
       }
       if (questionCard) {
         questionCard.classList.remove('card--closing');
@@ -576,11 +604,13 @@ document.addEventListener('DOMContentLoaded', () => {
       questionBox.classList.remove('closing');
     }
 
+    disableQuestionOverlay();
+
     if (!hasShownQuestionIntro) {
       setQuestionCardHidden(true);
       Promise.resolve(playQuestionIntro()).then(() => {
         hasShownQuestionIntro = true;
-        if (!isQuestionOverlayActive()) {
+        if (!isQuestionContainerActive()) {
           return;
         }
         revealQuestionCard();


### PR DESCRIPTION
## Summary
- make the question overlay background opt-in via a dedicated class so the dialogue can appear without the dark tint
- update the question flow to toggle the overlay only when the question card is revealed and clear it when the overlay closes

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d7548093648329aa2114665a80c6e6