### PR TITLE
Enable registration scrolling and lock Level 2+ landing layout

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -8,11 +8,16 @@ body {
   color: #272B34;
   background: url('../images/background/background.png') no-repeat center/cover;
   position: relative;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 body.is-level-one-landing {
   margin: 0;
+}
+
+body.is-standard-landing {
+  overflow: hidden;
 }
 
 :root {

--- a/css/signin.css
+++ b/css/signin.css
@@ -8,19 +8,19 @@ body {
 
 .preloader {
   --app-safe-area-padding: clamp(16px, 5vw, 48px);
-  position: fixed;
-  inset: 0;
+  position: relative;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
   gap: 40px;
+  min-height: 100vh;
+  min-height: 100dvh;
+  width: 100%;
   background-color: #001b41;
   text-align: center;
   box-sizing: border-box;
-  padding-top: calc(
-    var(--app-safe-area-padding) + env(safe-area-inset-top, 0px)
-  );
+  padding-top: calc(40px + env(safe-area-inset-top, 0px));
   padding-bottom: calc(
     var(--app-safe-area-padding) + env(safe-area-inset-bottom, 0px)
   );
@@ -30,7 +30,6 @@ body {
   padding-right: calc(
     var(--app-safe-area-padding) + env(safe-area-inset-right, 0px)
   );
-  overflow-y: auto;
 }
 
 .preloader__logo {


### PR DESCRIPTION
## Summary
- allow the registration layout to grow with its content so the page can scroll naturally
- keep the standard (Level 2+) landing view locked to the viewport by hiding overflow on that variant
- align the registration content to the top with 40px of safe-area-aware padding

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd415b732083298dfcbe51ea352099