### PR TITLE
Refine landing intro visuals

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -260,6 +260,17 @@ body:not(.is-level-one-landing) .level-one-intro {
   overflow: visible;
 }
 
+.level-one-intro__egg-button:focus {
+  outline: none;
+}
+
+.level-one-intro__egg-button:focus-visible {
+  outline: none;
+  border-radius: 50%;
+  box-shadow: 0 0 0 3px rgba(2, 221, 255, 0.75),
+    0 0 24px rgba(2, 221, 255, 0.55);
+}
+
 .level-one-intro__egg-button[disabled] {
   cursor: default;
   pointer-events: none;
@@ -272,14 +283,18 @@ body:not(.is-level-one-landing) .level-one-intro {
   border-radius: 50%;
   background: radial-gradient(
     circle,
-    rgba(2, 221, 255, 0.45) 0%,
-    rgba(2, 221, 255, 0) 70%
+    rgba(2, 221, 255, 0.75) 0%,
+    rgba(2, 221, 255, 0.4) 36%,
+    rgba(2, 221, 255, 0.15) 68%,
+    rgba(2, 221, 255, 0) 100%
   );
   opacity: 0;
-  transform: scale(0.85);
-  filter: blur(0px);
+  transform: scale(0.82);
+  filter: blur(12px);
+  mix-blend-mode: screen;
   pointer-events: none;
   z-index: 0;
+  will-change: opacity, transform, filter;
 }
 
 .level-one-intro__egg-button.is-glowing::after {
@@ -371,15 +386,18 @@ body:not(.is-level-one-landing) .level-one-intro {
 @keyframes level-one-egg-glow {
   0% {
     opacity: 0;
-    transform: scale(0.85);
+    transform: scale(0.78);
+    filter: blur(18px);
   }
-  50% {
-    opacity: 0.65;
-    transform: scale(1);
+  45% {
+    opacity: 0.95;
+    transform: scale(1.08);
+    filter: blur(8px);
   }
   100% {
     opacity: 0;
-    transform: scale(0.85);
+    transform: scale(0.8);
+    filter: blur(16px);
   }
 }
 
@@ -476,15 +494,15 @@ body.is-battle-transition .bubbles {
       scaleX(-1) scale(1);
     opacity: 1;
   }
-  50% {
+  28% {
     transform: translate(-50%, calc(-50% - var(--hero-float-range, 32px)))
-      scaleX(-1) scale(1.08);
+      scaleX(-1) scale(0.92);
     opacity: 1;
   }
-  60% {
+  62% {
     transform: translate(-50%, calc(-50% - var(--hero-float-range, 32px)))
-      scaleX(-1) scale(1.05);
-    opacity: 0.96;
+      scaleX(-1) scale(0.76);
+    opacity: 0.9;
   }
   100% {
     transform: translate(-50%, calc(-50% - var(--hero-float-range, 32px)))

--- a/index.html
+++ b/index.html
@@ -35,14 +35,38 @@
   </div>
   <main class="landing">
     <div class="bubbles" aria-hidden="true">
-      <span class="bubble" style="--size: 18px; --duration: 6.5s; --delay: 0s;"></span>
-      <span class="bubble" style="--size: 24px; --duration: 7.2s; --delay: 0.6s;"></span>
-      <span class="bubble" style="--size: 14px; --duration: 6s; --delay: 1.1s;"></span>
-      <span class="bubble" style="--size: 20px; --duration: 6.8s; --delay: 0.3s;"></span>
-      <span class="bubble" style="--size: 26px; --duration: 7.5s; --delay: 1.4s;"></span>
-      <span class="bubble" style="--size: 16px; --duration: 6.2s; --delay: 0.9s;"></span>
-      <span class="bubble" style="--size: 22px; --duration: 7s; --delay: 1.7s;"></span>
-      <span class="bubble" style="--size: 18px; --duration: 6.4s; --delay: 0.5s;"></span>
+      <span
+        class="bubble"
+        style="--size: 18px; --duration: 6.5s; --delay: -1.8s;"
+      ></span>
+      <span
+        class="bubble"
+        style="--size: 24px; --duration: 7.2s; --delay: -3.1s;"
+      ></span>
+      <span
+        class="bubble"
+        style="--size: 14px; --duration: 6s; --delay: -0.9s;"
+      ></span>
+      <span
+        class="bubble"
+        style="--size: 20px; --duration: 6.8s; --delay: -2.6s;"
+      ></span>
+      <span
+        class="bubble"
+        style="--size: 26px; --duration: 7.5s; --delay: -4.4s;"
+      ></span>
+      <span
+        class="bubble"
+        style="--size: 16px; --duration: 6.2s; --delay: -1.4s;"
+      ></span>
+      <span
+        class="bubble"
+        style="--size: 22px; --duration: 7s; --delay: -3.7s;"
+      ></span>
+      <span
+        class="bubble"
+        style="--size: 18px; --duration: 6.4s; --delay: -0.6s;"
+      ></span>
     </div>
 
     <section class="landing__hero-info" aria-live="polite">

--- a/js/index.js
+++ b/js/index.js
@@ -1087,25 +1087,6 @@ const applyLandingModeRequest = () => {
   clearLandingModeRequestFromQuery();
 };
 
-const randomizeBubbleTimings = () => {
-  const bubbles = document.querySelectorAll('.bubble');
-
-  bubbles.forEach((bubble) => {
-    const computedStyles = window.getComputedStyle(bubble);
-    const durationValue = computedStyles.getPropertyValue('--duration').trim();
-    const durationInSeconds = Number.parseFloat(durationValue);
-
-    if (!Number.isFinite(durationInSeconds) || durationInSeconds <= 0) {
-      const fallbackOffset = -(Math.random() * 2);
-      bubble.style.setProperty('--delay', `${fallbackOffset.toFixed(3)}s`);
-      return;
-    }
-
-    const randomOffset = Math.random() * durationInSeconds;
-    bubble.style.setProperty('--delay', `${-randomOffset.toFixed(3)}s`);
-  });
-};
-
 const preloadLandingAssets = async () => {
   const results = { levelsData: null, playerData: null, previewData: null };
   const imageAssets = new Set([
@@ -1268,8 +1249,6 @@ const initLandingInteractions = async (preloadedData = {}) => {
     redirectToBattle();
     return;
   }
-  randomizeBubbleTimings();
-
   const heroImage = document.querySelector('.hero');
   const enemyImage = document.querySelector('[data-enemy]');
   let battleButton = document.querySelector('[data-battle-button]');


### PR DESCRIPTION
## Summary
- keep the intro bubbles anchored by giving each one a fixed animation offset and removing the runtime randomizer
- intensify the level-one egg glow and replace the default focus ring with an on-theme highlight
- update the hero exit animation so the sprite shrinks before fading away

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9f671eb90832983643dd5d3deac9c