### PR TITLE
Fix hero prebattle charge scale retrieval

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -342,16 +342,16 @@ const setupLevelOneIntro = ({ heroImage, beginBattle } = {}) => {
         return;
       }
 
-      const inlineHeroChargeScale = heroImage.style.getPropertyValue(
-        '--hero-charge-scale'
-      );
-      const computedHeroChargeScale =
-        inlineHeroChargeScale ||
-        window.getComputedStyle(heroImage).getPropertyValue(
-          '--hero-charge-scale'
-        );
+      const computedHeroChargeScale = (
+        window
+          .getComputedStyle(heroImage)
+          .getPropertyValue('--hero-charge-scale') || ''
+      ).trim();
+      const inlineHeroChargeScale = (
+        heroImage.style.getPropertyValue('--hero-charge-scale') || ''
+      ).trim();
       const startingChargeScale =
-        (computedHeroChargeScale || '').trim() || '1';
+        computedHeroChargeScale || inlineHeroChargeScale || '1';
 
       cancelHeroPrebattleChargeAnimation();
 


### PR DESCRIPTION
## Summary
- ensure the level one intro hero charge animation uses the computed CSS variable value before falling back to inline styles, preventing the scale from snapping back to 1 between restarts

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc5860639c8329bc37dc3258683a95