### PR TITLE
Add overshoot to hero exit animation

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -298,12 +298,22 @@ body.is-post-evolution-active #complete-message {
 
 @keyframes hero-enter {
   0% {
-    transform: translateX(140%) scale(1.1) scaleX(1);
+    transform: translateX(140%) scale(1) scaleX(1);
     opacity: 0;
     filter: blur(16px);
   }
-  65% {
-    transform: translateX(-3%) scale(1.02) scaleX(1);
+  45% {
+    transform: translateX(12%) scale(1.1) scaleX(1);
+    opacity: 1;
+    filter: blur(8px);
+  }
+  70% {
+    transform: translateX(-4%) scale(0.96) scaleX(1);
+    opacity: 1;
+    filter: blur(0);
+  }
+  85% {
+    transform: translateX(1%) scale(1.02) scaleX(1);
     opacity: 1;
     filter: blur(0);
   }

--- a/css/index.css
+++ b/css/index.css
@@ -488,6 +488,24 @@ body.is-battle-transition .bubbles {
       scale(var(--hero-charge-scale, 1));
     opacity: 1;
   }
+  25% {
+    transform: translate3d(
+        calc(-50% + var(--hero-side-shift, 0px)),
+        calc(-50% - var(--hero-float-range, 32px)),
+        0
+      )
+      scale(calc(var(--hero-charge-scale, 1) * 1.1));
+    opacity: 1;
+  }
+  55% {
+    transform: translate3d(
+        calc(-50% + var(--hero-side-shift, 0px)),
+        calc(-50% - var(--hero-float-range, 32px)),
+        0
+      )
+      scale(calc(var(--hero-charge-scale, 1) * 0.92));
+    opacity: 1;
+  }
   100% {
     transform: translate3d(
         calc(-50% + var(--hero-side-shift, 0px)),


### PR DESCRIPTION
## Summary
- add a 110% overshoot to the hero intro exit animation before shrinking out
- smooth the exit timing by adding an intermediate easing keyframe

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc98593a248329bf8c6ec510e1d8c0