### PR TITLE
Add coin badge to home gems indicator

### DIFF
--- a/css/home.css
+++ b/css/home.css
@@ -62,6 +62,38 @@ body.home-page {
   object-fit: contain;
 }
 
+.home__status-gems {
+  position: relative;
+  display: inline-flex;
+}
+
+.home__status-coin {
+  position: absolute;
+  bottom: -16px;
+  left: -16px;
+  width: 64px;
+  height: 64px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.home__status-coin img {
+  width: 100%;
+  height: 100%;
+}
+
+.home__status-coin-count {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--text-size-small);
+  font-weight: 700;
+  color: #6c3b00;
+}
+
 .home__bar-item[aria-disabled='true'] {
   pointer-events: none;
   cursor: default;

--- a/html/home.html
+++ b/html/home.html
@@ -35,12 +35,24 @@
           />
         </div>
         <div class="home__bar-item home__bar-item--status" aria-live="polite">
-          <img
-            src="../images/home/gems.png"
-            alt="Gems"
-            width="100"
-            height="100"
-          />
+          <div class="home__status-gems">
+            <img
+              src="../images/home/gems.png"
+              alt="Gems"
+              width="100"
+              height="100"
+            />
+            <div class="home__status-coin">
+              <img
+                src="../images/home/coin.png"
+                alt=""
+                aria-hidden="true"
+                width="64"
+                height="64"
+              />
+              <span class="home__status-coin-count">40</span>
+            </div>
+          </div>
         </div>
       </header>
 


### PR DESCRIPTION
## Summary
- overlay the coin graphic on the gem status indicator with an offset badge
- add styling to center the global small text and apply the requested color

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd87b2caf48329bbff506001080459