### PR TITLE
Revamp post-battle reward flow

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -432,7 +432,7 @@ body.is-evolution-active #battle-shellfin {
   align-items: center;
   justify-content: center;
   gap: 32px;
-  background: transparent;
+  background: url('../images/background/background.png') no-repeat center/cover;
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
@@ -460,7 +460,7 @@ body.is-reward-active .reward-overlay {
   inset: 0;
   display: grid;
   place-items: center;
-  background: rgba(4, 15, 28, 0.82);
+  background: url('../images/background/background.png') no-repeat center/cover;
   pointer-events: none;
   opacity: 0;
   visibility: hidden;
@@ -480,42 +480,26 @@ body.is-reward-active .reward-overlay {
   max-width: 90vw;
   filter: drop-shadow(0 18px 32px rgba(0, 0, 0, 0.45));
   opacity: 0;
-  transition: opacity 0.6s ease;
+  transform-origin: center;
 }
 
-.evolution-overlay__sprite--current {
+.evolution-overlay__sprite--visible {
   opacity: 1;
 }
 
-.evolution-overlay--animating .evolution-overlay__sprite--current {
+.evolution-overlay__sprite--hidden {
   opacity: 0;
 }
 
-.evolution-overlay--animating .evolution-overlay__sprite--next {
-  opacity: 1;
-  transition-delay: 0.1s;
-=======
-  transform: scale(0.85) rotate(0deg);
+.evolution-overlay__sprite--growth {
+  animation: evolution-overlay-growth 0.6s cubic-bezier(0.34, 1.56, 0.64, 1)
+    forwards;
+  animation-iteration-count: 3;
 }
 
-.evolution-overlay__sprite--current {
-  z-index: 1;
-}
-
-.evolution-overlay__sprite--next {
-  z-index: 2;
-}
-
-.evolution-overlay--animating .evolution-overlay__sprite--current {
-  animation:
-    hero-evolution-current var(--evolution-duration)
-      cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
-}
-
-.evolution-overlay--animating .evolution-overlay__sprite--next {
-  animation:
-    hero-evolution-next var(--evolution-duration)
-      cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+.evolution-overlay__sprite--reveal {
+  animation: evolution-overlay-reveal 0.6s cubic-bezier(0.34, 1.56, 0.64, 1)
+    forwards;
 }
 
 .post-evolution-overlay {
@@ -567,6 +551,11 @@ body.is-reward-active .reward-overlay {
   height: 250px;
   object-fit: contain;
   opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.reward-overlay__image--visible {
+  opacity: 1;
 }
 
 .reward-overlay__image--interactive {
@@ -781,6 +770,43 @@ body.is-reward-active .reward-overlay {
   100% {
     opacity: 1;
     transform: scale(1) rotate(0deg);
+    filter: brightness(1) saturate(1);
+  }
+}
+
+@keyframes evolution-overlay-growth {
+  0% {
+    opacity: 1;
+    transform: scale(0.92);
+  }
+
+  50% {
+    opacity: 1;
+    transform: scale(1.08);
+  }
+
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes evolution-overlay-reveal {
+  0% {
+    opacity: 0;
+    transform: scale(0.88);
+    filter: brightness(1.35) saturate(1.3);
+  }
+
+  60% {
+    opacity: 1;
+    transform: scale(1.08);
+    filter: brightness(1.5) saturate(1.4);
+  }
+
+  100% {
+    opacity: 1;
+    transform: scale(1);
     filter: brightness(1) saturate(1);
   }
 }

--- a/html/battle.html
+++ b/html/battle.html
@@ -131,8 +131,8 @@
         <div class="meter meter--visible battle-complete-card__meter">
           <img
             class="meter__icon"
-            src="../images/complete/chest.png"
-            alt="Treasure chest level-up reward"
+            src="../images/complete/potion.png"
+            alt="Potion level-up reward"
           />
           <p class="meter__heading text-small text-dark">Level Up</p>
           <div
@@ -152,8 +152,8 @@
     <div class="reward-overlay" data-reward-overlay aria-hidden="true">
       <img
         class="reward-overlay__image"
-        src="../images/complete/chest.png"
-        alt=""
+        src="../images/complete/potion.png"
+        alt="Potion level-up reward"
         data-reward-sprite
       />
       <section


### PR DESCRIPTION
## Summary
- replace the treasure chest art with potion imagery on the post-battle reward surfaces
- rework the reward overlay to show the potion immediately, delay the doctor card reveal, and surface a register CTA after the evolution
- refresh the evolution overlay styling and logic so the level 1 sprite pulses three times before revealing the evolved creature

## Testing
- No tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68daf2a161c083299777ea3d0fbb3ec9