### PR TITLE
Hide early medal and restore battle completion stats

### DIFF
--- a/html/battle.html
+++ b/html/battle.html
@@ -101,9 +101,7 @@
               alt=""
               aria-hidden="true"
             />
-            <p class="meter__heading text-small text-dark" data-meter-heading>
-              Super Attack
-            </p>
+            <p class="meter__heading text-small text-dark" data-meter-heading></p>
             <div
               class="progress meter__progress"
               data-meter-progress
@@ -151,6 +149,16 @@
                 aria-hidden="true"
               />
             </div>
+          </div>
+        </div>
+        <div class="battle-stats">
+          <div class="battle-stat" data-goal="accuracy">
+            <p class="stat-label text-small text-dark">Accuracy</p>
+            <p class="stat-value summary-accuracy">100%</p>
+          </div>
+          <div class="battle-stat" data-goal="time">
+            <p class="stat-label text-small text-dark">Time</p>
+            <p class="stat-value summary-time">0s</p>
           </div>
         </div>
         <button type="button" class="btn-primary next-mission-btn" data-action="next">Claim Reward</button>

--- a/js/battle.js
+++ b/js/battle.js
@@ -480,7 +480,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     displayedMedals.add(LEVEL_ONE_FIRST_CORRECT_MEDAL_KEY);
-    showMedal();
+    hideMedal({ immediate: true });
   };
   let evolutionInProgress = false;
   let rewardCardDisplayTimeout = null;

--- a/js/question.js
+++ b/js/question.js
@@ -148,6 +148,10 @@ document.addEventListener('DOMContentLoaded', () => {
       meterProgress.setAttribute('aria-valuetext', '0 of 0');
     }
 
+    if (meterHeading) {
+      meterHeading.textContent = '';
+    }
+
     if (meterFill) {
       resetMeterAnimation();
       meterFill.style.transition = '';
@@ -434,7 +438,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   document.addEventListener('question-opened', (event) => {
     const levelDetail = Number(event?.detail?.battleLevel);
-    isMeterDisabled = Number.isFinite(levelDetail) && levelDetail === 1;
+    isMeterDisabled = !Number.isFinite(levelDetail) || levelDetail < 5;
     syncMeterDisabledAttribute();
     button.classList.remove('result', 'correct', 'incorrect');
     button.textContent = 'Submit';


### PR DESCRIPTION
## Summary
- keep the first-correct medal hidden while we revisit the feature later
- restore the accuracy and time statistics to the battle completion card
- gate the Super Attack meter so it only appears from level 5 onward

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e33b68f0a88329912914ba85e176c5