### PR TITLE
Preserve hero charge scale between animation loops

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -342,8 +342,6 @@ const setupLevelOneIntro = ({ heroImage, beginBattle } = {}) => {
         return;
       }
 
-      cancelHeroPrebattleChargeAnimation();
-
       const inlineHeroChargeScale = heroImage.style.getPropertyValue(
         '--hero-charge-scale'
       );
@@ -354,6 +352,8 @@ const setupLevelOneIntro = ({ heroImage, beginBattle } = {}) => {
         );
       const startingChargeScale =
         (computedHeroChargeScale || '').trim() || '1';
+
+      cancelHeroPrebattleChargeAnimation();
 
       heroPrebattleChargeAnimation = heroImage.animate(
         [


### PR DESCRIPTION
## Summary
- read the hero charge scale before cancelling the previous pre-battle animation
- reuse the captured scale as the starting keyframe for the next charge cycle to prevent popping

## Testing
- Manual landing page animation check

------
https://chatgpt.com/codex/tasks/task_e_68dc525d11c883299c90a1c9812b310e