### PR TITLE
Wait for evolution sprite decode before showing overlay

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -506,15 +506,45 @@ document.addEventListener('DOMContentLoaded', () => {
       return false;
     }
 
+    const revealOverlay = () => {
+      evolutionCompleteOverlay.setAttribute('aria-hidden', 'false');
+      evolutionCompleteOverlay.classList.add('post-evolution-overlay--visible');
+      document.body?.classList.add('is-post-evolution-active');
+      focusWithoutScroll(evolutionCompleteButton);
+    };
+
     if (evolutionCompleteSprite && typeof spriteSrc === 'string' && spriteSrc) {
       evolutionCompleteSprite.src = spriteSrc;
       evolutionCompleteSprite.alt = 'Shellfin evolved';
+
+      if (typeof evolutionCompleteSprite.decode === 'function') {
+        evolutionCompleteSprite
+          .decode()
+          .then(revealOverlay)
+          .catch((error) => {
+            console.warn('Unable to decode evolution sprite before showing overlay.', error);
+            revealOverlay();
+          });
+      } else if (!evolutionCompleteSprite.complete) {
+        const handleSpriteReady = () => {
+          evolutionCompleteSprite.removeEventListener('error', handleSpriteReady);
+          evolutionCompleteSprite.removeEventListener('load', handleSpriteReady);
+          revealOverlay();
+        };
+
+        evolutionCompleteSprite.addEventListener('load', handleSpriteReady, {
+          once: true,
+        });
+        evolutionCompleteSprite.addEventListener('error', handleSpriteReady, {
+          once: true,
+        });
+      } else {
+        revealOverlay();
+      }
+    } else {
+      revealOverlay();
     }
 
-    evolutionCompleteOverlay.setAttribute('aria-hidden', 'false');
-    evolutionCompleteOverlay.classList.add('post-evolution-overlay--visible');
-    document.body?.classList.add('is-post-evolution-active');
-    focusWithoutScroll(evolutionCompleteButton);
     return true;
   };
 


### PR DESCRIPTION
## Summary
- wait for the post-evolution overlay to become visible only after its sprite is ready
- add decode() feature detection with load/error fallback to avoid flashes in older browsers

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dc10365ec083298ea76a386bdcf3ac