### PR TITLE
Add medal reward for first correct Level 1 answer

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -354,6 +354,81 @@ button:focus-visible {
   gap: 24px;
 }
 
+.medal {
+  --surface-padding: var(--space-md);
+
+  position: fixed;
+  top: calc(env(safe-area-inset-top, 0px) + var(--space-lg));
+  left: 50%;
+  transform: translate(-50%, -24px) scale(0.92);
+  opacity: 0;
+  width: min(360px, calc(100% - 32px));
+  max-width: calc(100% - 32px);
+  text-align: left;
+  align-items: flex-start;
+  gap: var(--space-sm);
+  pointer-events: none;
+  z-index: 1200;
+  transition: opacity 0.35s ease,
+    transform 0.45s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.medal.medal--visible {
+  opacity: 1;
+  transform: translate(-50%, 0) scale(1);
+}
+
+.medal.medal--pop {
+  animation: medal-pop 0.5s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+@keyframes medal-pop {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -32px) scale(0.85);
+  }
+  60% {
+    opacity: 1;
+    transform: translate(-50%, 0) scale(1.04);
+  }
+  100% {
+    opacity: 1;
+    transform: translate(-50%, 0) scale(1);
+  }
+}
+
+.medal__pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 12px;
+  font-size: 14px;
+  line-height: 1;
+  font-weight: 600;
+  color: #ffffff;
+  background-image: linear-gradient(180deg, #30d158 0%, #1aaf4d 100%);
+  border-radius: 8px;
+}
+
+.medal__title,
+.medal__description {
+  margin: 0;
+}
+
+.medal__description {
+  color: rgba(39, 43, 52, 0.5);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .medal {
+    transition: none;
+  }
+
+  .medal.medal--pop {
+    animation: none;
+  }
+}
+
 .card--pop {
   animation: pop-in 0.4s ease-out forwards;
 }

--- a/html/battle.html
+++ b/html/battle.html
@@ -14,6 +14,20 @@
     <link rel="stylesheet" href="../css/battle.css" />
   </head>
   <body>
+  <section
+    class="card medal"
+    data-medal
+    hidden
+    aria-hidden="true"
+    role="status"
+    aria-live="polite"
+  >
+    <span class="medal__pill">Medal</span>
+    <p class="medal__title text-medium text-dark">Math Explorer</p>
+    <p class="medal__description text-small">
+      Awarded for your first correct answer
+    </p>
+  </section>
   <div id="battle">
     <img id="battle-monster" src="../images/battle/monster_battle_1_1.png" alt="Monster" />
     <img

--- a/js/battle.js
+++ b/js/battle.js
@@ -24,6 +24,9 @@ const progressUtils =
 
 const INTRO_QUESTION_LEVELS = new Set([1]);
 
+const MEDAL_DISPLAY_DURATION_MS = 3000;
+const LEVEL_ONE_FIRST_CORRECT_MEDAL_KEY = 'level-1:first-correct';
+
 if (!progressUtils) {
   throw new Error('Progress utilities are not available.');
 }
