### PR TITLE
Fix reward flow trigger on claim button

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -676,7 +676,9 @@ document.addEventListener('DOMContentLoaded', () => {
     levelExperienceEarned = nextTotal;
     maybeScheduleProgressUpdate();
 
-    hasPendingLevelUpReward = levelUpAvailable && !wasComplete;
+    const requirementMetWithUpdate =
+      levelExperienceRequirement > 0 && nextTotal >= levelExperienceRequirement;
+    hasPendingLevelUpReward = requirementMetWithUpdate && !wasComplete;
     if (hasPendingLevelUpReward) {
       rewardAnimationPlayed = false;
     }


### PR DESCRIPTION
## Summary
- ensure the post-battle "Claim Reward" button checks level progress after experience is added
- trigger the reward animation when the new experience total meets the level requirement

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dad431dc508329a0f2d05c2a7c7fd1