### PR TITLE
Prioritize computed hero charge scale fallback

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -342,16 +342,20 @@ const setupLevelOneIntro = ({ heroImage, beginBattle } = {}) => {
         return;
       }
 
-      const computedHeroChargeScale = (
-        window
-          .getComputedStyle(heroImage)
-          .getPropertyValue('--hero-charge-scale') || ''
-      ).trim();
-      const inlineHeroChargeScale = (
-        heroImage.style.getPropertyValue('--hero-charge-scale') || ''
-      ).trim();
+      const computedHeroChargeScaleRaw = window
+        .getComputedStyle(heroImage)
+        .getPropertyValue('--hero-charge-scale');
+      const inlineHeroChargeScaleRaw = heroImage.style.getPropertyValue(
+        '--hero-charge-scale'
+      );
+
+      const computedHeroChargeScale = (computedHeroChargeScaleRaw || '').trim();
+      const inlineHeroChargeScale = (inlineHeroChargeScaleRaw || '').trim();
+
       const startingChargeScale =
-        computedHeroChargeScale || inlineHeroChargeScale || '1';
+        computedHeroChargeScale !== ''
+          ? computedHeroChargeScale
+          : inlineHeroChargeScale || '1';
 
       cancelHeroPrebattleChargeAnimation();
 


### PR DESCRIPTION
## Summary
- prioritize the computed hero charge scale before falling back to inline styles
- trim the selected charge scale value before reapplying the CSS variable

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc7c8c197c8329b9a1ed5be6c18405