@@ -149,6 +152,105 @@ document.addEventListener('DOMContentLoaded', () => {
   const evolutionCompleteSprite = evolutionCompleteOverlay?.querySelector(
     '[data-evolution-complete-sprite]'
   );
+
+  const medalElement = document.querySelector('[data-medal]');
+  let medalHideTimeoutId = null;
+  let medalFinalizeTimeoutId = null;
+  const displayedMedals = new Set();
+
+  const finalizeMedalHide = () => {
+    if (!medalElement || medalElement.classList.contains('medal--visible')) {
+      return;
+    }
+
+    medalElement.setAttribute('aria-hidden', 'true');
+    if (!medalElement.hasAttribute('hidden')) {
+      medalElement.setAttribute('hidden', 'hidden');
+    }
+  };
+
+  const hideMedal = ({ immediate = false } = {}) => {
+    if (!medalElement) {
+      return;
+    }
+
+    if (medalHideTimeoutId !== null) {
+      window.clearTimeout(medalHideTimeoutId);
+      medalHideTimeoutId = null;
+    }
+
+    if (medalFinalizeTimeoutId !== null) {
+      window.clearTimeout(medalFinalizeTimeoutId);
+      medalFinalizeTimeoutId = null;
+    }
+
+    const removeVisibility = () => {
+      medalElement.classList.remove('medal--visible');
+      medalElement.classList.remove('medal--pop');
+    };
+
+    if (immediate) {
+      removeVisibility();
+      finalizeMedalHide();
+      return;
+    }
+
+    const handleTransitionEnd = (event) => {
+      if (event.target !== medalElement || event.propertyName !== 'opacity') {
+        return;
+      }
+      medalElement.removeEventListener('transitionend', handleTransitionEnd);
+      finalizeMedalHide();
+    };
+
+    medalElement.addEventListener('transitionend', handleTransitionEnd, {
+      once: true,
+    });
+
+    removeVisibility();
+
+    medalFinalizeTimeoutId = window.setTimeout(() => {
+      medalFinalizeTimeoutId = null;
+      finalizeMedalHide();
+    }, 450);
+  };
+
+  const showMedal = () => {
+    if (!medalElement) {
+      return;
+    }
+
+    if (medalHideTimeoutId !== null) {
+      window.clearTimeout(medalHideTimeoutId);
+      medalHideTimeoutId = null;
+    }
+
+    if (medalFinalizeTimeoutId !== null) {
+      window.clearTimeout(medalFinalizeTimeoutId);
+      medalFinalizeTimeoutId = null;
+    }
+
+    medalElement.classList.remove('medal--pop');
+    medalElement.removeAttribute('hidden');
+    void medalElement.offsetWidth;
+    medalElement.setAttribute('aria-hidden', 'false');
+    medalElement.classList.add('medal--visible', 'medal--pop');
+
+    medalHideTimeoutId = window.setTimeout(() => {
+      medalHideTimeoutId = null;
+      hideMedal();
+    }, MEDAL_DISPLAY_DURATION_MS);
+  };
+
+  if (medalElement) {
+    medalElement.addEventListener('animationend', (event) => {
+      if (event.target !== medalElement || event.animationName !== 'medal-pop') {
+        return;
+      }
+
+      medalElement.classList.remove('medal--pop');
+    });
+  }
 
   const summaryAccuracyText = ensureStatValueText(summaryAccuracyValue);
   const summaryTimeText = ensureStatValueText(summaryTimeValue);
@@ -358,6 +460,27 @@ document.addEventListener('DOMContentLoaded', () => {
   let evolutionGrowthFallbackTimeout = null;
   let evolutionRevealFallbackTimeout = null;
   let evolutionCardDelayTimeout = null;
+
+  const maybeShowFirstCorrectMedal = (resolvedLevel, correctCount) => {
+    if (!medalElement) {
+      return;
+    }
+
+    if (!Number.isFinite(resolvedLevel) || resolvedLevel !== 1) {
+      return;
+    }
+
+    if (displayedMedals.has(LEVEL_ONE_FIRST_CORRECT_MEDAL_KEY)) {
+      return;
+    }
+
+    if (correctCount !== 1) {
+      return;
+    }
+
+    displayedMedals.add(LEVEL_ONE_FIRST_CORRECT_MEDAL_KEY);
+    showMedal();
+  };
   let evolutionInProgress = false;
   let rewardCardDisplayTimeout = null;
   let heroSpriteReadyPromise = null;
@@ -2833,6 +2956,7 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
     const correct = e.detail.correct;
+    const resolvedLevel = getResolvedBattleLevel();
     totalAnswers++;
     if (correct) {
       correctAnswers++;
@@ -2841,6 +2965,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     updateAccuracyDisplays();
     if (correct) {
+      maybeShowFirstCorrectMedal(resolvedLevel, correctAnswers);
       let incEl = null;
       let incText = '';
       if (!streakMaxed) {
@@ -3034,6 +3159,7 @@ document.addEventListener('DOMContentLoaded', () => {
     cancelScheduledLevelProgressDisplayUpdate();
     clearRewardAnimation();
     updateLevelProgressDisplay();
+    hideMedal({ immediate: true });
     if (completeMessage) {
       completeMessage.classList.remove('show');
       completeMessage.setAttribute('aria-hidden', 'true');


### PR DESCRIPTION
## Summary
- add a reusable medal card component to the battle page and style it for a top-of-screen display
- animate and show the medal when the player records their first correct answer in Level 1, then hide it automatically
- ensure the medal hides on battle reset and respects reduced-motion preferences

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dd8d9386d88329b5575aeb32e8a593