### PR TITLE
Revamp level one intro sequence

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -258,8 +258,254 @@ body.is-level-one-landing .enemy {
   display: none;
 }
 
+body.is-level-one-landing .landing__hero-speech,
 body:not(.is-level-one-landing) .landing__hero-speech {
   display: none;
+}
+
+body.is-level-one-landing .hero {
+  opacity: 0;
+  visibility: hidden;
+  animation: none;
+  transition: opacity 0.4s ease;
+}
+
+body.is-level-one-landing .hero.is-revealed {
+  opacity: 1;
+  visibility: visible;
+}
+
+body:not(.is-level-one-landing) .level-one-intro {
+  display: none;
+}
+
+.level-one-intro {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: clamp(16px, 5vw, 32px);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.4s ease;
+  z-index: 4;
+}
+
+.level-one-intro.is-active {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.level-one-intro__egg-button {
+  position: relative;
+  width: min(250px, 62vw);
+  height: min(250px, 62vw);
+  padding: 0;
+  border: none;
+  background: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: opacity 0.3s ease;
+  z-index: 4;
+}
+
+.level-one-intro__egg-button[disabled] {
+  cursor: default;
+  pointer-events: none;
+}
+
+.level-one-intro__egg-button::after {
+  content: '';
+  position: absolute;
+  inset: -80px;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle,
+    rgba(2, 221, 255, 0.45) 0%,
+    rgba(2, 221, 255, 0) 70%
+  );
+  opacity: 0;
+  transform: scale(0.85);
+  filter: blur(0px);
+  pointer-events: none;
+}
+
+.level-one-intro__egg-button.is-glowing::after {
+  animation: level-one-egg-glow 2s ease-in-out infinite;
+}
+
+.level-one-intro__egg-button.is-hidden {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.level-one-intro__egg-image {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  transform: scale(0.45);
+  opacity: 0;
+  filter: drop-shadow(0 24px 32px rgba(0, 27, 65, 0.32));
+}
+
+.level-one-intro__egg-image.is-pop-in {
+  animation: level-one-egg-pop 0.6s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+.level-one-intro__egg-image.is-hatching {
+  animation: level-one-egg-hatch 0.9s cubic-bezier(0.36, 0, 0.66, -0.01) forwards;
+}
+
+.level-one-intro__card {
+  position: absolute;
+  left: 50%;
+  bottom: clamp(40px, 12vh, 110px);
+  transform: translate(-50%, 24px) scale(0.9);
+  width: min(360px, calc(100vw - 48px));
+  padding: clamp(20px, 4vw, 28px);
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 26px 48px rgba(0, 27, 65, 0.32);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  text-align: center;
+  opacity: 0;
+  pointer-events: none;
+  z-index: 5;
+}
+
+.level-one-intro__card.is-visible {
+  pointer-events: auto;
+  animation: level-one-card-pop 0.45s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+.level-one-intro__card.is-exiting {
+  pointer-events: none;
+  animation: level-one-card-exit 0.35s cubic-bezier(0.45, 0, 0.75, 0.45) forwards;
+}
+
+.level-one-intro__card-avatar {
+  width: 80px;
+  height: 80px;
+  border-radius: 20px;
+  object-fit: contain;
+  background: linear-gradient(180deg, rgba(2, 221, 255, 0.18), rgba(2, 221, 255, 0));
+  box-shadow: 0 14px 28px rgba(0, 46, 90, 0.28);
+}
+
+.level-one-intro__card-text {
+  margin: 0;
+  color: rgba(31, 45, 72, 0.96);
+  font-size: var(--text-size-medium);
+  line-height: 1.4;
+}
+
+.level-one-intro__card-button {
+  width: 100%;
+  padding: 14px 24px;
+  border: none;
+  border-radius: 999px;
+  font-size: var(--text-size-medium);
+  font-weight: 600;
+  color: #ffffff;
+  background: linear-gradient(180deg, #4de7ff 0%, #008aff 100%);
+  box-shadow: 0 18px 32px rgba(0, 58, 128, 0.35);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.level-one-intro__card-button:focus-visible {
+  outline: 3px solid rgba(2, 221, 255, 0.7);
+  outline-offset: 2px;
+}
+
+.level-one-intro__card-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 20px 36px rgba(0, 58, 128, 0.38);
+}
+
+.level-one-intro__card-button:active {
+  transform: translateY(0);
+  box-shadow: 0 12px 24px rgba(0, 58, 128, 0.32);
+}
+
+@keyframes level-one-egg-pop {
+  0% {
+    transform: scale(0.4);
+    opacity: 0;
+  }
+  65% {
+    transform: scale(1.12);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes level-one-egg-glow {
+  0% {
+    opacity: 0;
+    transform: scale(0.85);
+  }
+  50% {
+    opacity: 0.65;
+    transform: scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(0.85);
+  }
+}
+
+@keyframes level-one-egg-hatch {
+  0% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  60% {
+    transform: scale(1.24);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1.38);
+    opacity: 0;
+    filter: blur(2px);
+  }
+}
+
+@keyframes level-one-card-pop {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, 24px) scale(0.9);
+  }
+  60% {
+    opacity: 1;
+    transform: translate(-50%, -6px) scale(1.04);
+  }
+  100% {
+    opacity: 1;
+    transform: translate(-50%, 0) scale(1);
+  }
+}
+
+@keyframes level-one-card-exit {
+  0% {
+    opacity: 1;
+    transform: translate(-50%, 0) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, 12px) scale(0.94);
+  }
 }
 
 body.is-battle-transition {

--- a/index.html
+++ b/index.html
@@ -99,6 +99,74 @@
     />
 
   </main>
+  <div class="level-one-intro" data-level-one-intro aria-hidden="true">
+    <button
+      class="level-one-intro__egg-button"
+      type="button"
+      data-level-one-egg-button
+      aria-label="Inspect the mysterious egg"
+      disabled
+    >
+      <img
+        class="level-one-intro__egg-image"
+        src="./images/intro/egg.png"
+        alt="Glowing egg"
+        width="250"
+        height="250"
+        data-level-one-egg-image
+      />
+    </button>
+
+    <div
+      class="level-one-intro__card"
+      data-level-one-card="welcome"
+      aria-hidden="true"
+    >
+      <img
+        class="level-one-intro__card-avatar"
+        src="./images/intro/doctor.png"
+        alt="Dr. Wave"
+        width="80"
+        height="80"
+      />
+      <p class="level-one-intro__card-text">
+        Hi! I’m Dr. Wave. I study the ocean… and I think this egg is about to
+        hatch!
+      </p>
+      <button
+        class="level-one-intro__card-button"
+        type="button"
+        data-level-one-card-continue
+      >
+        Continue
+      </button>
+    </div>
+
+    <div
+      class="level-one-intro__card"
+      data-level-one-card="battle"
+      aria-hidden="true"
+    >
+      <img
+        class="level-one-intro__card-avatar"
+        src="./images/intro/doctor.png"
+        alt="Dr. Wave"
+        width="80"
+        height="80"
+      />
+      <p class="level-one-intro__card-text">
+        Wow! This creature fights monsters with math power. Give it a try and
+        see!
+      </p>
+      <button
+        class="level-one-intro__card-button"
+        type="button"
+        data-level-one-card-battle
+      >
+        Battle
+      </button>
+    </div>
+  </div>
   <div class="battle-intro" data-battle-intro aria-hidden="true">
     <img
       class="battle-intro__image"


### PR DESCRIPTION
## Summary
- add dedicated level one intro overlay with egg pop, Dr. Wave dialogue cards, and glow-driven egg interaction
- implement hatching flow that reveals the hero sprite before launching the battle sequence and polish supporting CSS
- update landing logic to drive the new intro, handle hero visibility, and reuse battle launch handling for the final battle CTA

## Testing
- `python3 -m http.server 8000` (manual visual verification)


------
https://chatgpt.com/codex/tasks/task_e_68d9e872efd48329898463a00a4cdd6f