### PR TITLE
Prevent hero transform transition during prebattle restarts

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -177,6 +177,10 @@ body:not(.is-preloading) main.landing {
   transition: transform 0.45s cubic-bezier(0.36, 0, 0.66, 1);
 }
 
+.hero.is-prebattle-restarting {
+  transition: none !important;
+}
+
 .hero.is-side-position {
   --hero-side-shift: calc(-1 * var(--intro-sprite-offset));
 }

--- a/js/index.js
+++ b/js/index.js
@@ -360,6 +360,7 @@ const setupLevelOneIntro = ({ heroImage, beginBattle } = {}) => {
 
       const startingChargeScale = computedHeroChargeScale || '1';
 
+      heroImage.classList.add('is-prebattle-restarting');
       cancelHeroPrebattleChargeAnimation();
 
       // Preserve the current charge scale so canceling the previous animation
@@ -387,6 +388,13 @@ const setupLevelOneIntro = ({ heroImage, beginBattle } = {}) => {
       heroPrebattleChargeAnimation.oncancel = () => {
         heroPrebattleChargeAnimation = null;
       };
+
+      window.requestAnimationFrame(() => {
+        if (!heroImage) {
+          return;
+        }
+        heroImage.classList.remove('is-prebattle-restarting');
+      });
     };
 
     clearHeroPrebattleChargeTimeout();


### PR DESCRIPTION
## Summary
- add a CSS helper class to disable the hero transform transition during prebattle restarts
- toggle the helper class when restarting the hero charge animation so the transform stays stable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc80053454832994f0df564de170d4