### PR TITLE
Ensure standard landing fills viewport

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -20,6 +20,19 @@ body.is-standard-landing {
   overflow: hidden;
 }
 
+body.is-standard-landing main.landing {
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  min-height: 100vh;
+  min-height: 100dvh;
+}
+
+body.is-standard-landing .landing__standard {
+  min-height: 100vh;
+  min-height: 100dvh;
+}
+
 :root {
   --intro-sprite-offset: clamp(200px, 24vw, 280px);
 }


### PR DESCRIPTION
## Summary
- ensure the standard landing state stretches the viewport by flexing the landing container and reinforcing 100vh height

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd6db32144832992b0cb1288a99ac8