### PR TITLE
Fix post-battle monster placeholder image

### DIFF
--- a/html/battle.html
+++ b/html/battle.html
@@ -43,7 +43,7 @@
     />
   </section>
   <div id="battle">
-    <img id="battle-monster" src="../images/monster/addition_battle_1.png" alt="Monster" />
+    <img id="battle-monster" src="../images/monster/addition_mini_1.png" alt="Monster" />
     <img
       id="battle-shellfin"
       src="../images/hero/shellfin_evolution_1.png"
@@ -140,7 +140,7 @@
           <div class="battle-complete-card__sprite-frame">
             <img
               class="monster-image battle-complete-card__monster"
-              src="../images/monster/addition_battle_1.png"
+              src="../images/monster/addition_mini_1.png"
               alt="Monster ready for battle"
             />
             <div


### PR DESCRIPTION
## Summary
- point the battle view monster placeholder to the existing addition_mini_1 asset
- ensure the post-battle card also uses the correct default monster sprite

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e48d73f84483299bf2de0c9e97ef29