### PR TITLE
Preserve hero charge scale during repeated prebattle animations

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -355,6 +355,12 @@ const setupLevelOneIntro = ({ heroImage, beginBattle } = {}) => {
 
       cancelHeroPrebattleChargeAnimation();
 
+      // Preserve the current charge scale so canceling the previous animation
+      // doesn't immediately revert the CSS variable back to its base style.
+      // Without this, the hero element's transform transition kicks in before
+      // the new animation starts, causing a visible jump.
+      heroImage.style.setProperty('--hero-charge-scale', startingChargeScale);
+
       heroPrebattleChargeAnimation = heroImage.animate(
         [
           { '--hero-charge-scale': startingChargeScale },


### PR DESCRIPTION
## Summary
- keep the hero charge scale custom property inline before restarting the prebattle animation
- prevent the hero transform transition from triggering between animation restarts, eliminating the visible jump

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc54e251b08329a8b1b2c0f235579e