### PR TITLE
Revamp level 2 home layout

### DIFF
--- a/css/home.css
+++ b/css/home.css
@@ -4,100 +4,95 @@ body.home-page {
 }
 
 .home {
-  --home-max-width: min(420px, 100%);
   --app-safe-area-padding: clamp(20px, 5vw, 28px);
 
-  width: var(--home-max-width);
+  width: min(100%, 420px);
+  min-width: min(100%, 320px);
   margin: 0 auto;
   min-height: 100vh;
   min-height: 100dvh;
-  display: grid;
-  grid-template-rows: auto minmax(0, 1fr) auto;
+  display: flex;
+  flex-direction: column;
   align-items: stretch;
-  justify-items: stretch;
-  row-gap: clamp(24px, 6vh, 48px);
+  justify-content: flex-start;
+  gap: clamp(24px, 6vh, 48px);
   color: inherit;
   box-sizing: border-box;
 }
 
-.home__top-bar {
-  width: 100%;
+.home__bar {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: var(--space-sm);
-  flex-wrap: wrap;
-  row-gap: var(--space-xs);
+  width: 100%;
 }
 
-.home__icon-button,
-.home__status {
-  width: 64px;
-  height: 64px;
+.home__bar-item {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  width: 100px;
+  height: 100px;
   padding: 0;
   background: none;
   border: none;
   box-shadow: none;
   border-radius: 0;
-  flex: 0 0 64px;
 }
 
-.home__icon-button {
+.home__bar-item--action {
   cursor: pointer;
 }
 
-.home__status {
+.home__bar-item--status {
   pointer-events: none;
 }
 
-.home__icon-button img,
-.home__status img {
+.home__bar-item img {
   display: block;
-  width: 64px;
-  height: 64px;
+  width: 100px;
+  height: 100px;
   object-fit: contain;
 }
 
-.home__hero {
-  width: 100%;
-  min-height: 0;
+.home__bar-item[aria-disabled='true'] {
+  pointer-events: none;
+  cursor: default;
+  opacity: 0.6;
+}
+
+.home__content {
+  flex: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: clamp(16px, 4vh, 28px);
   text-align: center;
-  gap: clamp(16px, 4vh, 32px);
 }
 
-.home__hero-info {
-  display: grid;
-  justify-items: center;
-  gap: var(--space-xs);
-}
 
-.home__hero-name {
+.home__title {
   margin: 0;
-  font-size: clamp(28px, 6vw, 42px);
+  font-size: clamp(32px, 7vw, 48px);
   font-weight: 400;
   color: #ffffff;
 }
 
-.home__hero-level {
+.home__level {
   margin: 0;
-  font-size: clamp(18px, 4vw, 22px);
+  font-size: clamp(18px, 4vw, 24px);
 }
 
-.home__hero-badge {
-  width: min(100px, 28vw);
-  height: min(100px, 28vw);
+.home__badge {
+  width: 100px;
+  height: 100px;
+  object-fit: contain;
 }
 
 .home__hero-sprite {
-  width: 300px;
-  height: 300px;
+  width: clamp(220px, 70vw, 320px);
   height: auto;
   object-fit: contain;
   animation: hero-swim 4.5s ease-in-out 0.6s infinite;
@@ -105,45 +100,12 @@ body.home-page {
   pointer-events: none;
 }
 
-.home__actions {
-  width: 100%;
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  flex-wrap: nowrap;
-  gap: var(--space-xs);
-}
-
-.home__action {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-  border: none;
-  background: none;
-  cursor: pointer;
-}
-
-.home__action img {
-  display: block;
-  width: min(100px, 32vw);
-  height: min(100px, 32vw);
-  object-fit: contain;
-}
-
-.home__icon-button[aria-disabled='true'],
-.home__action[aria-disabled='true'] {
-  pointer-events: none;
-  cursor: default;
-  opacity: 0.6;
-}
-
 @media (min-width: 768px) {
   .home {
     --app-safe-area-padding: var(--space-lg);
   }
 
-  .home__hero {
+  .home__content {
     gap: clamp(20px, 5vh, 36px);
   }
 }

--- a/html/home.html
+++ b/html/home.html
@@ -18,9 +18,9 @@
   </head>
   <body class="home-page">
     <main class="home app-safe-area">
-      <header class="home__top-bar">
+      <header class="home__bar home__bar--top">
         <div
-          class="home__icon-button"
+          class="home__bar-item home__bar-item--action"
           role="link"
           tabindex="0"
           data-initial-tabindex="0"
@@ -30,34 +30,32 @@
           <img
             src="../images/home/settings.png"
             alt="Settings"
-            width="64"
-            height="64"
-          />
-        </div>
-        <div class="home__status" aria-live="polite">
-          <img
-            src="../images/home/gems.png"
-            alt="Gems"
-            width="64"
-            height="64"
-          />
-        </div>
-      </header>
-
-      <section class="home__hero" aria-live="polite">
-        <div class="home__hero-info">
-          <h1 class="home__hero-name">Shellfin</h1>
-          <p class="home__hero-level text-small text-white">
-            Level <span data-hero-level>2</span>
-          </p>
-          <img
-            class="home__hero-badge"
-            src="../images/home/addition.png"
-            alt="Addition badge"
             width="100"
             height="100"
           />
         </div>
+        <div class="home__bar-item home__bar-item--status" aria-live="polite">
+          <img
+            src="../images/home/gems.png"
+            alt="Gems"
+            width="100"
+            height="100"
+          />
+        </div>
+      </header>
+
+      <section class="home__content" aria-live="polite">
+        <h1 class="home__title">Shellfin</h1>
+        <p class="home__level text-small text-white">
+          Level <span data-hero-level>2</span>
+        </p>
+        <img
+          class="home__badge"
+          src="../images/home/addition.png"
+          alt="Addition badge"
+          width="100"
+          height="100"
+        />
         <img
           class="home__hero-sprite"
           src="../images/hero/shellfin_level_2.png"
@@ -65,9 +63,9 @@
         />
       </section>
 
-      <footer class="home__actions">
+      <footer class="home__bar home__bar--bottom">
         <div
-          class="home__action"
+          class="home__bar-item home__bar-item--action"
           role="link"
           tabindex="0"
           data-initial-tabindex="0"
@@ -81,7 +79,7 @@
           />
         </div>
         <div
-          class="home__action"
+          class="home__bar-item home__bar-item--action"
           role="link"
           tabindex="0"
           data-initial-tabindex="0"

--- a/index.html
+++ b/index.html
@@ -121,9 +121,9 @@
       data-standard-landing
       aria-live="polite"
     >
-      <header class="home__top-bar">
+      <header class="home__bar home__bar--top">
         <div
-          class="home__icon-button"
+          class="home__bar-item home__bar-item--action"
           role="link"
           tabindex="0"
           data-initial-tabindex="0"
@@ -133,32 +133,30 @@
           <img
             src="./images/home/settings.png"
             alt="Settings"
-            width="64"
-            height="64"
-          />
-        </div>
-        <div class="home__status" aria-live="polite">
-          <img
-            src="./images/home/gems.png"
-            alt="Gems"
-            width="64"
-            height="64"
-          />
-        </div>
-      </header>
-
-      <section class="home__hero" aria-live="polite">
-        <div class="home__hero-info">
-          <h1 class="home__hero-name text-white" data-hero-name>Shellfin</h1>
-          <p class="home__hero-level text-small text-white" data-hero-level>Level 2</p>
-          <img
-            class="home__hero-badge"
-            src="./images/home/addition.png"
-            alt="Addition badge"
             width="100"
             height="100"
           />
         </div>
+        <div class="home__bar-item home__bar-item--status" aria-live="polite">
+          <img
+            src="./images/home/gems.png"
+            alt="Gems"
+            width="100"
+            height="100"
+          />
+        </div>
+      </header>
+
+      <section class="home__content" aria-live="polite">
+        <h1 class="home__title" data-hero-name>Shellfin</h1>
+        <p class="home__level text-small text-white" data-hero-level>Level 2</p>
+        <img
+          class="home__badge"
+          src="./images/home/addition.png"
+          alt="Addition badge"
+          width="100"
+          height="100"
+        />
         <img
           class="home__hero-sprite"
           src="./images/hero/shellfin_level_2.png"
@@ -167,9 +165,9 @@
         />
       </section>
 
-      <footer class="home__actions">
+      <footer class="home__bar home__bar--bottom">
         <div
-          class="home__action home__action--battle"
+          class="home__bar-item home__bar-item--action"
           role="link"
           tabindex="0"
           data-initial-tabindex="0"
@@ -184,7 +182,7 @@
           />
         </div>
         <div
-          class="home__action home__action--store"
+          class="home__bar-item home__bar-item--action"
           role="link"
           tabindex="0"
           data-initial-tabindex="0"


### PR DESCRIPTION
## Summary
- restructure the level 2+ home screen markup to present the top bar, hero details, and footer bar in a simple top-to-bottom flow
- refresh the home stylesheet to use the new bar styles, enforce the max 420px safe-area width, and size interface images to 100px
- mirror the layout updates in the static home page template for consistency

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd6a789fa48329b025015a7160c4ee