### PR TITLE
Update battle question path resolution

### DIFF
--- a/js/loader.js
+++ b/js/loader.js
@@ -447,7 +447,15 @@ const syncRemoteBattleLevel = (playerData) => {
       });
 
     let questions = [];
-    const questionFile = currentLevel?.battle?.questionReference?.file;
+    const battleQuestions = currentLevel?.battle?.questions;
+    const derivedQuestionPath =
+      typeof battleQuestions === 'string'
+        ? battleQuestions
+        : battleQuestions && typeof battleQuestions === 'object'
+        ? battleQuestions.path || battleQuestions.file || null
+        : null;
+    const legacyQuestionFile = currentLevel?.battle?.questionReference?.file;
+    const questionFile = derivedQuestionPath || legacyQuestionFile;
 
     if (questionFile) {
       try {


### PR DESCRIPTION
## Summary
- resolve battle questions from the new `battle.questions.path`
- fall back to legacy `battle.questionReference.file` to keep older data working

## Testing
- not run (requires launching the web experience to start a battle)


------
https://chatgpt.com/codex/tasks/task_e_68e027b5d4e88329a82b174607902b6b