### PR TITLE
Center sign-in page content

### DIFF
--- a/css/signin.css
+++ b/css/signin.css
@@ -11,7 +11,7 @@ body {
   position: relative;
   display: flex;
   flex-direction: column;
-  justify-content: flex-start;
+  justify-content: center;
   align-items: center;
   gap: 40px;
   min-height: 100vh;
@@ -20,7 +20,9 @@ body {
   background-color: #001b41;
   text-align: center;
   box-sizing: border-box;
-  padding-top: calc(40px + env(safe-area-inset-top, 0px));
+  padding-top: calc(
+    var(--app-safe-area-padding) + env(safe-area-inset-top, 0px)
+  );
   padding-bottom: calc(
     var(--app-safe-area-padding) + env(safe-area-inset-bottom, 0px)
   );


### PR DESCRIPTION
## Summary
- center the sign-in preloader layout vertically
- align the safe-area padding so centered content retains device insets

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd57866ee0832991e5bf43de9221cf