### PR TITLE
Use Supabase player profile data when available

### DIFF
--- a/html/battle.html
+++ b/html/battle.html
@@ -244,7 +244,10 @@
       </div>
     </div>
     <script src="../js/pwa.js" defer data-pwa-root=".."></script>
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2" defer></script>
+    <script src="../js/supabaseClient.js" defer></script>
     <script src="../js/utils/progress.js" defer></script>
+    <script src="../js/utils/playerProfile.js" defer></script>
     <script src="../js/loader.js" defer></script>
     <script src="../js/battle.js" defer></script>
     <script src="../js/question.js" defer></script>

--- a/index.html
+++ b/index.html
@@ -286,6 +286,7 @@
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2" defer></script>
   <script src="js/supabaseClient.js" defer></script>
   <script src="js/utils/progress.js" defer></script>
+  <script src="js/utils/playerProfile.js" defer></script>
   <script src="js/index.js" defer></script>
 </body>
 </html>

--- a/js/utils/playerProfile.js
+++ b/js/utils/playerProfile.js
@@ -1,0 +1,124 @@
+(() => {
+  const globalScope =
+    typeof globalThis !== 'undefined'
+      ? globalThis
+      : typeof window !== 'undefined'
+      ? window
+      : typeof self !== 'undefined'
+      ? self
+      : {};
+
+  const toNumericBattleLevel = (value) => {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value;
+    }
+
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (!trimmed) {
+        return null;
+      }
+      const parsed = Number(trimmed);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+
+    return null;
+  };
+
+  const syncBattleLevelToStorage = (playerData, storageKey) => {
+    if (!playerData || typeof storageKey !== 'string' || !storageKey) {
+      return;
+    }
+
+    const remoteLevel = playerData?.progress?.battleLevel;
+    const numericLevel = toNumericBattleLevel(remoteLevel);
+    if (numericLevel === null) {
+      return;
+    }
+
+    try {
+      const storage = globalScope?.localStorage;
+      if (!storage) {
+        return;
+      }
+
+      const raw = storage.getItem(storageKey);
+      let parsed = null;
+      if (raw) {
+        try {
+          parsed = JSON.parse(raw);
+        } catch (error) {
+          console.warn('Stored progress could not be parsed for sync.', error);
+        }
+      }
+
+      const nextValue =
+        parsed && typeof parsed === 'object' ? { ...parsed } : {};
+      nextValue.battleLevel = numericLevel;
+
+      storage.setItem(storageKey, JSON.stringify(nextValue));
+    } catch (error) {
+      console.warn('Failed to sync battle level with storage.', error);
+    }
+  };
+
+  const fetchPlayerProfile = async () => {
+    const supabase = globalScope?.supabaseClient;
+    if (!supabase?.auth) {
+      return null;
+    }
+
+    let userId = null;
+
+    try {
+      if (typeof supabase.auth.getUser === 'function') {
+        const { data, error } = await supabase.auth.getUser();
+        if (error) {
+          console.warn('Supabase user lookup failed.', error);
+        }
+        userId = data?.user?.id ?? null;
+      } else if (typeof supabase.auth.getSession === 'function') {
+        const { data, error } = await supabase.auth.getSession();
+        if (error) {
+          console.warn('Supabase session lookup failed.', error);
+        }
+        userId = data?.session?.user?.id ?? null;
+      }
+    } catch (error) {
+      console.warn('Failed to obtain Supabase user.', error);
+      return null;
+    }
+
+    if (!userId || typeof supabase.from !== 'function') {
+      return null;
+    }
+
+    try {
+      const { data, error } = await supabase
+        .from('player_profiles')
+        .select('player_data')
+        .eq('id', userId)
+        .single();
+
+      if (error) {
+        console.warn('Supabase player profile lookup failed.', error);
+        return null;
+      }
+
+      const playerData = data?.player_data;
+      return playerData && typeof playerData === 'object' ? playerData : null;
+    } catch (error) {
+      console.warn('Failed to fetch player profile from Supabase.', error);
+      return null;
+    }
+  };
+
+  const namespace =
+    (globalScope.mathMonstersPlayerProfile =
+      globalScope.mathMonstersPlayerProfile || {});
+
+  namespace.fetchPlayerProfile = fetchPlayerProfile;
+  namespace.syncBattleLevelToStorage = syncBattleLevelToStorage;
+})();


### PR DESCRIPTION
## Summary
- add a shared player profile helper that queries Supabase and syncs cached battle level
- load landing previews with Supabase-backed player data when available, falling back to bundled JSON when offline or guest
- reuse the Supabase player profile helper inside the battle loader so the scene mirrors remote progress

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dddda4b3b4832998fb08b4f28c6232