### PR TITLE
Fix Shellfin sprite mapping for home page

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -715,6 +715,11 @@ const sanitizeAssetPath = (path) => {
     trimmed = trimmed.replace(/^\/+/, '');
   }
 
+  trimmed = trimmed.replace(
+    /(\/?hero\/shellfin)_level_(\d+)/gi,
+    (_, prefix, level) => `${prefix}_evolution_${level}`
+  );
+
   return trimmed;
 };
 


### PR DESCRIPTION
## Summary
- normalize sanitized asset paths so Shellfin sprites use the evolution artwork instead of the outdated level variants

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e043bb50088329a016124afded3823