### PR TITLE
Call skipWaiting after service worker install

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -39,7 +39,11 @@ const OFFLINE_ASSETS = [
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(OFFLINE_ASSETS))
+    (async () => {
+      const cache = await caches.open(CACHE_NAME);
+      await cache.addAll(OFFLINE_ASSETS);
+      self.skipWaiting();
+    })()
   );
 });
 


### PR DESCRIPTION
## Summary
- ensure the service worker populates its cache and immediately calls `skipWaiting` to activate the new version

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc592dd8188329ac6db23305301c53