### PR TITLE
Refine level one intro animations

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -147,7 +147,7 @@ body:not(.is-preloading) main.landing {
   z-index: 2;
   pointer-events: none;
   will-change: transform, opacity;
-  transition: left 0.7s cubic-bezier(0.22, 1, 0.36, 1);
+  transition: left 0.45s cubic-bezier(0.36, 0, 0.66, 1);
 }
 
 .hero.is-click-scaling {
@@ -161,11 +161,11 @@ body:not(.is-preloading) main.landing {
 }
 
 .hero.is-exiting {
-  animation: hero-intro-exit 0.75s cubic-bezier(0.32, 0, 0.67, 1) forwards;
+  animation: hero-intro-exit 0.55s cubic-bezier(0.36, 0, 0.66, 1) forwards;
 }
 
 .hero.is-exiting.is-click-scaling {
-  animation: hero-intro-exit 0.75s cubic-bezier(0.32, 0, 0.67, 1) forwards;
+  animation: hero-intro-exit 0.55s cubic-bezier(0.36, 0, 0.66, 1) forwards;
 }
 
 .enemy {
@@ -233,7 +233,7 @@ body.is-level-one-landing .hero.is-revealed {
 
 body.is-level-one-landing .hero.is-exiting {
   visibility: visible;
-  animation: hero-intro-exit 0.75s cubic-bezier(0.32, 0, 0.67, 1) forwards;
+  animation: hero-intro-exit 0.55s cubic-bezier(0.36, 0, 0.66, 1) forwards;
 }
 
 body:not(.is-level-one-landing) .level-one-intro {
@@ -258,7 +258,6 @@ body:not(.is-level-one-landing) .level-one-intro {
   visibility: visible;
   pointer-events: auto;
 }
-
 .level-one-intro__egg-button {
   position: relative;
   width: min(250px, 62vw);
@@ -271,7 +270,7 @@ body:not(.is-level-one-landing) .level-one-intro {
   display: flex;
   align-items: center;
   justify-content: center;
-  cursor: pointer;
+  cursor: default;
   transition: opacity 0.3s ease;
   z-index: 4;
   overflow: visible;
@@ -285,38 +284,7 @@ body:not(.is-level-one-landing) .level-one-intro {
 }
 
 .level-one-intro__egg-button[disabled] {
-  cursor: default;
   pointer-events: none;
-}
-
-.level-one-intro__egg-button::after {
-  content: '';
-  position: absolute;
-  inset: -42px;
-  border-radius: 50%;
-  background: radial-gradient(
-    circle,
-    rgba(0, 188, 255, 0.79) 0%,
-    rgba(0, 174, 255, 0.47) 32%,
-    rgba(0, 136, 255, 0.16) 58%,
-    rgba(0, 92, 255, 0) 82%
-  );
-  opacity: 0;
-  transform: scale(0.74);
-  filter: blur(10px);
-  mix-blend-mode: screen;
-  pointer-events: none;
-  z-index: 0;
-  will-change: opacity, transform, filter;
-}
-
-.level-one-intro__egg-button.is-glowing::after {
-  animation: level-one-egg-glow 2s ease-in-out infinite;
-}
-
-.level-one-intro__egg-button.is-hatching::after {
-  opacity: 0;
-  background: none;
 }
 
 .level-one-intro__egg-button.is-hidden {
@@ -326,17 +294,11 @@ body:not(.is-level-one-landing) .level-one-intro {
   display: none;
 }
 
-.level-one-intro__egg-button.is-hidden::after {
-  animation: none;
-  opacity: 0;
-  background: none;
-}
-
 .level-one-intro__egg-image {
   width: 100%;
   height: 100%;
   object-fit: contain;
-  transform: scale(0.45);
+  transform: scale(1);
   opacity: 0;
   position: relative;
   z-index: 1;
@@ -347,7 +309,7 @@ body:not(.is-level-one-landing) .level-one-intro {
 }
 
 .level-one-intro__egg-image.is-hatching {
-  animation: level-one-egg-hatch 0.9s cubic-bezier(0.36, 0, 0.66, -0.01) forwards;
+  animation: level-one-egg-hatch 1.6s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
 }
 
 
@@ -395,34 +357,16 @@ body:not(.is-level-one-landing) .level-one-intro {
 
 @keyframes level-one-egg-pop {
   0% {
-    transform: scale(0.4);
+    transform: scale(0.24);
     opacity: 0;
   }
-  65% {
-    transform: scale(1.12);
+  52% {
+    transform: scale(1.05);
     opacity: 1;
   }
   100% {
     transform: scale(1);
     opacity: 1;
-  }
-}
-
-@keyframes level-one-egg-glow {
-  0% {
-    opacity: 0;
-    transform: scale(0.7);
-    filter: blur(14px);
-  }
-  45% {
-    opacity: 0.95;
-    transform: scale(0.98);
-    filter: blur(6px);
-  }
-  100% {
-    opacity: 0;
-    transform: scale(0.72);
-    filter: blur(12px);
   }
 }
 
@@ -431,14 +375,25 @@ body:not(.is-level-one-landing) .level-one-intro {
     transform: scale(1);
     opacity: 1;
   }
-  60% {
-    transform: scale(1.24);
+  28% {
+    transform: scale(1.12);
+    opacity: 1;
+  }
+  46% {
+    transform: scale(1.04);
+    opacity: 1;
+  }
+  72% {
+    transform: scale(1.22);
+    opacity: 1;
+  }
+  86% {
+    transform: scale(1.15);
     opacity: 1;
   }
   100% {
-    transform: scale(1.38);
+    transform: scale(0.7);
     opacity: 0;
-    filter: blur(2px);
   }
 }
 
@@ -542,24 +497,19 @@ body.is-battle-transition .bubbles {
       scaleX(-1) scale(1);
     opacity: 1;
   }
-  22% {
+  38% {
     transform: translate(-50%, calc(-50% - var(--hero-float-range, 32px)))
-      scaleX(-1) scale(0.94);
-    opacity: 1;
+      scaleX(-1) scale(0.88);
+    opacity: 0.98;
   }
-  48% {
+  68% {
     transform: translate(-50%, calc(-50% - var(--hero-float-range, 32px)))
-      scaleX(-1) scale(0.84);
-    opacity: 0.96;
-  }
-  74% {
-    transform: translate(-50%, calc(-50% - var(--hero-float-range, 32px)))
-      scaleX(-1) scale(0.72);
-    opacity: 0.85;
+      scaleX(-1) scale(0.7);
+    opacity: 0.82;
   }
   100% {
     transform: translate(-50%, calc(-50% - var(--hero-float-range, 32px)))
-      scaleX(-1) scale(0.6);
+      scaleX(-1) scale(0.58);
     opacity: 0;
   }
 }

--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@
       <img
         class="level-one-intro__egg-image"
         src="./images/intro/egg.png"
-        alt="Glowing egg"
+        alt="Mysterious egg"
         width="250"
         height="250"
         data-level-one-egg-image


### PR DESCRIPTION
## Summary
- remove the deprecated glow styling on the level-one egg and trigger an automatic hatch animation after the welcome card
- speed up the egg-to-hero reveal timing and battle intro by tightening hero animation easing and delays

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da7ddbb080832987740c5f391c5703