### PR TITLE
Update landing dialogue messaging and positioning

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -152,7 +152,7 @@ body:not(.is-preloading) main.landing {
 
 .landing__hero-speech {
   position: absolute;
-  top: calc(clamp(18%, 32vh, 44%) - 60px);
+  top: calc(clamp(18%, 32vh, 44%) - 80px);
   left: 50%;
   transform: translate(-50%, -8px);
   max-width: min(420px, 100%);

--- a/js/index.js
+++ b/js/index.js
@@ -20,7 +20,7 @@ const LEVEL_ONE_SPEECH_SEQUENCE = [
   { text: 'Hi! I’m Shellfin.', pauseAfterMs: 1000 },
   { text: ' Uh-oh…', pauseAfterMs: 1000 },
   { text: ' monsters are here!', pauseAfterMs: 1000 },
-  { text: ' Can you help me stop them?', pauseAfterMs: 4000 },
+  { text: ' Let’s use math to fight back!', pauseAfterMs: 4000 },
 ];
 
 const buildSpeechCharacters = (segments = []) =>


### PR DESCRIPTION
## Summary
- update the first hero speech line to invite players to fight back with math
- shift the landing dialogue box 20px upward for better placement

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8038d5390832984d8f9881fc7923e