### PR TITLE
Fix battle loader initialization order

### DIFF
--- a/js/loader.js
+++ b/js/loader.js
@@ -574,6 +574,12 @@ const syncRemoteBattleLevel = (playerData) => {
       progress.battleLevel = currentLevel.battleLevel;
     }
 
+    const levelBattleRaw = currentLevel?.battle ?? {};
+    const levelBattle =
+      levelBattleRaw && typeof levelBattleRaw === 'object'
+        ? { ...levelBattleRaw }
+        : {};
+
     const resolveAssetPath = (path) => normalizeAssetPath(path);
 
     const normalizeAttackSprites = (...spriteSources) => {
@@ -782,12 +788,6 @@ const syncRemoteBattleLevel = (playerData) => {
         console.error('Failed to load questions data', error);
       }
     }
-
-      const levelBattleRaw = currentLevel?.battle ?? {};
-      const levelBattle =
-        levelBattleRaw && typeof levelBattleRaw === 'object'
-          ? { ...levelBattleRaw }
-          : {};
 
     const resolvePlayerLevelData = (level) => {
       if (!basePlayer || typeof basePlayer !== 'object') {


### PR DESCRIPTION
## Summary
- compute `levelBattle` immediately after resolving the current level so question assets can be loaded
- let the loader finish without throwing, restoring hero and monster names as well as the question flow

## Testing
- browser_container.run_playwright_script (battle smoke test)

------
https://chatgpt.com/codex/tasks/task_e_68e04dbf903483298014cabed7506a7a