### PR TITLE
Adjust egg glow and sync battle intro exits

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -279,18 +279,18 @@ body:not(.is-level-one-landing) .level-one-intro {
 .level-one-intro__egg-button::after {
   content: '';
   position: absolute;
-  inset: -80px;
+  inset: -56px;
   border-radius: 50%;
   background: radial-gradient(
     circle,
-    rgba(2, 221, 255, 0.75) 0%,
-    rgba(2, 221, 255, 0.4) 36%,
-    rgba(2, 221, 255, 0.15) 68%,
-    rgba(2, 221, 255, 0) 100%
+    rgba(2, 221, 255, 0.78) 0%,
+    rgba(2, 221, 255, 0.42) 32%,
+    rgba(2, 221, 255, 0.16) 58%,
+    rgba(2, 221, 255, 0) 82%
   );
   opacity: 0;
-  transform: scale(0.82);
-  filter: blur(12px);
+  transform: scale(0.74);
+  filter: blur(10px);
   mix-blend-mode: screen;
   pointer-events: none;
   z-index: 0;
@@ -305,6 +305,12 @@ body:not(.is-level-one-landing) .level-one-intro {
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
+}
+
+.level-one-intro__egg-button.is-hidden::after {
+  animation: none;
+  opacity: 0;
+  background: none;
 }
 
 .level-one-intro__egg-image {
@@ -386,18 +392,18 @@ body:not(.is-level-one-landing) .level-one-intro {
 @keyframes level-one-egg-glow {
   0% {
     opacity: 0;
-    transform: scale(0.78);
-    filter: blur(18px);
+    transform: scale(0.7);
+    filter: blur(14px);
   }
   45% {
     opacity: 0.95;
-    transform: scale(1.08);
-    filter: blur(8px);
+    transform: scale(0.98);
+    filter: blur(6px);
   }
   100% {
     opacity: 0;
-    transform: scale(0.8);
-    filter: blur(16px);
+    transform: scale(0.72);
+    filter: blur(12px);
   }
 }
 

--- a/js/index.js
+++ b/js/index.js
@@ -20,6 +20,7 @@ const LEVEL_ONE_INTRO_CARD_DELAY_MS = 400;
 const LEVEL_ONE_INTRO_CARD_EXIT_DURATION_MS = 350;
 const LEVEL_ONE_INTRO_EGG_HATCH_DURATION_MS = 900;
 const LEVEL_ONE_INTRO_HERO_REVEAL_DELAY_MS = 2000;
+const LEVEL_ONE_INTRO_EGG_REMOVAL_DELAY_MS = 350;
 
 const CSS_VIEWPORT_OFFSET_VAR = '--viewport-bottom-offset';
 
@@ -226,12 +227,18 @@ const runBattleIntroSequence = async (options = {}) => {
     battleIntroImage.classList.add('is-pop-in');
   };
 
-  const hideBattleIntro = () => {
+  const hideBattleIntro = (onPopOutStart) => {
     if (!battleIntro || !battleIntroImage) {
+      if (typeof onPopOutStart === 'function') {
+        onPopOutStart();
+      }
       return 0;
     }
     battleIntroImage.classList.remove('is-pop-in');
     void battleIntroImage.offsetWidth;
+    if (typeof onPopOutStart === 'function') {
+      onPopOutStart();
+    }
     battleIntroImage.classList.add('is-pop-out');
     const duration = Math.max(0, BATTLE_CALL_POP_OUT_DURATION_MS);
     window.setTimeout(() => {
@@ -243,11 +250,13 @@ const runBattleIntroSequence = async (options = {}) => {
 
   const beginExitAnimations = () => {
     document.body.classList.add('is-battle-transition');
-    heroImage.classList.add('is-exiting');
-    if (enemyImage && !skipEnemyAppearance) {
-      enemyImage.classList.add('is-exiting');
-    }
-    return hideBattleIntro();
+    const syncCharacterExit = () => {
+      heroImage.classList.add('is-exiting');
+      if (enemyImage && !skipEnemyAppearance) {
+        enemyImage.classList.add('is-exiting');
+      }
+    };
+    return hideBattleIntro(syncCharacterExit);
   };
 
   const applySidePositionIfNeeded = () => {
@@ -442,6 +451,11 @@ const setupLevelOneIntro = ({ heroImage, beginBattle } = {}) => {
     await wait(LEVEL_ONE_INTRO_EGG_HATCH_DURATION_MS);
     eggButton.classList.remove('is-visible');
     eggButton.classList.add('is-hidden');
+    window.setTimeout(() => {
+      if (eggButton?.parentElement) {
+        eggButton.parentElement.removeChild(eggButton);
+      }
+    }, LEVEL_ONE_INTRO_EGG_REMOVAL_DELAY_MS);
     revealHero();
     await wait(LEVEL_ONE_INTRO_HERO_REVEAL_DELAY_MS);
     await showBattleCard();


### PR DESCRIPTION
## Summary
- tighten the egg button glow radius and clear its glow effect when hidden
- remove the egg button element after hatching to eliminate the lingering blue box
- trigger the hero exit animation in sync with the battle call pop-out animation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9f941c28c8329877274ed6a7a29a1