### PR TITLE
Reset guest progress on new sessions

### DIFF
--- a/js/welcome.js
+++ b/js/welcome.js
@@ -18,13 +18,10 @@ const persistGuestSession = () => {
       return false;
     }
     storage.setItem(GUEST_SESSION_KEY, GUEST_SESSION_ACTIVE_VALUE);
-    const existingProgress = storage.getItem(PROGRESS_STORAGE_KEY);
-    if (!existingProgress) {
-      storage.setItem(
-        PROGRESS_STORAGE_KEY,
-        JSON.stringify(createDefaultProgress())
-      );
-    }
+    storage.setItem(
+      PROGRESS_STORAGE_KEY,
+      JSON.stringify(createDefaultProgress())
+    );
     return true;
   } catch (error) {
     console.warn('Guest session could not be saved.', error);


### PR DESCRIPTION
## Summary
- overwrite any stored guest progress with the default Level 1 state when starting a new guest session
- ensure the welcome page always launches the Level 1 experience for guests before registration

## Testing
- node <<'NODE' ... (see conversation for exact script)
- manual verification in browser (pre-set progress to Level 2, start new game, observed Level 1 landing)


------
https://chatgpt.com/codex/tasks/task_e_68dc422e991c8329985ed8c3363e5ee4