### PR TITLE
Adjust immediate battle intro delay

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -252,9 +252,7 @@ const runBattleIntroSequence = async (options = {}) => {
     showEnemy();
   };
 
-  const holdDuration = showIntroImmediately
-    ? PRE_BATTLE_HOLD_DURATION_MS
-    : HERO_TO_ENEMY_DELAY_MS;
+  const holdDuration = showIntroImmediately ? 0 : HERO_TO_ENEMY_DELAY_MS;
 
   await wait(holdDuration);
   prepareForBattle();


### PR DESCRIPTION
## Summary
- update battle intro timing so immediate intros skip the pre-battle hold delay

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db452def748329b1c36886f4b4be54