### PR TITLE
Skip landing intro for dev flow

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -234,6 +234,22 @@ document.addEventListener('DOMContentLoaded', () => {
   const REWARD_CHEST_SRC = '../images/complete/chest.png';
   const REWARD_POTION_SRC = '../images/complete/potion.png';
 
+  const applyRewardChestGlow = () => {
+    if (!rewardSprite) {
+      return;
+    }
+
+    rewardSprite.style.setProperty('--pulsating-glow-color', 'rgba(255, 232, 118, 0.9)');
+    rewardSprite.style.setProperty('--pulsating-glow-opacity', '0.9');
+    rewardSprite.style.setProperty('--pulsating-glow-opacity-peak', '1');
+    rewardSprite.style.setProperty('--pulsating-glow-spread', '42px');
+    rewardSprite.style.setProperty('--pulsating-glow-radius', '48px');
+    rewardSprite.style.setProperty('--pulsating-glow-duration', '1.8s');
+    rewardSprite.style.setProperty('--pulsating-glow-scale-start', '0.88');
+    rewardSprite.style.setProperty('--pulsating-glow-scale-peak', '1.08');
+    rewardSprite.style.setProperty('--pulsating-glow-blur', '12px');
+  };
+
   const hero = {
     attack: 1,
     health: 5,
@@ -284,6 +300,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     rewardAwaitingActivation = true;
+    applyRewardChestGlow();
     rewardSprite.classList.add(
       'reward-overlay__image--interactive',
       'pulsating-glow'
@@ -343,15 +360,7 @@ document.addEventListener('DOMContentLoaded', () => {
     );
     rewardSprite.src = REWARD_CHEST_SRC;
     rewardSprite.alt = 'Treasure chest level-up reward';
-    rewardSprite.style.setProperty('--pulsating-glow-color', 'rgba(255, 232, 118, 0.9)');
-    rewardSprite.style.setProperty('--pulsating-glow-opacity', '0.9');
-    rewardSprite.style.setProperty('--pulsating-glow-opacity-peak', '1');
-    rewardSprite.style.setProperty('--pulsating-glow-spread', '42px');
-    rewardSprite.style.setProperty('--pulsating-glow-radius', '48px');
-    rewardSprite.style.setProperty('--pulsating-glow-duration', '1.8s');
-    rewardSprite.style.setProperty('--pulsating-glow-scale-start', '0.88');
-    rewardSprite.style.setProperty('--pulsating-glow-scale-peak', '1.08');
-    rewardSprite.style.setProperty('--pulsating-glow-blur', '12px');
+    applyRewardChestGlow();
 
     void rewardSprite.offsetWidth;
     rewardSprite.classList.add('reward-overlay__image--pop-in');

--- a/js/welcome.js
+++ b/js/welcome.js
@@ -2,6 +2,7 @@ const GUEST_SESSION_KEY = 'reefRangersGuestSession';
 const PROGRESS_STORAGE_KEY = 'reefRangersProgress';
 const LANDING_MODE_STORAGE_KEY = 'reefRangersLandingMode';
 const BATTLE_PAGE_MODE_PLAY = 'play';
+const BATTLE_PAGE_MODE_DEV_TOOLS = 'devtools';
 
 const createDefaultProgress = () => ({
   battleLevel: 1,
@@ -107,7 +108,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       persistLandingModeRequest(BATTLE_PAGE_MODE_PLAY);
       redirectTarget = '../index.html?mode=play';
     } else {
-      clearLandingModeRequest();
+      persistLandingModeRequest(BATTLE_PAGE_MODE_DEV_TOOLS);
     }
 
     window.location.replace(redirectTarget);


### PR DESCRIPTION
## Summary
- add a dev tools landing mode that jumps directly from the welcome flow to the battle page
- keep the battle reward chest highlighted with a reusable yellow glow helper

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d83f5ca8048329af8b685b93270955