### PR TITLE
Refine egg glow and sync hero exit

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -221,6 +221,11 @@ body.is-level-one-landing .hero.is-revealed {
   visibility: visible;
 }
 
+body.is-level-one-landing .hero.is-exiting {
+  visibility: visible;
+  animation: hero-intro-exit 0.7s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
 body:not(.is-level-one-landing) .level-one-intro {
   display: none;
 }
@@ -279,18 +284,18 @@ body:not(.is-level-one-landing) .level-one-intro {
 .level-one-intro__egg-button::after {
   content: '';
   position: absolute;
-  inset: -80px;
+  inset: -42px;
   border-radius: 50%;
   background: radial-gradient(
     circle,
-    rgba(2, 221, 255, 0.75) 0%,
-    rgba(2, 221, 255, 0.4) 36%,
-    rgba(2, 221, 255, 0.15) 68%,
-    rgba(2, 221, 255, 0) 100%
+    rgba(0, 188, 255, 0.88) 0%,
+    rgba(0, 174, 255, 0.52) 32%,
+    rgba(0, 136, 255, 0.18) 58%,
+    rgba(0, 92, 255, 0) 82%
   );
   opacity: 0;
-  transform: scale(0.82);
-  filter: blur(12px);
+  transform: scale(0.74);
+  filter: blur(10px);
   mix-blend-mode: screen;
   pointer-events: none;
   z-index: 0;
@@ -305,6 +310,13 @@ body:not(.is-level-one-landing) .level-one-intro {
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
+  display: none;
+}
+
+.level-one-intro__egg-button.is-hidden::after {
+  animation: none;
+  opacity: 0;
+  background: none;
 }
 
 .level-one-intro__egg-image {
@@ -386,18 +398,18 @@ body:not(.is-level-one-landing) .level-one-intro {
 @keyframes level-one-egg-glow {
   0% {
     opacity: 0;
-    transform: scale(0.78);
-    filter: blur(18px);
+    transform: scale(0.7);
+    filter: blur(14px);
   }
   45% {
     opacity: 0.95;
-    transform: scale(1.08);
-    filter: blur(8px);
+    transform: scale(0.98);
+    filter: blur(6px);
   }
   100% {
     opacity: 0;
-    transform: scale(0.8);
-    filter: blur(16px);
+    transform: scale(0.72);
+    filter: blur(12px);
   }
 }
 


### PR DESCRIPTION
## Summary
- shrink the level one egg glow radius and shift the gradient toward a richer blue tone
- hide the egg button immediately after hatching and blur focus to prevent the lingering square
- ensure the hero exit animation plays on level one landings when the battle call scales down

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9f941c28c8329877274ed6a7a29a1