### PR TITLE
Make register fields transparent

### DIFF
--- a/css/signin.css
+++ b/css/signin.css
@@ -95,9 +95,9 @@ body {
   height: clamp(56px, 7vh, 64px);
   padding: 0 clamp(16px, 4vw, 24px);
   box-sizing: border-box;
-  border: none;
+  border: 2px solid rgba(255, 255, 255, 0.5);
   border-radius: 12px;
-  background-color: #293f5f;
+  background-color: transparent;
   color: #ffffff;
   font-size: clamp(18px, 5vw, 20px);
 }
@@ -112,6 +112,10 @@ body {
   -webkit-appearance: none;
   padding-right: clamp(56px, 12vw, 72px);
   background-image: none;
+}
+
+.preloader__field--select:not(.has-value) {
+  color: rgba(255, 255, 255, 0.5);
 }
 
 .preloader__field--select.has-value {
@@ -148,8 +152,8 @@ body {
 
 .preloader__field:focus {
   color: #ffffff;
-  outline: 3px solid rgba(255, 255, 255, 0.5);
-  outline-offset: 0;
+  outline: none;
+  border-color: rgba(255, 255, 255, 0.5);
 }
 
 .preloader__field:focus::placeholder {


### PR DESCRIPTION
## Summary
- remove the background color from register form fields so they remain transparent against the page

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db26e4dd60832992dba18e0adb026f