### PR TITLE
Add level-up and experience metadata to battles

### DIFF
--- a/data/levels.json
+++ b/data/levels.json
@@ -10,6 +10,7 @@
             "questions": {
               "path": "questions/level_1_questions.json"
             },
+            "levelUp": 50,
             "hero": {
               "id": "shellfin",
               "name": "Shellfin",
@@ -26,6 +27,7 @@
               "attack": 1,
               "health": 3,
               "damage": 0,
+              "experiencePoints": 50,
               "attackSprite": "/mathmonsters/images/monster/monster_attack.png"
             },
             "winReward": {
@@ -43,6 +45,7 @@
             "questions": {
               "path": "questions/level_2_questions.json"
             },
+            "levelUp": 60,
             "hero": {
               "id": "shellfin",
               "name": "Shellfin",
@@ -59,6 +62,7 @@
               "attack": 1,
               "health": 5,
               "damage": 0,
+              "experiencePoints": 60,
               "attackSprite": "/mathmonsters/images/monster/monster_attack.png"
             },
             "winReward": {
@@ -76,6 +80,7 @@
             "questions": {
               "path": "questions/level_3_questions.json"
             },
+            "levelUp": 70,
             "hero": {
               "id": "shellfin",
               "name": "Shellfin",
@@ -92,6 +97,7 @@
               "attack": 1,
               "health": 5,
               "damage": 0,
+              "experiencePoints": 70,
               "attackSprite": "/mathmonsters/images/monster/monster_attack.png"
             },
             "winReward": {
@@ -109,6 +115,7 @@
             "questions": {
               "path": "questions/level_4_questions.json"
             },
+            "levelUp": 80,
             "hero": {
               "id": "shellfin",
               "name": "Shellfin",
@@ -125,6 +132,7 @@
               "attack": 1,
               "health": 5,
               "damage": 0,
+              "experiencePoints": 80,
               "attackSprite": "/mathmonsters/images/monster/monster_attack.png"
             },
             "winReward": {
@@ -142,6 +150,7 @@
             "questions": {
               "path": "questions/level_5_questions.json"
             },
+            "levelUp": 90,
             "hero": {
               "id": "shellfin",
               "name": "Shellfin",
@@ -158,6 +167,7 @@
               "attack": 1,
               "health": 5,
               "damage": 0,
+              "experiencePoints": 90,
               "attackSprite": "/mathmonsters/images/monster/monster_attack.png"
             },
             "winReward": {


### PR DESCRIPTION
## Summary
- add levelUp requirements to each defined battle
- provide experiencePoints for every battle monster
- rerun the data validation script to ensure the dataset remains compliant

## Testing
- node scripts/validate-data.js

------
https://chatgpt.com/codex/tasks/task_e_68e09e2331488329ad5551cb17eb4d46