### PR TITLE
Update hero exit animation to remove scale-up overshoot

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -470,16 +470,7 @@ body.is-battle-transition .bubbles {
         calc(-50% - var(--hero-float-range, 32px)),
         0
       )
-      scale(1);
-    opacity: 1;
-  }
-  70% {
-    transform: translate3d(
-        calc(-50% + var(--hero-side-shift, 0px)),
-        calc(-50% - var(--hero-float-range, 32px)),
-        0
-      )
-      scale(1.1);
+      scale(var(--hero-charge-scale, 1));
     opacity: 1;
   }
   100% {


### PR DESCRIPTION
## Summary
- stop the hero intro exit animation from scaling larger than its current charge scale
- ensure the hero sprite now only shrinks while transitioning into battle

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc0aa4cb148329b341c4289765d93c