### PR TITLE
Enhance hero entry animation with dynamic scaling

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -298,12 +298,22 @@ body.is-post-evolution-active #complete-message {
 
 @keyframes hero-enter {
   0% {
-    transform: translateX(140%) scale(1.1) scaleX(1);
+    transform: translateX(140%) scale(1) scaleX(1);
     opacity: 0;
     filter: blur(16px);
   }
-  65% {
-    transform: translateX(-3%) scale(1.02) scaleX(1);
+  45% {
+    transform: translateX(12%) scale(1.1) scaleX(1);
+    opacity: 1;
+    filter: blur(8px);
+  }
+  70% {
+    transform: translateX(-4%) scale(0.96) scaleX(1);
+    opacity: 1;
+    filter: blur(0);
+  }
+  85% {
+    transform: translateX(1%) scale(1.02) scaleX(1);
     opacity: 1;
     filter: blur(0);
   }


### PR DESCRIPTION
## Summary
- add a 10% scale-up overshoot to the hero entry animation before settling into position
- smooth out the scale-down portion of the hero entrance for a more fluid motion

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc98593a248329bf8c6ec510e1d8c0