### PR TITLE
Align evolution overlay sprite sizing with battle hero

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -12,6 +12,11 @@ body {
   box-sizing: border-box;
 }
 
+:root {
+  --hero-sprite-width: 300px;
+  --hero-sprite-max-width: 80vw;
+}
+
 body.is-evolution-active .battle-dev-controls,
 body.is-evolution-active #question,
 body.is-evolution-active #complete-message,
@@ -57,8 +62,8 @@ body.is-post-evolution-active #complete-message {
 #battle-monster,
 #battle-shellfin {
   position: absolute;
-  width: 300px;
-  max-width: 80vw;
+  width: var(--hero-sprite-width);
+  max-width: var(--hero-sprite-max-width);
   opacity: 0;
   filter: blur(18px);
   transform: translateZ(0);
@@ -492,8 +497,8 @@ body.is-reward-active .reward-overlay {
 
 .evolution-overlay__sprite {
   grid-area: 1 / 1;
-  width: clamp(240px, 38vmin, 360px);
-  max-width: 90vw;
+  width: var(--hero-sprite-width);
+  max-width: var(--hero-sprite-max-width);
   opacity: 0;
   transform: scaleX(1);
   transform-origin: center;
@@ -549,8 +554,8 @@ body.is-reward-active .reward-overlay {
 }
 
 .post-evolution-overlay__sprite {
-  width: clamp(240px, 38vmin, 360px);
-  max-width: 90vw;
+  width: var(--hero-sprite-width);
+  max-width: var(--hero-sprite-max-width);
   transform: scaleX(1);
   pointer-events: none;
 }


### PR DESCRIPTION
## Summary
- add shared hero sprite sizing variables to reuse across battle and overlay sprites
- update evolution and post-evolution overlays to match the battle hero dimensions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc102c6dcc8329a30e938b61ed474a