### PR TITLE
Require interaction before starting battle on standard landing

### DIFF
--- a/css/home.css
+++ b/css/home.css
@@ -155,6 +155,16 @@ body.home-page {
   pointer-events: none;
 }
 
+.home__hero-sprite[data-battle-trigger] {
+  pointer-events: auto;
+  cursor: pointer;
+}
+
+.home__hero-sprite[data-battle-trigger][aria-disabled='true'],
+.home__hero-sprite[data-battle-trigger][aria-busy='true'] {
+  cursor: default;
+}
+
 .home__sword {
   width: 160px;
   height: 160px;

--- a/css/index.css
+++ b/css/index.css
@@ -213,6 +213,16 @@ body:not(.is-preloading) main.landing {
     cubic-bezier(0.36, 0, 0.66, 1);
 }
 
+.hero[data-battle-trigger] {
+  pointer-events: auto;
+  cursor: pointer;
+}
+
+.hero[data-battle-trigger][aria-disabled='true'],
+.hero[data-battle-trigger][aria-busy='true'] {
+  cursor: default;
+}
+
 .hero.is-side-position {
   --hero-side-shift: calc(-1 * var(--intro-sprite-offset));
 }

--- a/html/home.html
+++ b/html/home.html
@@ -31,6 +31,7 @@
           class="home__hero-sprite"
           src="../images/hero/shellfin_evolution_2.png"
           alt="Shellfin ready for the next adventure"
+          data-battle-trigger
         />
         <img
           class="home__sword"

--- a/index.html
+++ b/index.html
@@ -135,6 +135,7 @@
           src="./images/hero/shellfin_evolution_2.png"
           alt="Shellfin ready for the next adventure"
           data-hero-sprite
+          data-battle-trigger
         />
         <img
           class="home__sword"

--- a/js/index.js
+++ b/js/index.js
@@ -2002,12 +2002,54 @@ const initLandingInteractions = async (preloadedData = {}) => {
     }
   };
 
+  const battleImageTriggers = !isLevelOneLanding
+    ? Array.from(
+        document.querySelectorAll('[data-standard-landing] [data-battle-trigger]')
+      ).filter((element) => element instanceof HTMLElement)
+    : [];
+
+  if (!isLevelOneLanding) {
+    battleImageTriggers.forEach((trigger) => {
+      if (!trigger || trigger.dataset.battleTriggerBound === 'true') {
+        return;
+      }
+
+      trigger.dataset.battleTriggerBound = 'true';
+
+      if (!trigger.hasAttribute('role')) {
+        trigger.setAttribute('role', 'button');
+      }
+
+      if (!trigger.hasAttribute('aria-label')) {
+        trigger.setAttribute('aria-label', 'Start battle');
+      }
+
+      if (!trigger.hasAttribute('data-initial-tabindex')) {
+        trigger.setAttribute('data-initial-tabindex', '0');
+      }
+
+      setInteractiveDisabled(trigger, false);
+
+      attachInteractiveHandler(trigger, (event) => {
+        if (event && typeof event.preventDefault === 'function') {
+          event.preventDefault();
+        }
+
+        beginBattle({ triggerButton: trigger, showIntroImmediately: true });
+      });
+    });
+  }
+
   if (isLevelOneLanding) {
     setupLevelOneIntro({ heroImage: levelOneHeroImage, beginBattle });
     return;
   }
 
   if (!battleButton) {
+    if (battleImageTriggers.length) {
+      return;
+    }
+
     await waitForImages;
 
     const showIntroImmediately = true;


### PR DESCRIPTION
## Summary
- add a data-battle-trigger hook to the level 2+ hero artwork
- enable pointer interaction styling for the clickable battle image
- wait for user interaction on the battle image instead of auto-starting the encounter

## Testing
- Not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68e33563afe88329bdaa0358f7804cdf