### PR TITLE
Add register prompt to evolution complete overlay

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -525,7 +525,7 @@ body.is-reward-active .reward-overlay {
   align-items: center;
   justify-content: center;
   padding: clamp(24px, 5vmin, 48px);
-  background: transparent;
+  background: url('../images/background/background.png') no-repeat center/cover;
   backdrop-filter: none;
   opacity: 0;
   visibility: hidden;
@@ -540,11 +540,37 @@ body.is-reward-active .reward-overlay {
   pointer-events: auto;
 }
 
+.post-evolution-overlay__content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(24px, 5vmin, 40px);
+}
+
 .post-evolution-overlay__sprite {
   width: clamp(240px, 38vmin, 360px);
   max-width: 90vw;
   transform: scaleX(1);
   pointer-events: none;
+}
+
+.post-evolution-overlay__card {
+  width: min(420px, 90vw);
+  align-items: flex-start;
+  text-align: left;
+}
+
+.post-evolution-overlay__card-avatar {
+  align-self: flex-start;
+}
+
+.post-evolution-overlay__card-text {
+  margin: 0;
+}
+
+.post-evolution-overlay__card-button {
+  width: 100%;
 }
 
 .reward-overlay__image {

--- a/html/battle.html
+++ b/html/battle.html
@@ -203,12 +203,35 @@
       data-evolution-complete-overlay
       aria-hidden="true"
     >
-      <img
-        class="post-evolution-overlay__sprite"
-        src="../images/hero/shellfin_level_2.png"
-        alt="Shellfin evolved"
-        data-evolution-complete-sprite
-      />
+      <div class="post-evolution-overlay__content">
+        <img
+          class="post-evolution-overlay__sprite"
+          src="../images/hero/shellfin_level_2.png"
+          alt="Shellfin evolved"
+          data-evolution-complete-sprite
+        />
+        <section
+          class="card card--home card--pop reward-overlay__card post-evolution-overlay__card"
+        >
+          <img
+            class="reward-overlay__card-avatar post-evolution-overlay__card-avatar"
+            src="../images/intro/doctor.png"
+            alt="Dr. Wave"
+            width="80"
+            height="80"
+          />
+          <p class="reward-overlay__card-text post-evolution-overlay__card-text text-medium text-dark">
+            Your creature just evolved! It’s stronger now and ready for new adventures!
+          </p>
+          <button
+            type="button"
+            class="btn-primary reward-overlay__card-button post-evolution-overlay__card-button"
+            data-evolution-complete-button
+          >
+            Register Now
+          </button>
+        </section>
+      </div>
     </div>
     <div id="battle-message">
       <div class="content">


### PR DESCRIPTION
## Summary
- add the evolution-complete reward card markup with a focused register button
- style the post-evolution overlay to match the reward overlay presentation

## Testing
- browser_container.run_playwright_script (triggered dev battle flow, validated post-evolution card, and navigation to register page)


------
https://chatgpt.com/codex/tasks/task_e_68dbf05c6ab88329b40fe391ee165623