### PR TITLE
Fix fallback base detection for prefixed paths

### DIFF
--- a/js/loader.js
+++ b/js/loader.js
@@ -14,8 +14,24 @@ const deriveBaseFromLocation = (fallbackBase) => {
       ? window.location.pathname
       : '';
 
-  if (rawFallback && locationPath.startsWith(rawFallback)) {
-    return fallbackBase;
+  if (rawFallback) {
+    let fallbackNormalized = rawFallback;
+    if (fallbackNormalized !== '/') {
+      fallbackNormalized = fallbackNormalized.replace(/\/+$/, '');
+    }
+    if (fallbackNormalized && !fallbackNormalized.startsWith('/')) {
+      fallbackNormalized = `/${fallbackNormalized}`;
+    }
+    if (!fallbackNormalized) {
+      fallbackNormalized = '/';
+    }
+    const matchesFallback =
+      locationPath === fallbackNormalized ||
+      (fallbackNormalized !== '/' &&
+        locationPath.startsWith(`${fallbackNormalized}/`));
+    if (matchesFallback) {
+      return fallbackBase;
+    }
   }
 
   const withoutQuery = locationPath.replace(/[?#].*$/, '');


### PR DESCRIPTION
## Summary
- tighten the loader's reuse of the fallback asset base so it only applies to exact matches or paths nested under the fallback
- normalize fallback paths to prevent false positives when checking prefixed locations

## Testing
- not run (not able to run browser smoke tests in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e047366ba0832988a838dde414077e