### PR TITLE
Update monster defeated stats colors and remove icons

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -529,7 +529,7 @@ button:focus-visible {
 
 .card .stat-label {
   font-size: 18px;
-  color: #888888;
+  color: #272b34;
 }
 
 .card .stat-value {
@@ -541,12 +541,9 @@ button:focus-visible {
   color: #006aff;
 }
 
-.card .stat-value.goal-result--met {
-  color: #00b600;
-}
-
+.card .stat-value.goal-result--met,
 .card .stat-value.goal-result--missed {
-  color: #e20000;
+  color: #006aff;
 }
 
 .card .stat-value .goal-result-icon {

--- a/js/battle.js
+++ b/js/battle.js
@@ -2008,16 +2008,10 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
     textSpan.textContent = text;
-    let icon = valueEl.querySelector('.goal-result-icon');
-    if (!icon) {
-      icon = document.createElement('img');
-      icon.classList.add('goal-result-icon');
-      valueEl.insertBefore(icon, textSpan);
+    const icon = valueEl.querySelector('.goal-result-icon');
+    if (icon) {
+      icon.remove();
     }
-    icon.src = met
-      ? '/mathmonsters/images/complete/correct.svg'
-      : '/mathmonsters/images/complete/incorrect.svg';
-    icon.alt = met ? 'Goal met' : 'Goal not met';
     valueEl.classList.remove('goal-result--met', 'goal-result--missed');
     valueEl.classList.add(met ? 'goal-result--met' : 'goal-result--missed');
   }


### PR DESCRIPTION
## Summary
- remove the goal result icons from the monster defeated accuracy and time stats
- ensure the accuracy/time values stay #006AFF and their labels use #272B34

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e48858033c8329aa37603d04a79345