### PR TITLE
Ensure post-battle card uses global styling

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -396,7 +396,7 @@ body {
   display: flex;
   align-items: flex-end;
   justify-content: center;
-  padding: 24px;
+  padding: 0;
   background: rgba(0, 0, 0, 0.3);
   opacity: 0;
   visibility: hidden;
@@ -494,10 +494,6 @@ body.is-reward-active .reward-overlay {
 }
 
 .battle-complete-card {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
   gap: 24px;
 }
 

--- a/html/battle.html
+++ b/html/battle.html
@@ -124,7 +124,7 @@
       aria-hidden="true"
       tabindex="-1"
     >
-      <section class="card card--pop battle-complete-card">
+      <section class="card card--home card--pop battle-complete-card">
         <h2 id="battle-complete-title" class="battle-complete-card__title battle-title">
           Monster Defeated
         </h2>


### PR DESCRIPTION
## Summary
- apply the global home card styling to the post-battle dialog
- adjust the overlay padding so the card sits flush with the viewport bottom
- remove conflicting positioning rules from the battle-complete card styles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dabbcd3ba483299b07bd1f2dd214f8