### PR TITLE
Streamline level one battle handoff

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -221,6 +221,11 @@ body.is-level-one-landing .hero.is-revealed {
   visibility: visible;
 }
 
+body.is-level-one-landing .hero.is-exiting {
+  visibility: visible;
+  animation: hero-intro-exit 0.7s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
 body:not(.is-level-one-landing) .level-one-intro {
   display: none;
 }
@@ -279,18 +284,18 @@ body:not(.is-level-one-landing) .level-one-intro {
 .level-one-intro__egg-button::after {
   content: '';
   position: absolute;
-  inset: -80px;
+  inset: -42px;
   border-radius: 50%;
   background: radial-gradient(
     circle,
-    rgba(2, 221, 255, 0.75) 0%,
-    rgba(2, 221, 255, 0.4) 36%,
-    rgba(2, 221, 255, 0.15) 68%,
-    rgba(2, 221, 255, 0) 100%
+    rgba(0, 188, 255, 0.79) 0%,
+    rgba(0, 174, 255, 0.47) 32%,
+    rgba(0, 136, 255, 0.16) 58%,
+    rgba(0, 92, 255, 0) 82%
   );
   opacity: 0;
-  transform: scale(0.82);
-  filter: blur(12px);
+  transform: scale(0.74);
+  filter: blur(10px);
   mix-blend-mode: screen;
   pointer-events: none;
   z-index: 0;
@@ -301,10 +306,22 @@ body:not(.is-level-one-landing) .level-one-intro {
   animation: level-one-egg-glow 2s ease-in-out infinite;
 }
 
+.level-one-intro__egg-button.is-hatching::after {
+  opacity: 0;
+  background: none;
+}
+
 .level-one-intro__egg-button.is-hidden {
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
+  display: none;
+}
+
+.level-one-intro__egg-button.is-hidden::after {
+  animation: none;
+  opacity: 0;
+  background: none;
 }
 
 .level-one-intro__egg-image {
@@ -386,18 +403,18 @@ body:not(.is-level-one-landing) .level-one-intro {
 @keyframes level-one-egg-glow {
   0% {
     opacity: 0;
-    transform: scale(0.78);
-    filter: blur(18px);
+    transform: scale(0.7);
+    filter: blur(14px);
   }
   45% {
     opacity: 0.95;
-    transform: scale(1.08);
-    filter: blur(8px);
+    transform: scale(0.98);
+    filter: blur(6px);
   }
   100% {
     opacity: 0;
-    transform: scale(0.8);
-    filter: blur(16px);
+    transform: scale(0.72);
+    filter: blur(12px);
   }
 }
 
@@ -755,83 +772,6 @@ body.is-battle-transition .bubbles {
   10%  {                            --sx: 0.98; --sy: 0.98; opacity: 0.45; }
   40%  {                            --sx: 1.02; --sy: 1.02; opacity: 0.92; }
   100% { --ty: -110vh;              --sx: 1.06; --sy: 1.06; opacity: 0; }
-}
-
-.battle-intro {
-  position: fixed;
-  left: var(--battle-intro-left, 50%);
-  top: var(--battle-intro-top, 50%);
-  transform: translate(-50%, -50%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  pointer-events: none;
-  opacity: 0;
-  visibility: hidden;
-  z-index: 3;
-}
-
-.battle-intro__image {
-  width: min(350px, 90vw);
-  height: min(350px, 90vw);
-  object-fit: contain;
-  transform: scale(0.2);
-  transform-origin: center;
-  opacity: 0;
-}
-
-.battle-intro.is-visible {
-  opacity: 1;
-  visibility: visible;
-}
-
-.battle-intro__image.is-pop-in {
-  animation: battle-intro-pop 0.6s cubic-bezier(0.16, 1, 0.3, 1) forwards;
-}
-
-.battle-intro__image.is-pop-out {
-  animation: battle-intro-pop-out 0.45s cubic-bezier(0.16, 1, 0.3, 1) forwards;
-}
-
-@keyframes battle-intro-pop {
-  0% {
-    transform: scale(0.2);
-    opacity: 0;
-  }
-  60% {
-    transform: scale(1.12);
-    opacity: 1;
-  }
-  100% {
-    transform: scale(1);
-    opacity: 1;
-  }
-}
-
-@keyframes battle-intro-pop-out {
-  0% {
-    transform: scale(1);
-    opacity: 1;
-  }
-  40% {
-    transform: scale(1.08);
-    opacity: 1;
-  }
-  100% {
-    transform: scale(0.2);
-    opacity: 0;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .battle-intro {
-    transition: none;
-  }
-
-  .battle-intro__image {
-    transform: scale(1);
-    opacity: 1;
-  }
 }
 
 /* Organic horizontal meander tied to --drift */

--- a/index.html
+++ b/index.html
@@ -169,8 +169,7 @@
         height="80"
       />
       <p class="level-one-intro__card-text">
-        Wow! This creature fights monsters with math power. Give it a try and
-        see!
+        Wow! This creature fights monsters with math. Give it a try and see!
       </p>
       <button
         class="btn-primary"
@@ -180,15 +179,6 @@
         Battle
       </button>
     </div>
-  </div>
-  <div class="battle-intro" data-battle-intro aria-hidden="true">
-    <img
-      class="battle-intro__image"
-      src="./images/battle/battle_time.png"
-      alt="Battle time"
-      width="350"
-      height="350"
-    />
   </div>
   <script>
     window.SUPABASE_URL = 'https://jxlxpumcoihfapmrsaqd.supabase.co';


### PR DESCRIPTION
## Summary
- dim the level one egg glow and cut the glow pseudo-element during hatching so the blue box disappears
- remove the battle intro artwork and drive the hero/enemy exit timing directly for a smooth pre-battle scale-down
- update the level one battle card copy

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9f941c28c8329877274ed6a7a29a1