### PR TITLE
Update post-battle progress UX

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -513,79 +513,11 @@ body.is-reward-active .reward-overlay {
   margin: 0;
 }
 
-.battle-complete-card__enemy {
-  position: relative;
-  width: 100%;
-  display: flex;
-  justify-content: center;
+.battle-complete-card__meter .meter__icon {
+  width: 80px;
+  height: 80px;
 }
 
-.battle-complete-card .enemy-image {
-  display: block;
-  max-width: 200px;
-  width: 100%;
-  height: auto;
-  transition: filter 0.4s ease, opacity 0.4s ease;
-}
-
-.battle-complete-card .enemy-image.enemy-image--defeated {
-  filter: saturate(0);
-  opacity: 0.1;
-}
-
-.battle-complete-card .enemy-defeat-overlay {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%) scale(0.4);
-  opacity: 0;
-  max-width: 200px;
-  z-index: 1;
-  pointer-events: none;
-}
-
-.battle-complete-card .enemy-defeat-overlay img {
-  display: block;
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
-}
-
-@keyframes enemy-defeat-check-pop {
-  0% {
-    transform: translate(-50%, -50%) scale(0.4);
-    opacity: 0;
-  }
-
-  60% {
-    transform: translate(-50%, -50%) scale(1.15);
-    opacity: 1;
-  }
-
-  100% {
-    transform: translate(-50%, -50%) scale(1);
-    opacity: 1;
-  }
-}
-
-.battle-complete-card .enemy-defeat-overlay--visible {
-  animation: enemy-defeat-check-pop 0.45s ease-out forwards;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .battle-complete-card .enemy-image {
-    transition: none;
-  }
-
-  .battle-complete-card .enemy-defeat-overlay {
-    transform: translate(-50%, -50%) scale(1);
-  }
-
-  .battle-complete-card .enemy-defeat-overlay--visible {
-    animation: none;
-    opacity: 1;
-  }
-}
 
 
 .battle-dev-controls {

--- a/html/battle.html
+++ b/html/battle.html
@@ -128,16 +128,6 @@
         <h2 id="battle-complete-title" class="battle-complete-card__title battle-title">
           Monster Defeated
         </h2>
-        <div class="battle-complete-card__enemy">
-          <img
-            class="enemy-image"
-            src="../images/battle/monster_battle_1_1.png"
-            alt="Enemy preparing for the next battle"
-          />
-          <div class="enemy-defeat-overlay" data-enemy-defeat-overlay aria-hidden="true">
-            <img src="../images/complete/check.svg" alt="" />
-          </div>
-        </div>
         <div class="meter meter--visible battle-complete-card__meter">
           <img
             class="meter__icon"

--- a/index.html
+++ b/index.html
@@ -144,8 +144,8 @@
         height="80"
       />
       <p class="level-one-intro__card-text">
-        Hi! I’m Dr. Wave. I study the ocean… and I think this egg is about to
-        hatch!
+        Hi! I’m Dr. Wave. I study math in the ocean. I think this egg is about
+        to hatch!
       </p>
       <button
         class="btn-primary"

--- a/js/battle.js
+++ b/js/battle.js
@@ -8,6 +8,7 @@ const BATTLE_PAGE_MODE_PLAY = 'play';
 const ENEMY_DEFEAT_ANIMATION_DELAY = 1000;
 const VICTORY_PROGRESS_UPDATE_DELAY = ENEMY_DEFEAT_ANIMATION_DELAY + 1000;
 const DEFEAT_PROGRESS_UPDATE_DELAY = 1000;
+const LEVEL_PROGRESS_ANIMATION_DELAY_MS = 1000;
 
 const progressUtils =
   (typeof globalThis !== 'undefined' && globalThis.mathMonstersProgress) || null;
@@ -219,6 +220,7 @@ document.addEventListener('DOMContentLoaded', () => {
   let hasPendingLevelUpReward = false;
   let rewardAnimationPlayed = false;
   let levelProgressUpdateTimeout = null;
+  let levelProgressAnimationTimeout = null;
   let rewardSpriteTransitionHandler = null;
   let rewardAwaitingActivation = false;
 
@@ -494,6 +496,38 @@ document.addEventListener('DOMContentLoaded', () => {
         ? window.requestAnimationFrame.bind(window)
         : (callback) => window.setTimeout(callback, 16);
 
+    const applyProgressVisuals = () => {
+      requestProgressFrame(() => {
+        if (levelProgressMeter) {
+          levelProgressMeter.style.setProperty('--progress-value', `${clampedRatio}`);
+        }
+        if (levelProgressFill) {
+          levelProgressFill.style.width = targetWidth;
+        }
+      });
+    };
+
+    const scheduleProgressAnimation = () => {
+      if (levelProgressAnimationTimeout !== null) {
+        window.clearTimeout(levelProgressAnimationTimeout);
+        levelProgressAnimationTimeout = null;
+      }
+
+      const animationDelay = prefersReducedMotion
+        ? 0
+        : LEVEL_PROGRESS_ANIMATION_DELAY_MS;
+
+      if (animationDelay > 0) {
+        levelProgressAnimationTimeout = window.setTimeout(() => {
+          levelProgressAnimationTimeout = null;
+          applyProgressVisuals();
+        }, animationDelay);
+        return;
+      }
+
+      applyProgressVisuals();
+    };
+
     if (levelProgressFill) {
       const wasInitialized = levelProgressFill.dataset.progressAnimated === 'true';
 
@@ -507,16 +541,11 @@ document.addEventListener('DOMContentLoaded', () => {
         void levelProgressFill.offsetWidth;
         levelProgressFill.style.transition = '';
       }
-
-      requestProgressFrame(() => {
-        if (levelProgressMeter) {
-          levelProgressMeter.style.setProperty('--progress-value', `${clampedRatio}`);
-        }
-        levelProgressFill.style.width = targetWidth;
-      });
     } else if (levelProgressMeter) {
-      levelProgressMeter.style.setProperty('--progress-value', `${clampedRatio}`);
+      levelProgressMeter.style.setProperty('--progress-value', '0');
     }
+
+    scheduleProgressAnimation();
 
 
     const requirementMet =
@@ -533,6 +562,10 @@ document.addEventListener('DOMContentLoaded', () => {
     if (levelProgressUpdateTimeout !== null) {
       window.clearTimeout(levelProgressUpdateTimeout);
       levelProgressUpdateTimeout = null;
+    }
+    if (levelProgressAnimationTimeout !== null) {
+      window.clearTimeout(levelProgressAnimationTimeout);
+      levelProgressAnimationTimeout = null;
     }
   };
 

--- a/js/utils/progress.js
+++ b/js/utils/progress.js
@@ -66,17 +66,17 @@
       ? Math.max(0, Math.round(requirement))
       : 0;
 
-    const totalWithBase = safeRequirement + 1;
-    const earnedWithBase = Math.min(totalWithBase, safeEarned + 1);
-    const ratio = totalWithBase > 0 ? Math.min(1, earnedWithBase / totalWithBase) : 0;
+    const totalDisplay = safeRequirement;
+    const earnedDisplay = Math.min(totalDisplay, safeEarned);
+    const ratio = totalDisplay > 0 ? Math.min(1, earnedDisplay / totalDisplay) : 0;
 
     return {
       ratio,
-      text: `${earnedWithBase} of ${totalWithBase}`,
-      earned: earnedWithBase,
-      total: totalWithBase,
-      earnedDisplay: earnedWithBase,
-      totalDisplay: totalWithBase,
+      text: `${earnedDisplay} of ${totalDisplay}`,
+      earned: earnedDisplay,
+      total: totalDisplay,
+      earnedDisplay,
+      totalDisplay,
     };
   };
 


### PR DESCRIPTION
## Summary
- remove the enemy illustration from the post-battle completion card and enlarge the reward chest icon
- reset the experience progress calculation so meters start at zero and animate after a one second delay
- refresh the first landing card copy to the new Dr. Wave introduction

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68daaa58ebc08329bb5be90fe811391f