### PR TITLE
Implement logout action and layout updates for level 2 home

### DIFF
--- a/css/home.css
+++ b/css/home.css
@@ -11,11 +11,11 @@ body.home-page {
   margin: 0 auto;
   min-height: 100vh;
   min-height: 100dvh;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
   align-items: stretch;
-  justify-content: space-between;
-  gap: clamp(24px, 6vh, 48px);
+  justify-items: stretch;
+  row-gap: clamp(24px, 6vh, 48px);
   color: inherit;
   box-sizing: border-box;
 }
@@ -45,6 +45,10 @@ body.home-page {
   flex: 0 0 64px;
 }
 
+.home__icon-button {
+  cursor: pointer;
+}
+
 .home__status {
   pointer-events: none;
 }
@@ -58,8 +62,8 @@ body.home-page {
 }
 
 .home__hero {
-  flex: 1;
   width: 100%;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -107,7 +111,6 @@ body.home-page {
   justify-content: space-between;
   align-items: flex-end;
   flex-wrap: nowrap;
-  margin-top: auto;
   gap: var(--space-xs);
 }
 
@@ -126,6 +129,13 @@ body.home-page {
   width: min(100px, 32vw);
   height: min(100px, 32vw);
   object-fit: contain;
+}
+
+.home__icon-button[aria-disabled='true'],
+.home__action[aria-disabled='true'] {
+  pointer-events: none;
+  cursor: default;
+  opacity: 0.6;
 }
 
 @media (min-width: 768px) {

--- a/html/home.html
+++ b/html/home.html
@@ -19,14 +19,21 @@
   <body class="home-page">
     <main class="home app-safe-area">
       <header class="home__top-bar">
-        <button class="home__icon-button" type="button" aria-label="Open settings">
+        <div
+          class="home__icon-button"
+          role="link"
+          tabindex="0"
+          data-initial-tabindex="0"
+          aria-label="Open settings"
+          data-settings-logout
+        >
           <img
             src="../images/home/settings.png"
             alt="Settings"
             width="64"
             height="64"
           />
-        </button>
+        </div>
         <div class="home__status" aria-live="polite">
           <img
             src="../images/home/gems.png"
@@ -59,23 +66,43 @@
       </section>
 
       <footer class="home__actions">
-        <button class="home__action" type="button" aria-label="Battle">
+        <div
+          class="home__action"
+          role="link"
+          tabindex="0"
+          data-initial-tabindex="0"
+          aria-label="Battle"
+        >
           <img
             src="../images/home/battle.png"
             alt="Battle"
             width="100"
             height="100"
           />
-        </button>
-        <button class="home__action" type="button" aria-label="Store">
+        </div>
+        <div
+          class="home__action"
+          role="link"
+          tabindex="0"
+          data-initial-tabindex="0"
+          aria-label="Store"
+        >
           <img
             src="../images/home/store.png"
             alt="Store"
             width="100"
             height="100"
           />
-        </button>
+        </div>
       </footer>
     </main>
+    <script>
+      window.SUPABASE_URL = 'https://jxlxpumcoihfapmrsaqd.supabase.co';
+      window.SUPABASE_ANON_KEY =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imp4bHhwdW1jb2loZmFwbXJzYXFkIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTc0MjE3MDcsImV4cCI6MjA3Mjk5NzcwN30.PJiDPZ_Dqli_42isJexeYgsf0ebWbCSOwHtR7lsQTN0';
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2" defer></script>
+    <script src="../js/supabaseClient.js" defer></script>
+    <script src="../js/home.js" defer></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -122,14 +122,21 @@
       aria-live="polite"
     >
       <header class="home__top-bar">
-        <button class="home__icon-button" type="button" aria-label="Open settings">
+        <div
+          class="home__icon-button"
+          role="link"
+          tabindex="0"
+          data-initial-tabindex="0"
+          aria-label="Open settings"
+          data-settings-logout
+        >
           <img
             src="./images/home/settings.png"
             alt="Settings"
             width="64"
             height="64"
           />
-        </button>
+        </div>
         <div class="home__status" aria-live="polite">
           <img
             src="./images/home/gems.png"
@@ -161,9 +168,11 @@
       </section>
 
       <footer class="home__actions">
-        <button
+        <div
           class="home__action home__action--battle"
-          type="button"
+          role="link"
+          tabindex="0"
+          data-initial-tabindex="0"
           aria-label="Battle"
           data-battle-button
         >
@@ -173,15 +182,21 @@
             width="100"
             height="100"
           />
-        </button>
-        <button class="home__action home__action--store" type="button" aria-label="Store">
+        </div>
+        <div
+          class="home__action home__action--store"
+          role="link"
+          tabindex="0"
+          data-initial-tabindex="0"
+          aria-label="Store"
+        >
           <img
             src="./images/home/store.png"
             alt="Store"
             width="100"
             height="100"
           />
-        </button>
+        </div>
       </footer>
     </div>
 

--- a/js/home.js
+++ b/js/home.js
@@ -1,0 +1,134 @@
+const GUEST_SESSION_KEY = 'mathmonstersGuestSession';
+
+const redirectToWelcome = () => {
+  window.location.replace('welcome.html');
+};
+
+const clearGuestMode = () => {
+  try {
+    window.localStorage?.removeItem(GUEST_SESSION_KEY);
+  } catch (error) {
+    console.warn('Unable to clear guest session.', error);
+  }
+};
+
+const setElementDisabled = (element, disabled) => {
+  if (!element) {
+    return;
+  }
+
+  const shouldDisable = Boolean(disabled);
+
+  if (shouldDisable) {
+    element.setAttribute('aria-disabled', 'true');
+    if (!element.hasAttribute('data-previous-tabindex')) {
+      const current = element.getAttribute('tabindex');
+      if (current !== null) {
+        element.setAttribute('data-previous-tabindex', current);
+      }
+    }
+    element.setAttribute('tabindex', '-1');
+    return;
+  }
+
+  element.removeAttribute('aria-disabled');
+  if (element.hasAttribute('data-previous-tabindex')) {
+    const previous = element.getAttribute('data-previous-tabindex');
+    if (previous) {
+      element.setAttribute('tabindex', previous);
+    } else {
+      element.removeAttribute('tabindex');
+    }
+    element.removeAttribute('data-previous-tabindex');
+    return;
+  }
+
+  const initialTabIndex = element.getAttribute('data-initial-tabindex');
+  if (initialTabIndex !== null) {
+    element.setAttribute('tabindex', initialTabIndex || '0');
+  } else if (!element.hasAttribute('tabindex')) {
+    element.setAttribute('tabindex', '0');
+  }
+};
+
+const isElementDisabled = (element) =>
+  element ? element.getAttribute('aria-disabled') === 'true' : false;
+
+const attachInteractiveHandler = (element, handler) => {
+  if (!element || typeof handler !== 'function') {
+    return;
+  }
+
+  const handleClick = (event) => {
+    if (isElementDisabled(element)) {
+      if (typeof event?.preventDefault === 'function') {
+        event.preventDefault();
+      }
+      return;
+    }
+    handler(event);
+  };
+
+  element.addEventListener('click', handleClick);
+  element.addEventListener('keydown', (event) => {
+    if (isElementDisabled(element)) {
+      return;
+    }
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handler(event);
+    }
+  });
+};
+
+const logoutAndRedirect = async () => {
+  const supabase = window.supabaseClient;
+  if (supabase?.auth?.signOut) {
+    try {
+      const { error } = await supabase.auth.signOut();
+      if (error) {
+        console.warn('Failed to sign out user.', error);
+      }
+    } catch (error) {
+      console.warn('Unexpected error during sign out.', error);
+    }
+  }
+
+  clearGuestMode();
+  redirectToWelcome();
+};
+
+const setupHomeLogout = () => {
+  const logoutTrigger = document.querySelector('[data-settings-logout]');
+  if (!logoutTrigger) {
+    return;
+  }
+
+  if (logoutTrigger.dataset.logoutBound === 'true') {
+    return;
+  }
+  logoutTrigger.dataset.logoutBound = 'true';
+
+  const handleLogout = async (event) => {
+    if (event && typeof event.preventDefault === 'function') {
+      event.preventDefault();
+    }
+
+    if (isElementDisabled(logoutTrigger)) {
+      return;
+    }
+
+    setElementDisabled(logoutTrigger, true);
+    logoutTrigger.setAttribute('aria-busy', 'true');
+
+    await logoutAndRedirect();
+  };
+
+  attachInteractiveHandler(logoutTrigger, handleLogout);
+};
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', setupHomeLogout);
+} else {
+  setupHomeLogout();
+}


### PR DESCRIPTION
## Summary
- convert level 2 home controls into link-style elements and wire the settings icon to sign out
- stretch the hero panel to occupy the space between the top bar and footer
- add a dedicated home script so the standalone home page also signs out when the settings control is activated

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dd62f250e8832981e9863e7a4c910b