### PR TITLE
Fix landing layout defaults

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -32,7 +32,7 @@ html {
 }
 
 body {
-  margin: 16px;
+  margin: 0;
   min-height: 100vh;
   min-height: 100dvh;
   font-family: var(--font-family-rounded);

--- a/css/home.css
+++ b/css/home.css
@@ -9,7 +9,8 @@ body.home-page {
 
   width: var(--home-max-width);
   margin: 0 auto;
-  min-height: calc(100dvh - 32px);
+  min-height: 100vh;
+  min-height: 100dvh;
   display: flex;
   flex-direction: column;
   align-items: stretch;

--- a/js/index.js
+++ b/js/index.js
@@ -1027,7 +1027,7 @@ const applyBattlePreview = (previewData = {}) => {
   const resolvedBattleLevel = Number(previewData?.battleLevel);
   const isLevelOneLanding = Number.isFinite(resolvedBattleLevel)
     ? resolvedBattleLevel <= 1
-    : false;
+    : true;
 
   if (landingRoot) {
     landingRoot.classList.toggle('is-level-one-landing', isLevelOneLanding);


### PR DESCRIPTION
## Summary
- remove the default body margin so the landing fills the viewport
- ensure the Level 1 landing view remains active when the level is unknown
- stretch the Level 2+ home layout to the full device height

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc907c2f6c8329884a0f942d86b386