### PR TITLE
Register absolute sprite URLs in character asset tracking

### DIFF
--- a/js/loader.js
+++ b/js/loader.js
@@ -733,6 +733,20 @@ const syncRemoteBattleLevel = (playerData) => {
       if (resolvedSprite) {
         normalized.sprite = resolvedSprite;
         registerAsset(resolvedSprite);
+        if (
+          typeof window !== 'undefined' &&
+          typeof document !== 'undefined' &&
+          typeof document.baseURI === 'string'
+        ) {
+          try {
+            const absoluteSprite = new URL(resolvedSprite, document.baseURI).href;
+            if (!characterAssetSet.has(absoluteSprite)) {
+              characterAssetSet.add(absoluteSprite);
+            }
+          } catch (error) {
+            // Ignore URL resolution errors and continue with normalized sprite only.
+          }
+        }
       } else {
         delete normalized.sprite;
       }


### PR DESCRIPTION
## Summary
- register browser-resolved absolute sprite URLs alongside normalized paths when preparing characters
- guard absolute URL resolution for browser environments and avoid duplicate asset registrations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1fdbd15cc83298351c301a0073a34