### PR TITLE
Fix hero charge animation without CSS property

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -125,12 +125,6 @@ body:not(.is-preloading) main.landing {
   inherits: false;
 }
 
-@property --hero-scale {
-  syntax: '<number>';
-  initial-value: 1;
-  inherits: false;
-}
-
 .hero {
   position: absolute;
   left: 50%;
@@ -143,13 +137,12 @@ body:not(.is-preloading) main.landing {
   --hero-float-range: 32px;
   --hero-float-duration: 3.5s;
   --hero-float-offset: calc(-1 * var(--hero-float-range, 32px));
-  --hero-scale: 1;
   transform: translate(
       -50%,
       calc(-50% + var(--hero-float-offset))
     )
     scaleX(-1)
-    scale(var(--hero-scale));
+    scale(1);
   transform-origin: 50% 85%;
   image-rendering: auto;
   z-index: 2;
@@ -159,7 +152,10 @@ body:not(.is-preloading) main.landing {
 }
 
 .hero.is-click-scaling {
-  animation: hero-prebattle-charge 220ms cubic-bezier(0.2, 0.9, 0.3, 1) forwards;
+  animation:
+    hero-float var(--hero-float-duration, 3.5s) cubic-bezier(0.42, 0, 0.58, 1)
+      1.35s infinite,
+    hero-prebattle-charge 220ms cubic-bezier(0.2, 0.9, 0.3, 1) forwards;
 }
 
 .hero.is-side-position {
@@ -450,13 +446,16 @@ body.is-battle-transition .bubbles {
 
 @keyframes hero-prebattle-charge {
   0% {
-    --hero-scale: 1;
+    transform: translate(-50%, calc(-50% + var(--hero-float-offset))) scaleX(-1)
+      scale(1);
   }
   36% {
-    --hero-scale: 0.94;
+    transform: translate(-50%, calc(-50% + var(--hero-float-offset))) scaleX(-1)
+      scale(0.94);
   }
   100% {
-    --hero-scale: 0.82;
+    transform: translate(-50%, calc(-50% + var(--hero-float-offset))) scaleX(-1)
+      scale(0.82);
   }
 }
 


### PR DESCRIPTION
## Summary
- remove the custom `@property --hero-scale` usage and use literal base transforms
- update the hero charge keyframes to animate the full transform while easing to 0.82 scale
- keep the float animation active while the hero scales during the prebattle charge

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daf84868008329965c822adf24710e