### PR TITLE
Refine standard landing safe-area sizing

### DIFF
--- a/css/home.css
+++ b/css/home.css
@@ -4,18 +4,19 @@ body.home-page {
 }
 
 .home {
-  --app-safe-area-padding: clamp(20px, 5vw, 28px);
+  --app-safe-area-padding: clamp(16px, 4vw, 28px);
 
   width: min(100%, 420px);
   min-width: min(100%, 320px);
   margin: 0 auto;
+  height: 100%;
   min-height: 100vh;
   min-height: 100dvh;
   display: flex;
   flex-direction: column;
   align-items: stretch;
   justify-content: flex-start;
-  gap: clamp(24px, 6vh, 48px);
+  gap: clamp(12px, 3vh, 24px);
   color: inherit;
   box-sizing: border-box;
 }
@@ -26,14 +27,19 @@ body.home-page {
   justify-content: space-between;
   gap: var(--space-sm);
   width: 100%;
+  flex-shrink: 0;
+}
+
+.home__bar--bottom {
+  margin-top: auto;
 }
 
 .home__bar-item {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 100px;
-  height: 100px;
+  width: clamp(64px, 18vw, 96px);
+  height: clamp(64px, 18vw, 96px);
   padding: 0;
   background: none;
   border: none;
@@ -51,8 +57,8 @@ body.home-page {
 
 .home__bar-item img {
   display: block;
-  width: 100px;
-  height: 100px;
+  width: 100%;
+  height: 100%;
   object-fit: contain;
 }
 
@@ -63,13 +69,30 @@ body.home-page {
 }
 
 .home__content {
-  flex: 1;
+  flex: 1 1 auto;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: clamp(16px, 4vh, 28px);
+  gap: clamp(12px, 4vh, 24px);
   text-align: center;
+  padding-block: clamp(8px, 3vh, 16px);
+}
+
+.home__identity {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
+}
+
+.home__identity-text {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
 }
 
 
@@ -86,13 +109,14 @@ body.home-page {
 }
 
 .home__badge {
-  width: 100px;
-  height: 100px;
+  width: min(96px, 18vh);
+  height: min(96px, 18vh);
   object-fit: contain;
 }
 
 .home__hero-sprite {
-  width: clamp(220px, 70vw, 320px);
+  width: min(clamp(160px, 60vw, 320px), 36vh);
+  max-height: 36vh;
   height: auto;
   object-fit: contain;
   animation: hero-swim 4.5s ease-in-out 0.6s infinite;

--- a/css/index.css
+++ b/css/index.css
@@ -20,6 +20,23 @@ body.is-standard-landing {
   overflow: hidden;
 }
 
+body.is-standard-landing main.landing {
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  min-height: 100vh;
+  min-height: 100dvh;
+  height: 100vh;
+  height: 100dvh;
+}
+
+body.is-standard-landing .landing__standard {
+  flex: 0 1 auto;
+  height: 100%;
+  min-height: 100%;
+  max-height: 100%;
+}
+
 :root {
   --intro-sprite-offset: clamp(200px, 24vw, 280px);
 }

--- a/html/home.html
+++ b/html/home.html
@@ -45,17 +45,21 @@
       </header>
 
       <section class="home__content" aria-live="polite">
-        <h1 class="home__title">Shellfin</h1>
-        <p class="home__level text-small text-white">
-          Level <span data-hero-level>2</span>
-        </p>
-        <img
-          class="home__badge"
-          src="../images/home/addition.png"
-          alt="Addition badge"
-          width="100"
-          height="100"
-        />
+        <div class="home__identity">
+          <div class="home__identity-text">
+            <h1 class="home__title">Shellfin</h1>
+            <p class="home__level text-small text-white">
+              Level <span data-hero-level>2</span>
+            </p>
+          </div>
+          <img
+            class="home__badge"
+            src="../images/home/addition.png"
+            alt="Addition badge"
+            width="100"
+            height="100"
+          />
+        </div>
         <img
           class="home__hero-sprite"
           src="../images/hero/shellfin_level_2.png"


### PR DESCRIPTION
## Summary
- constrain the Level 2+ safe area to the viewport height when the standard landing renders
- rescale home layout elements so header, content, and footer remain within the safe area without overflow
- group the home identity text and badge to enforce an 8px text gap and 24px text-to-badge spacing

## Testing
- not run (styling change)

------
https://chatgpt.com/codex/tasks/task_e_68dd6db32144832992b0cb1288a99ac8