### PR TITLE
Delay level 1 intro glow animation

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -269,6 +269,14 @@ body:not(.is-level-one-landing) .level-one-intro {
   border-radius: 50%;
   background: #02ddff;
   filter: blur(40px);
+  opacity: 0;
+  transition: opacity 0.45s ease;
+  transition-delay: 0s;
+}
+
+.level-one-intro__egg-button.is-visible::before {
+  opacity: 1;
+  transition-delay: 0.5s;
 }
 
 .level-one-intro__egg-button:hover,


### PR DESCRIPTION
## Summary
- delay the Level 1 intro egg button's blue glow so it fades in half a second after the egg appears

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dacaa7515483298dda2ae2387b4411