### PR TITLE
Replace battle enemy references with monster schema

### DIFF
--- a/data/levels.json
+++ b/data/levels.json
@@ -19,7 +19,7 @@
               "damage": 1,
               "attackSprite": "/mathmonsters/images/hero/shellfin_attack_1.png"
             },
-            "enemy": {
+            "monster": {
               "id": "octomurk",
               "name": "Octomurk",
               "sprite": "/mathmonsters/images/monster/addition_battle_1.png",
@@ -52,7 +52,7 @@
               "damage": 1,
               "attackSprite": "/mathmonsters/images/hero/shellfin_attack_2.png"
             },
-            "enemy": {
+            "monster": {
               "id": "ripjaw",
               "name": "Ripjaw",
               "sprite": "/mathmonsters/images/monster/addition_battle_2.png",
@@ -85,7 +85,7 @@
               "damage": 2,
               "attackSprite": "/mathmonsters/images/hero/shellfin_attack_2.png"
             },
-            "enemy": {
+            "monster": {
               "id": "gulper",
               "name": "Gulper",
               "sprite": "/mathmonsters/images/monster/addition_battle_3.png",
@@ -118,7 +118,7 @@
               "damage": 2,
               "attackSprite": "/mathmonsters/images/hero/shellfin_attack_2.png"
             },
-            "enemy": {
+            "monster": {
               "id": "typhoon",
               "name": "Typhoon",
               "sprite": "/mathmonsters/images/monster/addition_battle_4.png",
@@ -151,7 +151,7 @@
               "damage": 3,
               "attackSprite": "/mathmonsters/images/hero/shellfin_attack_2.png"
             },
-            "enemy": {
+            "monster": {
               "id": "maelstrom",
               "name": "Maelstrom",
               "sprite": "/mathmonsters/images/monster/addition_battle_5.png",

--- a/data/schema.json
+++ b/data/schema.json
@@ -129,9 +129,16 @@
                     "required": [
                       "questions",
                       "hero",
-                      "enemy",
                       "winReward",
                       "loseReward"
+                    ],
+                    "allOf": [
+                      {
+                        "anyOf": [
+                          { "required": ["monster"] },
+                          { "required": ["monsters"] }
+                        ]
+                      }
                     ],
                     "properties": {
                       "questions": {
@@ -162,7 +169,7 @@
                           "attackSprite": { "type": "string" }
                         }
                       },
-                      "enemy": {
+                      "monster": {
                         "type": "object",
                         "required": [
                           "id",
@@ -181,6 +188,30 @@
                           "health": { "type": "integer" },
                           "damage": { "type": "integer" },
                           "attackSprite": { "type": "string" }
+                        }
+                      },
+                      "monsters": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "id",
+                            "name",
+                            "sprite",
+                            "attack",
+                            "health",
+                            "damage",
+                            "attackSprite"
+                          ],
+                          "properties": {
+                            "id": { "type": "string" },
+                            "name": { "type": "string" },
+                            "sprite": { "type": "string" },
+                            "attack": { "type": "integer" },
+                            "health": { "type": "integer" },
+                            "damage": { "type": "integer" },
+                            "attackSprite": { "type": "string" }
+                          }
                         }
                       },
                       "winReward": {

--- a/js/index.js
+++ b/js/index.js
@@ -871,20 +871,21 @@ const determineBattlePreview = (levelsData, playerData) => {
       : 'Math Mission';
   const mathLabel = mathLabelSource.trim() || 'Math Mission';
 
-  const monsterData = (() => {
-    if (battle && typeof battle.monster === 'object' && battle.monster !== null) {
-      return battle.monster;
-    }
-    if (Array.isArray(battle?.monsters)) {
-      const match = battle.monsters.find(
-        (candidate) => candidate && typeof candidate === 'object'
-      );
-      if (match) {
-        return match;
+  const monsterCandidates = [];
+  if (battle && typeof battle.monster === 'object' && battle.monster !== null) {
+    monsterCandidates.push(battle.monster);
+  }
+  if (Array.isArray(battle?.monsters)) {
+    battle.monsters.forEach((candidate) => {
+      if (candidate && typeof candidate === 'object') {
+        monsterCandidates.push(candidate);
       }
-    }
-    return {};
-  })();
+    });
+  }
+  const monsterData =
+    monsterCandidates.find(
+      (candidate) => candidate && typeof candidate === 'object'
+    ) || {};
   const rawMonsterSprite =
     typeof monsterData?.sprite === 'string' ? monsterData.sprite.trim() : '';
   const monsterSprite = sanitizeAssetPath(rawMonsterSprite) || rawMonsterSprite;

--- a/js/loader.js
+++ b/js/loader.js
@@ -480,7 +480,11 @@ const syncRemoteBattleLevel = (playerData) => {
       }
     }
 
-    const levelBattle = currentLevel?.battle ?? {};
+    const levelBattleRaw = currentLevel?.battle ?? {};
+    const levelBattle =
+      levelBattleRaw && typeof levelBattleRaw === 'object'
+        ? (({ enemy, enemies, ...rest }) => rest)(levelBattleRaw)
+        : {};
 
     const resolvePlayerLevelData = (level) => {
       if (!basePlayer || typeof basePlayer !== 'object') {


### PR DESCRIPTION
## Summary
- update level definitions to provide monsters instead of the legacy enemy field
- adjust the game data schema to validate the unified monster/monsters properties
- ensure the loader and UI preview consume only monster data when preparing battles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0294b53e48329b8401c8a8a3b2272