### PR TITLE
Remove CSS flipping of hero sprite

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -156,7 +156,6 @@ body:not(.is-preloading) main.landing {
       calc(-50% + var(--hero-float-offset)),
       0
     )
-    scaleX(-1)
     scale(var(--hero-charge-scale, 1));
   transform-origin: 50% 85%;
   image-rendering: auto;
@@ -471,7 +470,6 @@ body.is-battle-transition .bubbles {
         calc(-50% - var(--hero-float-range, 32px)),
         0
       )
-      scaleX(-1)
       scale(1);
     opacity: 1;
   }
@@ -481,7 +479,6 @@ body.is-battle-transition .bubbles {
         calc(-50% - var(--hero-float-range, 32px)),
         0
       )
-      scaleX(-1)
       scale(1.1);
     opacity: 1;
   }
@@ -491,7 +488,6 @@ body.is-battle-transition .bubbles {
         calc(-50% - var(--hero-float-range, 32px)),
         0
       )
-      scaleX(-1)
       scale(0.2);
     opacity: 0;
   }


### PR DESCRIPTION
## Summary
- remove the forced horizontal flip from the landing hero transform so the sprite keeps its natural orientation
- stop applying a horizontal flip during the landing exit animation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db4fe616ec832996b3b32b09a7de9e