### PR TITLE
Rework level 2 nameplate with ocean styling

### DIFF
--- a/css/home.css
+++ b/css/home.css
@@ -119,31 +119,102 @@ body.home-page {
   justify-content: center;
 }
 
-.home__identity-statbox {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 8px;
-  padding: 16px 40px;
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.5);
-  background-color: rgba(0, 27, 65, 0.4);
-  backdrop-filter: blur(4px);
-  color: var(--text-color-light);
+.mm-nameplate {
+  --ocean-deep: #022b57;
+  --ocean-mid: #045f88;
+  --aqua-glow: rgba(67, 210, 255, 0.55);
+  --abyss-shadow: rgba(1, 15, 38, 0.45);
+  --ridge-highlight: rgba(155, 241, 255, 0.55);
+
+  display: inline-block;
+  padding: 8px;
+  border-radius: 24px;
+  background:
+    radial-gradient(120% 160% at 18% 18%, var(--ridge-highlight) 0 18%, transparent 19%),
+    radial-gradient(150% 140% at 80% 10%, var(--aqua-glow) 0 26%, transparent 27%),
+    linear-gradient(135deg, var(--ocean-mid), var(--ocean-deep));
+  box-shadow:
+    0 10px 26px var(--abyss-shadow),
+    inset 0 3px 0 rgba(255, 255, 255, 0.18),
+    inset 0 -3px 0 rgba(0, 13, 32, 0.4);
+  outline: 3px solid rgba(6, 36, 74, 0.85);
 }
 
-
-.home__title {
-  margin: 0;
-  font-size: 40px;
-  font-weight: 400;
-  color: #ffffff;
+.mm-nameplate__panel {
+  position: relative;
+  border-radius: 16px;
+  padding: 16px 28px 14px;
+  background:
+    radial-gradient(180% 120% at 50% 0%, rgba(216, 251, 255, 0.35) 0 32%, transparent 33%),
+    conic-gradient(from 210deg at 50% 10%, rgba(43, 184, 223, 0.2), rgba(9, 76, 127, 0.5), rgba(43, 184, 223, 0.25)),
+    linear-gradient(165deg, rgba(15, 109, 160, 0.95), rgba(2, 43, 87, 0.95));
+  box-shadow:
+    inset 0 10px 22px rgba(255, 255, 255, 0.35),
+    inset 0 -12px 24px rgba(0, 20, 50, 0.5);
+  overflow: hidden;
 }
 
-.home__level {
-  margin: 0;
-  font-size: 20px;
-  color: rgba(255, 255, 255, 0.5);
+.mm-nameplate__panel::before {
+  content: '';
+  position: absolute;
+  inset: 12px 12px auto 12px;
+  height: 12px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0));
+  filter: blur(0.4px);
+}
+
+.mm-nameplate__panel::after {
+  content: '';
+  position: absolute;
+  right: 16px;
+  bottom: 12px;
+  width: 42px;
+  height: 42px;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.45), transparent 60%);
+  opacity: 0.6;
+}
+
+.mm-nameplate__name {
+  font-family: inherit;
+  font-weight: 700;
+  font-size: clamp(20px, 5vw, 34px);
+  line-height: 1.05;
+  color: #e7fcff;
+  letter-spacing: 0.4px;
+  text-shadow:
+    0 3px 6px rgba(0, 13, 32, 0.5),
+    0 0 16px rgba(155, 241, 255, 0.45);
+}
+
+.mm-nameplate__level {
+  margin-top: 6px;
+  display: inline-block;
+  padding: 4px 14px;
+  border-radius: 999px;
+  font: inherit;
+  font-weight: 700;
+  font-size: clamp(12px, 3.4vw, 18px);
+  letter-spacing: 0.3px;
+  color: #042f5c;
+  background:
+    linear-gradient(90deg, rgba(155, 241, 255, 0.7), rgba(67, 210, 255, 0.35));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.6),
+    inset 0 -1px 0 rgba(0, 42, 80, 0.35),
+    0 4px 10px rgba(5, 49, 90, 0.35);
+}
+
+@media (max-width: 480px) {
+  .mm-nameplate {
+    padding: 6px;
+    border-radius: 20px;
+  }
+
+  .mm-nameplate__panel {
+    padding: 14px 22px 12px;
+    border-radius: 14px;
+  }
 }
 
 .home__hero-sprite {

--- a/html/home.html
+++ b/html/home.html
@@ -20,11 +20,11 @@
     <main class="home app-safe-area">
       <section class="home__content" aria-live="polite">
         <div class="home__identity">
-          <div class="home__identity-statbox">
-            <h1 class="home__title">Shellfin</h1>
-            <p class="home__level text-small text-white">
-              Level <span data-hero-level>2</span>
-            </p>
+          <div class="mm-nameplate">
+            <div class="mm-nameplate__panel">
+              <div class="mm-nameplate__name">Shellfin</div>
+              <div class="mm-nameplate__level" data-hero-level>Level 2</div>
+            </div>
           </div>
         </div>
         <img

--- a/index.html
+++ b/index.html
@@ -123,11 +123,11 @@
     >
       <section class="home__content" aria-live="polite">
         <div class="home__identity">
-          <div class="home__identity-statbox">
-            <h1 class="home__title" data-hero-name>Shellfin</h1>
-            <p class="home__level text-small text-white" data-hero-level>
-              Level 2
-            </p>
+          <div class="mm-nameplate">
+            <div class="mm-nameplate__panel">
+              <div class="mm-nameplate__name" data-hero-name>Shellfin</div>
+              <div class="mm-nameplate__level" data-hero-level>Level 2</div>
+            </div>
           </div>
         </div>
         <img


### PR DESCRIPTION
## Summary
- restyle the level 2+ nameplate to use layered ocean gradients and glassy highlights
- remove the external Fredoka font and rely on the existing rounded system typography

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e336c55fa08329a3fb242134ef068a