### PR TITLE
Fix player data extraction for hero and monster names

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -934,22 +934,38 @@ const sanitizeAssetPath = (path) => {
   return trimmed;
 };
 
+const extractPlayerData = (rawPlayerData) => {
+  if (!rawPlayerData || typeof rawPlayerData !== 'object') {
+    return {};
+  }
+
+  if (
+    typeof rawPlayerData.player === 'object' &&
+    rawPlayerData.player !== null &&
+    !Array.isArray(rawPlayerData.player)
+  ) {
+    return rawPlayerData.player;
+  }
+
+  return rawPlayerData;
+};
+
 const mergePlayerWithProgress = (rawPlayerData) => {
+  const sourceData = extractPlayerData(rawPlayerData);
+
   const player =
-    rawPlayerData && typeof rawPlayerData === 'object'
-      ? { ...rawPlayerData }
-      : {};
+    sourceData && typeof sourceData === 'object' ? { ...sourceData } : {};
 
   const storedProgress = readStoredProgress();
 
   const baseProgress =
-    rawPlayerData && typeof rawPlayerData.progress === 'object'
-      ? rawPlayerData.progress
+    sourceData && typeof sourceData.progress === 'object'
+      ? sourceData.progress
       : {};
   const mergedProgress = { ...baseProgress };
   const baseBattleVariables =
-    rawPlayerData && typeof rawPlayerData.battleVariables === 'object'
-      ? rawPlayerData.battleVariables
+    sourceData && typeof sourceData.battleVariables === 'object'
+      ? sourceData.battleVariables
       : {};
 
   const existingExperience = normalizeExperienceMap(player?.progress?.experience);

--- a/js/loader.js
+++ b/js/loader.js
@@ -110,6 +110,22 @@ if (!progressUtils) {
 
 const { isPlainObject, normalizeExperienceMap, mergeExperienceMaps } = progressUtils;
 
+const extractPlayerData = (rawPlayerData) => {
+  if (!rawPlayerData || typeof rawPlayerData !== 'object') {
+    return {};
+  }
+
+  if (
+    typeof rawPlayerData.player === 'object' &&
+    rawPlayerData.player !== null &&
+    !Array.isArray(rawPlayerData.player)
+  ) {
+    return rawPlayerData.player;
+  }
+
+  return rawPlayerData;
+};
+
 const playerProfileUtils =
   (typeof globalThis !== 'undefined' && globalThis.mathMonstersPlayerProfile) ||
   (typeof window !== 'undefined' ? window.mathMonstersPlayerProfile : null);
@@ -526,8 +542,10 @@ const syncRemoteBattleLevel = (playerData) => {
       levelsRes.json(),
     ]);
 
-    let basePlayer =
+    const localPlayerData =
       playerJson && typeof playerJson === 'object' ? playerJson : {};
+
+    let basePlayer = extractPlayerData(localPlayerData);
 
     try {
       const remotePlayerData = await fetchPlayerProfile();

--- a/js/register.js
+++ b/js/register.js
@@ -20,6 +20,19 @@ const clonePlainObject = (value) => {
   }
 };
 
+const extractPlayerData = (rawPlayerData) => {
+  if (!isPlainObject(rawPlayerData)) {
+    return null;
+  }
+
+  const nestedPlayer = rawPlayerData.player;
+  if (isPlainObject(nestedPlayer)) {
+    return nestedPlayer;
+  }
+
+  return rawPlayerData;
+};
+
 const applyStartingBattleLevel = (playerData) => {
   const clonedData = clonePlainObject(playerData) ?? {};
 
@@ -109,7 +122,8 @@ const loadDefaultPlayerData = async () => {
     }
 
     const data = await response.json();
-    return clonePlainObject(data);
+    const extracted = extractPlayerData(data);
+    return clonePlainObject(extracted ?? {});
   } catch (error) {
     console.warn('Unable to load default player data for the new account.', error);
     return null;


### PR DESCRIPTION
## Summary
- unwrap nested player.json data so hero metadata merges correctly when preloading content
- update loader and landing flow to rely on the normalized player object for hero and monster assets
- normalize default player data used during registration to the same flattened shape

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e491e8907483298a3eeda60959eed0