### PR TITLE
Replace registration badge with circular parent image

### DIFF
--- a/css/signin.css
+++ b/css/signin.css
@@ -43,9 +43,11 @@
 
 .preloader__badge {
   display: block;
-  width: clamp(200px, 45vw, 320px);
-  max-width: 100%;
+  width: min(200px, 100%);
   height: auto;
+  aspect-ratio: 1 / 1;
+  border-radius: 50%;
+  object-fit: cover;
 }
 
 .preloader__form {

--- a/html/register.html
+++ b/html/register.html
@@ -29,9 +29,9 @@
         <img
           class="preloader__badge"
           src="../images/complete/parent.png"
-          width="320"
-          height="96"
-          alt="Parent Check-In badge"
+          width="200"
+          height="200"
+          alt="Parent profile illustration"
         />
         <div class="preloader__titles">
           <h1 class="preloader__headline text-large text-white">


### PR DESCRIPTION
## Summary
- swap the registration badge graphic for the parent illustration sized at 200x200
- adjust the shared preloader badge styles to render the image as a circular avatar

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0a9ec40c48329a9e51277c0822efc