### PR TITLE
Refine level one intro animations

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -151,9 +151,7 @@ body:not(.is-preloading) main.landing {
 }
 
 .hero.is-click-scaling {
-  animation: hero-float var(--hero-float-duration, 3.5s)
-      cubic-bezier(0.42, 0, 0.58, 1) 1.35s infinite,
-    hero-click-pop 340ms cubic-bezier(0.34, 1.56, 0.64, 1) 0s 1 forwards;
+  animation: hero-prebattle-charge 420ms cubic-bezier(0.33, 1, 0.68, 1) forwards;
 }
 
 .hero.is-side-position {
@@ -164,9 +162,6 @@ body:not(.is-preloading) main.landing {
   animation: hero-intro-exit 0.55s cubic-bezier(0.36, 0, 0.66, 1) forwards;
 }
 
-.hero.is-exiting.is-click-scaling {
-  animation: hero-intro-exit 0.55s cubic-bezier(0.36, 0, 0.66, 1) forwards;
-}
 
 .enemy {
   --enemy-float-range: 28px;
@@ -388,7 +383,11 @@ body:not(.is-level-one-landing) .level-one-intro {
     opacity: 1;
   }
   86% {
-    transform: scale(1.15);
+    transform: scale(1.12);
+    opacity: 1;
+  }
+  94% {
+    transform: scale(1.28);
     opacity: 1;
   }
   100% {
@@ -421,22 +420,26 @@ body.is-battle-transition .bubbles {
   }
 }
 
-@keyframes hero-click-pop {
+@keyframes hero-prebattle-charge {
   0% {
     transform: translate(-50%, calc(-50% - var(--hero-float-range, 32px)))
-      scaleX(-1);
+      scaleX(-1) scale(1);
   }
-  48% {
+  58% {
     transform: translate(-50%, calc(-50% - var(--hero-float-range, 32px)))
-      scaleX(-1) scale(0.88);
+      scaleX(-1) scale(1.08);
   }
-  78% {
+  72% {
     transform: translate(-50%, calc(-50% - var(--hero-float-range, 32px)))
-      scaleX(-1) scale(1.06);
+      scaleX(-1) scale(1.16);
+  }
+  88% {
+    transform: translate(-50%, calc(-50% - var(--hero-float-range, 32px)))
+      scaleX(-1) scale(0.9);
   }
   100% {
     transform: translate(-50%, calc(-50% - var(--hero-float-range, 32px)))
-      scaleX(-1);
+      scaleX(-1) scale(1);
   }
 }
 

--- a/js/index.js
+++ b/js/index.js
@@ -21,8 +21,8 @@ const LEVEL_ONE_INTRO_EGG_AUTO_START_DELAY_MS = 1000;
 const LEVEL_ONE_INTRO_EGG_HATCH_DURATION_MS = 1600;
 const LEVEL_ONE_INTRO_HERO_REVEAL_DELAY_MS = 700;
 const LEVEL_ONE_INTRO_EGG_REMOVAL_DELAY_MS = 220;
-const HERO_CLICK_POP_DELAY_MS = 1000;
-const HERO_CLICK_POP_ANIMATION_NAME = 'hero-click-pop';
+const HERO_PREBATTLE_CHARGE_DELAY_MS = 500;
+const HERO_PREBATTLE_CHARGE_ANIMATION_NAME = 'hero-prebattle-charge';
 
 const CSS_VIEWPORT_OFFSET_VAR = '--viewport-bottom-offset';
 
@@ -286,43 +286,59 @@ const setupLevelOneIntro = ({ heroImage, beginBattle } = {}) => {
     typeof window.matchMedia === 'function' &&
     window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-  let heroClickPopTimeoutId = null;
+  let heroPrebattleChargeTimeoutId = null;
 
-  const clearHeroClickPopTimeout = () => {
-    if (heroClickPopTimeoutId !== null) {
-      window.clearTimeout(heroClickPopTimeoutId);
-      heroClickPopTimeoutId = null;
+  const clearHeroPrebattleChargeTimeout = () => {
+    if (heroPrebattleChargeTimeoutId !== null) {
+      window.clearTimeout(heroPrebattleChargeTimeoutId);
+      heroPrebattleChargeTimeoutId = null;
     }
   };
 
-  const scheduleHeroClickPop = () => {
-    if (!heroImage || shouldReduceMotion || HERO_CLICK_POP_DELAY_MS <= 0) {
+  const scheduleHeroPrebattleCharge = () => {
+    if (
+      !heroImage ||
+      shouldReduceMotion ||
+      HERO_PREBATTLE_CHARGE_DELAY_MS <= 0
+    ) {
       return;
     }
 
-    clearHeroClickPopTimeout();
-    heroClickPopTimeoutId = window.setTimeout(() => {
-      heroClickPopTimeoutId = null;
+    clearHeroPrebattleChargeTimeout();
+    heroPrebattleChargeTimeoutId = window.setTimeout(() => {
+      heroPrebattleChargeTimeoutId = null;
 
       if (!heroImage || heroImage.classList.contains('is-exiting')) {
         return;
       }
 
-      const handleHeroClickPopEnd = (event) => {
-        if (event && event.animationName !== HERO_CLICK_POP_ANIMATION_NAME) {
+      const handleHeroPrebattleChargeEnd = (event) => {
+        if (
+          event &&
+          event.animationName !== HERO_PREBATTLE_CHARGE_ANIMATION_NAME
+        ) {
           return;
         }
 
         heroImage.classList.remove('is-click-scaling');
-        heroImage.removeEventListener('animationend', handleHeroClickPopEnd);
-        heroImage.removeEventListener('animationcancel', handleHeroClickPopEnd);
+        heroImage.removeEventListener(
+          'animationend',
+          handleHeroPrebattleChargeEnd
+        );
+        heroImage.removeEventListener(
+          'animationcancel',
+          handleHeroPrebattleChargeEnd
+        );
       };
 
       heroImage.classList.remove('is-click-scaling');
-      heroImage.addEventListener('animationend', handleHeroClickPopEnd);
-      heroImage.addEventListener('animationcancel', handleHeroClickPopEnd);
+      heroImage.addEventListener('animationend', handleHeroPrebattleChargeEnd);
+      heroImage.addEventListener(
+        'animationcancel',
+        handleHeroPrebattleChargeEnd
+      );
       heroImage.classList.add('is-click-scaling');
-    }, HERO_CLICK_POP_DELAY_MS);
+    }, HERO_PREBATTLE_CHARGE_DELAY_MS);
   };
 
   if (
@@ -476,7 +492,7 @@ const setupLevelOneIntro = ({ heroImage, beginBattle } = {}) => {
     }
     hasStartedBattle = true;
     clearEggAutoHatchTimeout();
-    scheduleHeroClickPop();
+    scheduleHeroPrebattleCharge();
     await hideCard(battleCard);
     introRoot.classList.remove('is-active');
     introRoot.setAttribute('aria-hidden', 'true');


### PR DESCRIPTION
## Summary
- trigger the hero's pre-battle charge animation after a shorter delay and reset its event handling
- rebuild the hero scaling animation with a smoother grow-then-shrink motion
- add a third growth beat to the egg hatch animation for extra anticipation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dab3554a2c83299f481e47ac147ee2