### PR TITLE
Ensure registration fields have consistent height

### DIFF
--- a/css/signin.css
+++ b/css/signin.css
@@ -92,7 +92,8 @@ body {
 
 .preloader__field {
   width: 100%;
-  height: clamp(56px, 7vh, 64px);
+  min-height: 64px;
+  height: 64px;
   padding: 0 clamp(16px, 4vw, 24px);
   box-sizing: border-box;
   border: 2px solid rgba(255, 255, 255, 0.5);


### PR DESCRIPTION
## Summary
- set preloader form fields to a fixed 64px height to align registration and global inputs

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68db560000c48329943f910aed54b7ad