### PR TITLE
Remove pre-battle hero charge animation

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -180,10 +180,6 @@ body:not(.is-preloading) main.landing {
   transition: transform 0.45s cubic-bezier(0.36, 0, 0.66, 1);
 }
 
-.hero.is-prebattle-restarting {
-  transition: none !important;
-}
-
 .hero.is-side-position {
   --hero-side-shift: calc(-1 * var(--intro-sprite-offset));
 }


### PR DESCRIPTION
## Summary
- remove the level one intro hero charge animation logic so the sprite no longer animates solo before the battle slide-in
- drop the unused CSS class that disabled transitions during that animation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc900b3e9483298b0be8b84cbce251