### PR TITLE
Adjust center image hold behavior for intro mode

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1465,7 +1465,14 @@ const initLandingInteractions = async (preloadedData = {}) => {
 
     await waitForImages;
 
-    if (CENTER_IMAGE_HOLD_DURATION_MS > 0 && !isLevelOneLanding) {
+    const shouldShowIntroImmediately =
+      typeof showIntroImmediately === 'boolean' ? showIntroImmediately : true;
+
+    if (
+      CENTER_IMAGE_HOLD_DURATION_MS > 0 &&
+      !isLevelOneLanding &&
+      !shouldShowIntroImmediately
+    ) {
       await new Promise((resolve) =>
         window.setTimeout(
           resolve,
@@ -1476,10 +1483,7 @@ const initLandingInteractions = async (preloadedData = {}) => {
 
     try {
       await runBattleIntroSequence({
-        showIntroImmediately:
-          typeof showIntroImmediately === 'boolean'
-            ? showIntroImmediately
-            : true,
+        showIntroImmediately: shouldShowIntroImmediately,
         skipHeroSidePosition: isLevelOneLanding,
         hideEnemy: isLevelOneLanding,
       });
@@ -1498,7 +1502,9 @@ const initLandingInteractions = async (preloadedData = {}) => {
   if (!battleButton) {
     await waitForImages;
 
-    if (CENTER_IMAGE_HOLD_DURATION_MS > 0) {
+    const showIntroImmediately = true;
+
+    if (CENTER_IMAGE_HOLD_DURATION_MS > 0 && !showIntroImmediately) {
       await new Promise((resolve) =>
         window.setTimeout(
           resolve,
@@ -1507,7 +1513,7 @@ const initLandingInteractions = async (preloadedData = {}) => {
       );
     }
 
-    await beginBattle({ showIntroImmediately: true });
+    await beginBattle({ showIntroImmediately });
     return;
   }
 


### PR DESCRIPTION
## Summary
- gate the landing center image hold duration on the intro-immediate flag when launching the battle
- mirror the immediate-intro hold behavior in the fallback path when the battle button is missing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db4c4a49748329928ba400e288c3e3