### PR TITLE
Display numeric level on level 2+ home hero label

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1376,10 +1376,9 @@ const determineBattlePreview = (levelsData, playerData) => {
       ? `Battle ${activeLevel.battleLevel}`
       : 'Upcoming Battle');
   const heroLevelLabel =
-    levelName ||
-    (typeof activeLevel?.battleLevel === 'number'
+    typeof activeLevel?.battleLevel === 'number'
       ? `Level ${activeLevel.battleLevel}`
-      : 'Level');
+      : 'Level';
   const experienceMap = normalizeExperienceMap(player?.progress?.experience);
   const earnedExperience = readExperienceForLevel(
     experienceMap,


### PR DESCRIPTION
## Summary
- adjust the battle preview hero level label to always show the numeric level
- prevent level 2+ homepages from showing the level name beneath the hero

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1fa0a865483298b950b722c1c2e3c