### PR TITLE
Normalize battle level progress before selecting battle assets

### DIFF
--- a/docs/regression-scenarios.md
+++ b/docs/regression-scenarios.md
@@ -1,0 +1,20 @@
+# Regression Scenarios
+
+## String Battle Level Normalization
+
+This scenario verifies that stored progress using a string battle level still loads the correct level assets.
+
+1. Run the site locally and open the Math Monsters battle page in a browser.
+2. Open the developer console and seed battle progress with a string value:
+   ```js
+   localStorage.setItem('mathmonstersProgress', JSON.stringify({
+     battleLevel: '2'
+   }));
+   ```
+3. Refresh the page. Confirm the hero and monster sprites correspond to level 2 (e.g., the level selector highlights "2" and the level 2 art assets are displayed).
+4. Clear the seeded value after verification:
+   ```js
+   localStorage.removeItem('mathmonstersProgress');
+   ```
+
+This protects against regressions where string-based battle progress prevented level-specific sprites from loading.

--- a/js/loader.js
+++ b/js/loader.js
@@ -541,8 +541,11 @@ const syncRemoteBattleLevel = (playerData) => {
     let experienceMap = normalizeExperienceMap(progress?.experience);
 
     if (storedProgress && typeof storedProgress === 'object') {
-      if (typeof storedProgress.battleLevel === 'number') {
-        progress.battleLevel = storedProgress.battleLevel;
+      const storedBattleLevel = normalizeBattleLevel(
+        storedProgress.battleLevel
+      );
+      if (storedBattleLevel !== null) {
+        progress.battleLevel = storedBattleLevel;
       }
       if (typeof storedProgress.timeRemainingSeconds === 'number') {
         battleVariables.timeRemainingSeconds =
@@ -558,8 +561,20 @@ const syncRemoteBattleLevel = (playerData) => {
       delete progress.experience;
     }
 
+    const normalizedProgressBattleLevel = normalizeBattleLevel(
+      progress.battleLevel
+    );
+
     const activeBattleLevel =
-      progress.battleLevel ?? levels[0]?.battleLevel ?? null;
+      normalizedProgressBattleLevel ?? levels[0]?.battleLevel ?? null;
+
+    if (normalizedProgressBattleLevel !== null) {
+      progress.battleLevel = normalizedProgressBattleLevel;
+    } else if (Number.isFinite(activeBattleLevel)) {
+      progress.battleLevel = activeBattleLevel;
+    } else {
+      delete progress.battleLevel;
+    }
 
     const currentLevel =
       levels.find((level) => level?.battleLevel === activeBattleLevel) ??


### PR DESCRIPTION
## Summary
- normalize stored and base progress battle level values before choosing the active level
- synchronize progress with the normalized value and only fall back to the first level when needed
- document a manual regression scenario to confirm level 2 assets load when progress stores the level as a string

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e078b83fec8329b773a0afb0198e97