### PR TITLE
Adjust hero sprite sizing based on loaded assets

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -13,8 +13,10 @@ body {
 }
 
 :root {
-  --hero-sprite-width: 300px;
-  --hero-sprite-max-width: 80vw;
+  --battle-hero-sprite-width: 300px;
+  --battle-hero-sprite-max-width: 80vw;
+  --battle-monster-sprite-width: 300px;
+  --battle-monster-sprite-max-width: 80vw;
 }
 
 body.is-evolution-active .battle-dev-controls,
@@ -62,12 +64,20 @@ body.is-post-evolution-active #complete-message {
 #battle-monster,
 #battle-shellfin {
   position: absolute;
-  width: var(--hero-sprite-width);
-  max-width: var(--hero-sprite-max-width);
   opacity: 0;
   filter: blur(18px);
   transform: translateZ(0);
   will-change: transform, opacity, filter;
+}
+
+#battle-monster {
+  width: var(--battle-monster-sprite-width);
+  max-width: var(--battle-monster-sprite-max-width);
+}
+
+#battle-shellfin {
+  width: var(--battle-hero-sprite-width);
+  max-width: var(--battle-hero-sprite-max-width);
 }
 
 #battle-monster.battle-ready,
@@ -497,8 +507,8 @@ body.is-reward-active .reward-overlay {
 
 .evolution-overlay__sprite {
   grid-area: 1 / 1;
-  width: var(--hero-sprite-width);
-  max-width: var(--hero-sprite-max-width);
+  width: var(--battle-hero-sprite-width);
+  max-width: var(--battle-hero-sprite-max-width);
   opacity: 0;
   transform: scaleX(1);
   transform-origin: center;
@@ -552,8 +562,8 @@ body.is-reward-active .reward-overlay {
 }
 
 .post-evolution-overlay__sprite {
-  width: var(--hero-sprite-width);
-  max-width: var(--hero-sprite-max-width);
+  width: var(--battle-hero-sprite-width);
+  max-width: var(--battle-hero-sprite-max-width);
   transform: scaleX(1);
   pointer-events: none;
 }

--- a/js/battle.js
+++ b/js/battle.js
@@ -218,6 +218,75 @@ document.addEventListener('DOMContentLoaded', () => {
     'Your creature just evolved! It’s stronger now and ready for new adventures!';
   const REGISTER_REWARD_CARD_BUTTON_TEXT = 'Register Now';
 
+  const waitForImageToSettle = (image) =>
+    new Promise((resolve) => {
+      if (!image) {
+        resolve(false);
+        return;
+      }
+
+      if (image.complete) {
+        resolve(image.naturalWidth > 0 && image.naturalHeight > 0);
+        return;
+      }
+
+      let settled = false;
+      const finalize = () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        image.removeEventListener('load', finalize);
+        image.removeEventListener('error', finalize);
+        resolve(image.naturalWidth > 0 && image.naturalHeight > 0);
+      };
+
+      image.addEventListener('load', finalize, { once: true });
+      image.addEventListener('error', finalize, { once: true });
+
+      if (typeof image.decode === 'function') {
+        image
+          .decode()
+          .then(finalize)
+          .catch(() => {});
+      }
+    });
+
+  const updateHeroSpriteCustomProperties = (image) => {
+    if (!image) {
+      return Promise.resolve(false);
+    }
+
+    const rootElement = image.ownerDocument?.documentElement ?? document.documentElement;
+
+    if (!rootElement) {
+      return Promise.resolve(false);
+    }
+
+    const applySpriteDimensions = () => {
+      const naturalWidth = Math.round(image.naturalWidth || 0);
+      const naturalHeight = Math.round(image.naturalHeight || 0);
+
+      if (naturalWidth > 0 && naturalHeight > 0) {
+        const widthValue = `${naturalWidth}px`;
+        const maxWidthValue = `min(${widthValue}, 80vw)`;
+        rootElement.style.setProperty('--battle-hero-sprite-width', widthValue);
+        rootElement.style.setProperty('--battle-hero-sprite-max-width', maxWidthValue);
+        return true;
+      }
+
+      rootElement.style.removeProperty('--battle-hero-sprite-width');
+      rootElement.style.removeProperty('--battle-hero-sprite-max-width');
+      return false;
+    };
+
+    if (image.complete) {
+      return Promise.resolve(applySpriteDimensions());
+    }
+
+    return waitForImageToSettle(image).then(() => applySpriteDimensions());
+  };
+
   if (bannerAccuracyValue) bannerAccuracyValue.textContent = '100%';
   if (bannerTimeValue) bannerTimeValue.textContent = '0s';
   if (summaryAccuracyText) summaryAccuracyText.textContent = '100%';
@@ -280,6 +349,11 @@ document.addEventListener('DOMContentLoaded', () => {
   let evolutionCardDelayTimeout = null;
   let evolutionInProgress = false;
   let rewardCardDisplayTimeout = null;
+  let heroSpriteReadyPromise = null;
+
+  if (heroImg) {
+    heroSpriteReadyPromise = updateHeroSpriteCustomProperties(heroImg);
+  }
 
   const rewardGlowStyleProperties = [
     '--pulsating-glow-color',
@@ -560,12 +634,21 @@ document.addEventListener('DOMContentLoaded', () => {
 
     clearEvolutionTimers();
 
+    let spriteReadyPromise = heroSpriteReadyPromise;
+    let evolutionFinalized = false;
+
     if (heroImg && typeof nextSpriteSrc === 'string') {
       heroImg.src = nextSpriteSrc;
+      heroSpriteReadyPromise = updateHeroSpriteCustomProperties(heroImg);
+      spriteReadyPromise = heroSpriteReadyPromise;
       heroImg.classList.add('battle-shellfin--evolved');
     }
 
-    const completeEvolution = () => {
+    const finalizeEvolution = () => {
+      if (evolutionFinalized) {
+        return;
+      }
+      evolutionFinalized = true;
       hideRewardOverlayInstantly();
       if (completeMessage) {
         completeMessage.classList.remove('show');
@@ -577,6 +660,14 @@ document.addEventListener('DOMContentLoaded', () => {
       markRegistrationAsRequired();
       if (!overlayShown) {
         showRegisterRewardCard();
+      }
+    };
+
+    const completeEvolution = () => {
+      if (spriteReadyPromise && typeof spriteReadyPromise.finally === 'function') {
+        spriteReadyPromise.finally(finalizeEvolution);
+      } else {
+        finalizeEvolution();
       }
     };
 
@@ -1932,6 +2023,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const heroSprite = resolveAssetPath(heroData.sprite);
     if (heroSprite && heroImg) {
       heroImg.src = heroSprite;
+    }
+    if (heroImg) {
+      heroSpriteReadyPromise = updateHeroSpriteCustomProperties(heroImg);
     }
     if (heroImg && hero.name) {
       heroImg.alt = `${hero.name} ready for battle`;


### PR DESCRIPTION
## Summary
- add a helper that waits for the hero image to load and updates CSS custom properties with its natural width
- reuse the helper whenever the hero sprite changes so overlays wait for the correct sizing
- switch battle styles to the new hero and monster sprite variables

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc2d9753f8832994e3f99122a43f64