### PR TITLE
Normalize asset path handling for loaders and validation

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -587,17 +587,37 @@ const sanitizeAssetPath = (path) => {
   if (typeof path !== 'string') {
     return null;
   }
+
   let trimmed = path.trim();
   if (!trimmed || trimmed.startsWith('data:')) {
     return null;
   }
-  while (trimmed.startsWith('./') || trimmed.startsWith('../')) {
-    if (trimmed.startsWith('./')) {
+
+  const hasProtocol = /^[a-z]+:/i.test(trimmed);
+  const isProtocolRelative = trimmed.startsWith('//');
+  const hadRootSlash =
+    !hasProtocol && !isProtocolRelative && trimmed.startsWith('/');
+
+  trimmed = trimmed.replace(/\\/g, '/');
+
+  if (!hasProtocol && !isProtocolRelative) {
+    trimmed = trimmed.replace(/\/{2,}/g, '/');
+
+    while (trimmed.startsWith('./')) {
       trimmed = trimmed.slice(2);
-    } else if (trimmed.startsWith('../')) {
+    }
+
+    while (trimmed.startsWith('../')) {
       trimmed = trimmed.slice(3);
     }
   }
+
+  if (hadRootSlash) {
+    trimmed = `/${trimmed.replace(/^\/+/, '')}`;
+  } else if (!hasProtocol && !isProtocolRelative) {
+    trimmed = trimmed.replace(/^\/+/, '');
+  }
+
   return trimmed;
 };
 

--- a/scripts/validate-data.js
+++ b/scripts/validate-data.js
@@ -29,9 +29,20 @@ function resolveAssetToDisk(assetPath) {
   }
 
   cleaned = cleaned.replace(/[?#].*$/, '');
+  cleaned = cleaned.replace(/\\/g, '/');
 
   if (/^(?:https?:)?\/\//i.test(cleaned) || cleaned.startsWith('data:')) {
     return null;
+  }
+
+  cleaned = cleaned.replace(/\/{2,}/g, '/');
+
+  while (cleaned.startsWith('./')) {
+    cleaned = cleaned.slice(2);
+  }
+
+  while (cleaned.startsWith('../')) {
+    cleaned = cleaned.slice(3);
   }
 
   if (cleaned.startsWith('/mathmonsters/')) {


### PR DESCRIPTION
## Summary
- normalize asset paths on the landing page so Windows-style separators and redundant segments resolve consistently
- update the data validation script to mirror the same normalization before checking assets on disk

## Testing
- node scripts/validate-data.js

------
https://chatgpt.com/codex/tasks/task_e_68dc40a045b48329bc04fb823e90d067