### PR TITLE
Refactor addition levels into multi-battle structure

### DIFF
--- a/data/levels.json
+++ b/data/levels.json
@@ -1,217 +1,263 @@
 {
   "mathTypes": {
     "addition": {
-      "totalLevels": 5,
+      "totalLevels": 6,
+      "totalBattles": 21,
+      "defaultStats": {
+        "attack": 1,
+        "health": 3,
+        "damage": 0
+      },
+      "rewards": {
+        "win": {
+          "gems": 5
+        },
+        "loss": {
+          "gems": 1
+        }
+      },
+      "monsterSprites": {
+        "standardPool": [
+          "/mathmonsters/images/monster/addition_mini_1.png",
+          "/mathmonsters/images/monster/addition_mini_2.png",
+          "/mathmonsters/images/monster/addition_mini_3.png",
+          "/mathmonsters/images/monster/addition_mini_4.png",
+          "/mathmonsters/images/monster/addition_mini_5.png"
+        ],
+        "uniquePerLevel": true,
+        "bossTemplate": "/mathmonsters/images/monster/addition_boss_{level}.png"
+      },
       "levels": [
         {
           "level": 1,
           "name": "Level 1 Questions",
-          "battle": {
-            "questions": {
-              "path": "questions/level_1_questions.json"
-            },
-            "levelUp": 1,
-            "hero": {
-              "id": "shellfin",
-              "name": "Shellfin",
-              "sprite": "/mathmonsters/images/hero/shellfin_evolution_1.png",
-              "attack": 1,
-              "health": 3,
-              "damage": 0,
-              "attackSprite": "/mathmonsters/images/hero/shellfin_attack_1.png"
-            },
-            "monster": {
-              "id": "octomurk",
-              "name": "Octomurk",
-              "sprite": "/mathmonsters/images/monster/addition_battle_1.png",
-              "attack": 1,
-              "health": 3,
-              "damage": 0,
-              "experiencePoints": 1,
-              "attackSprite": "/mathmonsters/images/monster/monster_attack.png"
-            },
-            "winReward": {
-              "gems": 5
-            },
-            "loseReward": {
-              "gems": 1
+          "levelUpRequirement": "completeAllBattles",
+          "battles": [
+            {
+              "type": "standard",
+              "questions": {
+                "path": "questions/level_1_questions.json"
+              },
+              "monster": {
+                "spritePool": "standardPool"
+              }
             }
-          }
+          ]
         },
         {
           "level": 2,
           "name": "Level 2 Questions",
-          "battle": {
-            "questions": {
-              "path": "questions/level_2_questions.json"
+          "levelUpRequirement": "completeAllBattles",
+          "battles": [
+            {
+              "type": "standard",
+              "questions": {
+                "path": "questions/level_2_questions.json"
+              },
+              "monster": {
+                "spritePool": "standardPool"
+              }
             },
-            "levelUp": 2,
-            "hero": {
-              "id": "shellfin",
-              "name": "Shellfin",
-              "sprite": "/mathmonsters/images/hero/shellfin_evolution_2.png",
-              "attack": 1,
-              "health": 3,
-              "damage": 0,
-              "attackSprite": "/mathmonsters/images/hero/shellfin_attack_2.png"
+            {
+              "type": "standard",
+              "questions": {
+                "path": "questions/level_2_questions.json"
+              },
+              "monster": {
+                "spritePool": "standardPool"
+              }
             },
-            "monster": {
-              "id": "ripjaw",
-              "name": "Ripjaw",
-              "sprite": "/mathmonsters/images/monster/addition_battle_2.png",
-              "attack": 1,
-              "health": 3,
-              "damage": 0,
-              "experiencePoints": 1,
-              "attackSprite": "/mathmonsters/images/monster/monster_attack.png"
+            {
+              "type": "standard",
+              "questions": {
+                "path": "questions/level_2_questions.json"
+              },
+              "monster": {
+                "spritePool": "standardPool"
+              }
             },
-            "winReward": {
-              "gems": 5
-            },
-            "loseReward": {
-              "gems": 1
+            {
+              "type": "boss",
+              "questions": {
+                "path": "questions/level_2_questions.json"
+              },
+              "monster": {
+                "sprite": "/mathmonsters/images/monster/addition_boss_2.png"
+              }
             }
-          }
+          ]
         },
         {
           "level": 3,
           "name": "Level 3 Questions",
-          "battle": {
-            "questions": {
-              "path": "questions/level_3_questions.json"
+          "levelUpRequirement": "completeAllBattles",
+          "battles": [
+            {
+              "type": "standard",
+              "questions": {
+                "path": "questions/level_3_questions.json"
+              },
+              "monster": {
+                "spritePool": "standardPool"
+              }
             },
-            "levelUp": 3,
-            "hero": {
-              "id": "shellfin",
-              "name": "Shellfin",
-              "sprite": "/mathmonsters/images/hero/shellfin_evolution_2.png",
-              "attack": 1,
-              "health": 3,
-              "damage": 0,
-              "attackSprite": "/mathmonsters/images/hero/shellfin_attack_2.png"
+            {
+              "type": "standard",
+              "questions": {
+                "path": "questions/level_3_questions.json"
+              },
+              "monster": {
+                "spritePool": "standardPool"
+              }
             },
-            "monster": {
-              "id": "ripjaw",
-              "name": "Ripjaw",
-              "sprite": "/mathmonsters/images/monster/addition_battle_2.png",
-              "attack": 1,
-              "health": 3,
-              "damage": 0,
-              "experiencePoints": 1,
-              "attackSprite": "/mathmonsters/images/monster/monster_attack.png"
+            {
+              "type": "standard",
+              "questions": {
+                "path": "questions/level_3_questions.json"
+              },
+              "monster": {
+                "spritePool": "standardPool"
+              }
             },
-            "winReward": {
-              "gems": 5
-            },
-            "loseReward": {
-              "gems": 1
+            {
+              "type": "boss",
+              "questions": {
+                "path": "questions/level_3_questions.json"
+              },
+              "monster": {
+                "sprite": "/mathmonsters/images/monster/addition_boss_3.png"
+              }
             }
-          }
+          ]
         },
         {
           "level": 4,
           "name": "Level 4 Questions",
-          "battle": {
-            "questions": {
-              "path": "questions/level_4_questions.json"
+          "levelUpRequirement": "completeAllBattles",
+          "battles": [
+            {
+              "type": "standard",
+              "questions": {
+                "path": "questions/level_4_questions.json"
+              },
+              "monster": {
+                "spritePool": "standardPool"
+              }
             },
-            "levelUp": 4,
-            "hero": {
-              "id": "shellfin",
-              "name": "Shellfin",
-              "sprite": "/mathmonsters/images/hero/shellfin_evolution_2.png",
-              "attack": 1,
-              "health": 3,
-              "damage": 0,
-              "attackSprite": "/mathmonsters/images/hero/shellfin_attack_2.png"
+            {
+              "type": "standard",
+              "questions": {
+                "path": "questions/level_4_questions.json"
+              },
+              "monster": {
+                "spritePool": "standardPool"
+              }
             },
-            "monster": {
-              "id": "ripjaw",
-              "name": "Ripjaw",
-              "sprite": "/mathmonsters/images/monster/addition_battle_2.png",
-              "attack": 1,
-              "health": 3,
-              "damage": 0,
-              "experiencePoints": 1,
-              "attackSprite": "/mathmonsters/images/monster/monster_attack.png"
+            {
+              "type": "standard",
+              "questions": {
+                "path": "questions/level_4_questions.json"
+              },
+              "monster": {
+                "spritePool": "standardPool"
+              }
             },
-            "winReward": {
-              "gems": 5
-            },
-            "loseReward": {
-              "gems": 1
+            {
+              "type": "boss",
+              "questions": {
+                "path": "questions/level_4_questions.json"
+              },
+              "monster": {
+                "sprite": "/mathmonsters/images/monster/addition_boss_4.png"
+              }
             }
-          }
+          ]
         },
         {
           "level": 5,
           "name": "Level 5 Questions",
-          "battle": {
-            "questions": {
-              "path": "questions/level_5_questions.json"
+          "levelUpRequirement": "completeAllBattles",
+          "battles": [
+            {
+              "type": "standard",
+              "questions": {
+                "path": "questions/level_5_questions.json"
+              },
+              "monster": {
+                "spritePool": "standardPool"
+              }
             },
-            "levelUp": 5,
-            "hero": {
-              "id": "shellfin",
-              "name": "Shellfin",
-              "sprite": "/mathmonsters/images/hero/shellfin_evolution_2.png",
-              "attack": 1,
-              "health": 6,
-              "damage": 0,
-              "attackSprite": "/mathmonsters/images/hero/shellfin_attack_2.png"
+            {
+              "type": "standard",
+              "questions": {
+                "path": "questions/level_5_questions.json"
+              },
+              "monster": {
+                "spritePool": "standardPool"
+              }
             },
-            "monster": {
-              "id": "ripjaw",
-              "name": "Ripjaw",
-              "sprite": "/mathmonsters/images/monster/addition_battle_2.png",
-              "attack": 1,
-              "health": 6,
-              "damage": 0,
-              "experiencePoints": 1,
-              "attackSprite": "/mathmonsters/images/monster/monster_attack.png"
+            {
+              "type": "standard",
+              "questions": {
+                "path": "questions/level_5_questions.json"
+              },
+              "monster": {
+                "spritePool": "standardPool"
+              }
             },
-            "winReward": {
-              "gems": 5
-            },
-            "loseReward": {
-              "gems": 1
+            {
+              "type": "boss",
+              "questions": {
+                "path": "questions/level_5_questions.json"
+              },
+              "monster": {
+                "sprite": "/mathmonsters/images/monster/addition_boss_5.png"
+              }
             }
-          }
+          ]
         },
         {
           "level": 6,
           "name": "Level 6 Questions",
-          "battle": {
-            "questions": {
-              "path": "questions/level_6_questions.json"
+          "levelUpRequirement": "completeAllBattles",
+          "battles": [
+            {
+              "type": "standard",
+              "questions": {
+                "path": "questions/level_6_questions.json"
+              },
+              "monster": {
+                "spritePool": "standardPool"
+              }
             },
-            "levelUp": 6,
-            "hero": {
-              "id": "shellfin",
-              "name": "Shellfin",
-              "sprite": "/mathmonsters/images/hero/shellfin_evolution_2.png",
-              "attack": 1,
-              "health": 6,
-              "damage": 0,
-              "attackSprite": "/mathmonsters/images/hero/shellfin_attack_2.png"
+            {
+              "type": "standard",
+              "questions": {
+                "path": "questions/level_6_questions.json"
+              },
+              "monster": {
+                "spritePool": "standardPool"
+              }
             },
-            "monster": {
-              "id": "ripjaw",
-              "name": "Ripjaw",
-              "sprite": "/mathmonsters/images/monster/addition_battle_2.png",
-              "attack": 1,
-              "health": 6,
-              "damage": 0,
-              "experiencePoints": 1,
-              "attackSprite": "/mathmonsters/images/monster/monster_attack.png"
+            {
+              "type": "standard",
+              "questions": {
+                "path": "questions/level_6_questions.json"
+              },
+              "monster": {
+                "spritePool": "standardPool"
+              }
             },
-            "winReward": {
-              "gems": 5
-            },
-            "loseReward": {
-              "gems": 1
+            {
+              "type": "boss",
+              "questions": {
+                "path": "questions/level_6_questions.json"
+              },
+              "monster": {
+                "sprite": "/mathmonsters/images/monster/addition_boss_6.png"
+              }
             }
-          }
+          ]
         }
       ]
     }


### PR DESCRIPTION
## Summary
- restructure addition level data to support three standard battles and a boss per level
- centralize shared stats, rewards, and sprite pools while removing hero battle configuration
- add explicit boss references and maintain existing question sets for each battle

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e48749c5c48329906f4fe148802b56