### PR TITLE
Exclude home image buttons from global styling

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -113,7 +113,7 @@ textarea {
   color: var(--text-color-dark);
 }
 
-button {
+button:not(.home__action):not(.home__icon-button) {
   --btn-gradient-start: var(--button-gradient-start);
   --btn-gradient-end: var(--button-gradient-end);
   --btn-text-color: var(--button-text-color);

--- a/css/home.css
+++ b/css/home.css
@@ -39,6 +39,7 @@ body.home-page {
   justify-content: center;
   padding: 0;
   background: none;
+  background-image: none;
   border: none;
   box-shadow: none;
   border-radius: 0;
@@ -115,9 +116,13 @@ body.home-page {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  width: auto;
+  min-height: 0;
+  height: auto;
   padding: 0;
   border: none;
   background: none;
+  background-image: none;
   cursor: pointer;
 }
 


### PR DESCRIPTION
## Summary
- prevent home icon buttons from inheriting the shared gradient styling by excluding them from the global button selector
- reset the home icon and action buttons so their linked images render without button chrome

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dc92f36a3c8329b282ad72f12d1eec