### PR TITLE
Add glow effect behind level one egg image

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -271,6 +271,16 @@ body:not(.is-level-one-landing) .level-one-intro {
   overflow: visible;
 }
 
+.level-one-intro__egg-button::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  box-shadow: 0 0 40px 0 #02ddff;
+  z-index: 0;
+  pointer-events: none;
+}
+
 .level-one-intro__egg-button:hover,
 .level-one-intro__egg-button:focus-visible {
   background: none;


### PR DESCRIPTION
## Summary
- add a pseudo-element to the level one egg button that renders a cyan glow behind the egg image

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dabaaa88b08329b769ef2b65c20c37