### PR TITLE
Simplify level 2+ home layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,53 +121,13 @@
       data-standard-landing
       aria-live="polite"
     >
-      <header class="home__bar home__bar--top">
-        <div
-          class="home__bar-item home__bar-item--action"
-          role="link"
-          tabindex="0"
-          data-initial-tabindex="0"
-          aria-label="Open settings"
-          data-settings-logout
-        >
-          <img
-            src="./images/home/medal_1.png"
-            alt="Settings"
-            width="100"
-            height="100"
-          />
-        </div>
-        <div class="home__bar-item home__bar-item--status" aria-live="polite">
-          <div class="home__status-gems">
-            <img
-              src="./images/home/gems.png"
-              alt="Gems"
-              width="100"
-              height="100"
-            />
-            <div class="home__status-coin">
-              <img
-                src="./images/home/coin.png"
-                alt=""
-                aria-hidden="true"
-                width="64"
-                height="64"
-              />
-              <span class="home__status-coin-count">40</span>
-            </div>
-          </div>
-        </div>
-      </header>
-
       <section class="home__content" aria-live="polite">
         <div class="home__identity">
-          <div class="home__identity-text">
-            <div class="home__identity-copy">
-              <h1 class="home__title" data-hero-name>Shellfin</h1>
-              <p class="home__level text-small text-white" data-hero-level>
-                Level 2
-              </p>
-            </div>
+          <div class="home__identity-statbox">
+            <h1 class="home__title" data-hero-name>Shellfin</h1>
+            <p class="home__level text-small text-white" data-hero-level>
+              Level 2
+            </p>
           </div>
         </div>
         <img
@@ -176,39 +136,12 @@
           alt="Shellfin ready for the next adventure"
           data-hero-sprite
         />
+        <img
+          class="home__sword"
+          src="./images/home/sword.png"
+          alt="Forged sword unlocked for the next quest"
+        />
       </section>
-
-      <footer class="home__bar home__bar--bottom">
-        <div
-          class="home__bar-item home__bar-item--action"
-          role="link"
-          tabindex="0"
-          data-initial-tabindex="0"
-          aria-label="Battle"
-          data-battle-button
-        >
-          <img
-            src="./images/home/battle.png"
-            alt="Battle"
-            width="100"
-            height="100"
-          />
-        </div>
-        <div
-          class="home__bar-item home__bar-item--action"
-          role="link"
-          tabindex="0"
-          data-initial-tabindex="0"
-          aria-label="Store"
-        >
-          <img
-            src="./images/home/store.png"
-            alt="Store"
-            width="100"
-            height="100"
-          />
-        </div>
-      </footer>
     </div>
 
   </main>


### PR DESCRIPTION
## Summary
- remove the icon bars from the level 2+ home landing view
- show the hero stats in the statbox and add the centered sword image beneath the hero sprite

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1fde345148329a25be3ced88b309c