### PR TITLE
Adjust hero charge animation start scale

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -344,15 +344,16 @@ const setupLevelOneIntro = ({ heroImage, beginBattle } = {}) => {
 
       cancelHeroPrebattleChargeAnimation();
 
-      let startingChargeScale = heroImage.style.getPropertyValue(
+      const inlineHeroChargeScale = heroImage.style.getPropertyValue(
         '--hero-charge-scale'
       );
-      if (!startingChargeScale) {
-        startingChargeScale = window
-          .getComputedStyle(heroImage)
-          .getPropertyValue('--hero-charge-scale');
-      }
-      startingChargeScale = (startingChargeScale || '').trim() || '1';
+      const computedHeroChargeScale =
+        inlineHeroChargeScale ||
+        window.getComputedStyle(heroImage).getPropertyValue(
+          '--hero-charge-scale'
+        );
+      const startingChargeScale =
+        (computedHeroChargeScale || '').trim() || '1';
 
       heroPrebattleChargeAnimation = heroImage.animate(
         [


### PR DESCRIPTION
## Summary
- read the hero sprite's current `--hero-charge-scale` before the pre-battle charge animation
- start the animation from the existing scale while keeping subsequent keyframes unchanged

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc4e5efd1c83299d8539970d3ef051