### PR TITLE
Reuse existing gem icon asset

### DIFF
--- a/css/home.css
+++ b/css/home.css
@@ -4,9 +4,9 @@ body.home-page {
 }
 
 .home {
-  --app-safe-area-padding: clamp(16px, 4vw, 28px);
+  --app-safe-area-padding: 24px;
 
-  width: min(100%, 420px);
+  width: min(100%, 440px);
   min-width: min(100%, 320px);
   margin: 0 auto;
   height: 100%;
@@ -16,88 +16,8 @@ body.home-page {
   flex-direction: column;
   align-items: stretch;
   justify-content: flex-start;
-  gap: clamp(12px, 3vh, 24px);
   color: inherit;
   box-sizing: border-box;
-}
-
-.home__bar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-sm);
-  width: 100%;
-  flex-shrink: 0;
-}
-
-.home__bar--bottom {
-  margin-top: auto;
-}
-
-.home__bar-item {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 100px;
-  height: 100px;
-  padding: 0;
-  background: none;
-  border: none;
-  box-shadow: none;
-  border-radius: 0;
-}
-
-.home__bar-item--action {
-  cursor: pointer;
-}
-
-.home__bar-item--status {
-  pointer-events: none;
-}
-
-.home__bar-item img {
-  display: block;
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
-}
-
-.home__status-gems {
-  position: relative;
-  display: inline-flex;
-}
-
-.home__status-coin {
-  position: absolute;
-  bottom: -16px;
-  left: -16px;
-  width: 64px;
-  height: 64px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.home__status-coin img {
-  width: 100%;
-  height: 100%;
-}
-
-.home__status-coin-count {
-  position: absolute;
-  inset: -4px 0 0 -4px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: var(--text-size-small);
-  font-weight: 400;
-  color: #000000;
-}
-
-.home__bar-item[aria-disabled='true'] {
-  pointer-events: none;
-  cursor: default;
-  opacity: 0.6;
 }
 
 .home__content {
@@ -105,11 +25,53 @@ body.home-page {
   min-height: 0;
   display: flex;
   flex-direction: column;
+  align-items: stretch;
+  gap: clamp(24px, 5vh, 36px);
+}
+
+.home__top {
+  display: flex;
   align-items: center;
-  justify-content: center;
-  gap: clamp(12px, 4vh, 24px);
-  text-align: center;
-  padding-block: clamp(8px, 3vh, 16px);
+  justify-content: flex-start;
+}
+
+.home__gem-box {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 18px;
+  border-radius: 18px;
+  background-color: rgba(0, 0, 0, 0.16);
+  backdrop-filter: blur(4px);
+  color: #ffffff;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+}
+
+.home__gem-icon {
+  width: 40px;
+  height: 40px;
+  object-fit: contain;
+}
+
+.home__gem-text {
+  margin: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  font-size: clamp(16px, 3.6vw, 20px);
+}
+
+.home__gem-value {
+  font-size: clamp(20px, 4.2vw, 24px);
+  font-weight: 700;
+}
+
+.home__gem-label {
+  opacity: 0.7;
+  text-transform: uppercase;
+  letter-spacing: 1.2px;
+  font-size: clamp(12px, 3vw, 14px);
 }
 
 .home__identity {
@@ -117,109 +79,85 @@ body.home-page {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-}
-
-.home__stat-box {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 8px;
-  width: min(100%, 320px);
-  padding: 20px 28px;
-  border-radius: 16px;
-  border: 1.5px solid rgba(255, 255, 255, 0.55);
-  background:
-    linear-gradient(140deg, rgba(11, 61, 110, 0.78), rgba(4, 29, 68, 0.74));
-  box-shadow:
-    0 20px 36px rgba(1, 12, 32, 0.4),
-    inset 0 1px 0 rgba(255, 255, 255, 0.28),
-    inset 0 -1px 0 rgba(2, 19, 43, 0.55);
-  backdrop-filter: blur(6px);
+  gap: clamp(12px, 3vh, 20px);
   text-align: center;
 }
 
-.home__stat-box::after {
-  content: '';
-  position: absolute;
-  inset: 12px 18px auto 18px;
-  height: 10px;
-  border-radius: 999px;
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
-  opacity: 0.8;
-}
-
-.home__stat-box .name {
+.home__hero-name {
   margin: 0;
   font-weight: 700;
-  font-size: clamp(22px, 5vw, 34px);
-  line-height: 1.1;
-  letter-spacing: 0.4px;
+  font-size: clamp(40px, 8vw, 48px);
+  line-height: 1.05;
+  letter-spacing: 0.6px;
   color: #ffffff;
-  text-shadow:
-    0 3px 12px rgba(0, 12, 30, 0.55),
-    0 0 16px rgba(122, 210, 255, 0.4);
 }
 
-.home__stat-box-level {
+.home__hero-level {
   margin: 0;
-  padding: 4px 16px;
-  border-radius: 999px;
-  display: inline-block;
-  font-weight: 600;
-  font-size: clamp(13px, 3.6vw, 18px);
-  letter-spacing: 0.35px;
-  color: rgba(8, 209, 255, 0.9);
-  background: rgba(255, 255, 255, 0.18);
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.35),
-    inset 0 -1px 0 rgba(0, 22, 46, 0.4);
+  font-size: clamp(18px, 4vw, 20px);
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.5);
 }
 
-@media (max-width: 480px) {
-  .home__stat-box {
-    padding: 18px 22px;
-    border-radius: 14px;
-  }
+.home__progress {
+  --progress-gradient-start: #2bf542;
+  --progress-gradient-end: #0ea631;
 
-  .home__stat-box::after {
-    inset: 10px 16px auto 16px;
-  }
+  width: 160px;
+  max-width: 100%;
+  margin: 0 auto;
+  background-color: rgba(255, 255, 255, 0.15);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.15);
+}
+
+.home__progress-fill::after {
+  inset: 2px 6px 0px 6px;
+  height: 6px;
 }
 
 .home__hero-sprite {
-  width: 300px;
-  height: 300px;
+  width: min(100%, 320px);
+  height: auto;
+  max-height: 320px;
   object-fit: contain;
+  margin: 0 auto;
   animation: hero-swim 4.5s ease-in-out 0.6s infinite;
   will-change: transform;
   pointer-events: none;
 }
 
-.home__sword {
-  width: 160px;
-  height: 160px;
+.home__actions {
+  margin-top: auto;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.home__action {
+  display: inline-flex;
+}
+
+.home__action-image {
+  display: block;
+  width: 120px;
+  height: 120px;
   object-fit: contain;
-  pointer-events: none;
-}
-
-.home__sword[data-battle-trigger] {
-  pointer-events: auto;
-  cursor: pointer;
-}
-
-.home__sword[data-battle-trigger][aria-disabled='true'],
-.home__sword[data-battle-trigger][aria-busy='true'] {
-  cursor: default;
 }
 
 @media (min-width: 768px) {
   .home {
-    --app-safe-area-padding: var(--space-lg);
+    --app-safe-area-padding: 32px;
   }
 
   .home__content {
-    gap: clamp(20px, 5vh, 36px);
+    gap: clamp(28px, 6vh, 42px);
+  }
+
+  .home__action-image {
+    width: 140px;
+    height: 140px;
   }
 }
 

--- a/html/home.html
+++ b/html/home.html
@@ -19,23 +19,65 @@
   <body class="home-page">
     <main class="home app-safe-area">
       <section class="home__content" aria-live="polite">
-        <div class="home__identity">
-          <div class="stat-box home__stat-box">
-            <p class="name" data-hero-name>Shellfin</p>
-            <p class="home__stat-box-level" data-hero-level>Level 2</p>
+        <div class="home__top">
+          <div class="home__gem-box" aria-live="polite">
+            <img
+              class="home__gem-icon"
+              src="../images/complete/gem.png"
+              alt=""
+              aria-hidden="true"
+            />
+            <p class="home__gem-text">
+              <span class="home__gem-value" data-hero-gems>0</span>
+              <span class="home__gem-label">Gems</span>
+            </p>
           </div>
         </div>
+
+        <div class="home__identity">
+          <p class="home__hero-name" data-hero-name>Shellfin</p>
+          <p class="home__hero-level" data-hero-level>Level 2</p>
+          <div
+            class="progress home__progress"
+            role="progressbar"
+            aria-label="Level progress"
+            aria-valuemin="0"
+            aria-valuemax="4"
+            aria-valuenow="0"
+            data-battle-progress
+          >
+            <div class="progress__fill home__progress-fill" aria-hidden="true"></div>
+          </div>
+        </div>
+
         <img
           class="home__hero-sprite"
           src="../images/hero/shellfin_evolution_2.png"
           alt="Shellfin ready for the next adventure"
+          data-hero-sprite
         />
-        <img
-          class="home__sword"
-          src="../images/home/sword.png"
-          alt="Forged sword unlocked for the next quest"
-          data-battle-trigger
-        />
+
+        <div class="home__actions">
+          <a
+            class="home__action"
+            href="./battle.html"
+            data-battle-trigger
+            aria-label="Start next battle"
+          >
+            <img
+              class="home__action-image"
+              src="../images/home/sword.png"
+              alt="Forged sword unlocked for the next quest"
+            />
+          </a>
+          <a class="home__action" href="#" aria-label="Visit the shop">
+            <img
+              class="home__action-image"
+              src="../images/home/shop.png"
+              alt="Shop"
+            />
+          </a>
+        </div>
       </section>
     </main>
     <script>

--- a/index.html
+++ b/index.html
@@ -122,10 +122,33 @@
       aria-live="polite"
     >
       <section class="home__content" aria-live="polite">
+        <div class="home__top">
+          <div class="home__gem-box" aria-live="polite">
+            <img
+              class="home__gem-icon"
+              src="./images/complete/gem.png"
+              alt=""
+              aria-hidden="true"
+            />
+            <p class="home__gem-text">
+              <span class="home__gem-value" data-hero-gems>0</span>
+              <span class="home__gem-label">Gems</span>
+            </p>
+          </div>
+        </div>
         <div class="home__identity">
-          <div class="stat-box home__stat-box">
-            <p class="name" data-hero-name>Shellfin</p>
-            <p class="home__stat-box-level" data-hero-level>Level 2</p>
+          <p class="home__hero-name" data-hero-name>Shellfin</p>
+          <p class="home__hero-level" data-hero-level>Level 2</p>
+          <div
+            class="progress home__progress"
+            role="progressbar"
+            aria-label="Level progress"
+            aria-valuemin="0"
+            aria-valuemax="4"
+            aria-valuenow="0"
+            data-battle-progress
+          >
+            <div class="progress__fill home__progress-fill" aria-hidden="true"></div>
           </div>
         </div>
         <img
@@ -134,12 +157,27 @@
           alt="Shellfin ready for the next adventure"
           data-hero-sprite
         />
-        <img
-          class="home__sword"
-          src="./images/home/sword.png"
-          alt="Forged sword unlocked for the next quest"
-          data-battle-trigger
-        />
+        <div class="home__actions">
+          <a
+            class="home__action"
+            href="./html/battle.html"
+            data-battle-trigger
+            aria-label="Start next battle"
+          >
+            <img
+              class="home__action-image"
+              src="./images/home/sword.png"
+              alt="Forged sword unlocked for the next quest"
+            />
+          </a>
+          <a class="home__action" href="#" aria-label="Visit the shop">
+            <img
+              class="home__action-image"
+              src="./images/home/shop.png"
+              alt="Shop"
+            />
+          </a>
+        </div>
       </section>
     </div>
 

--- a/js/index.js
+++ b/js/index.js
@@ -998,6 +998,30 @@ const mergePlayerWithProgress = (rawPlayerData) => {
   return player;
 };
 
+const readPlayerGemCount = (player) => {
+  if (!player || typeof player !== 'object') {
+    return 0;
+  }
+
+  const candidateValues = [
+    player.gems,
+    player?.currency?.gems,
+    player?.currencies?.gems,
+    player?.wallet?.gems,
+    player?.inventory?.gems,
+    player?.progress?.gems,
+  ];
+
+  for (const value of candidateValues) {
+    const numericValue = Number(value);
+    if (Number.isFinite(numericValue)) {
+      return Math.max(0, Math.round(numericValue));
+    }
+  }
+
+  return 0;
+};
+
 const normalizeBattleLevel = (value) => {
   if (typeof value === 'number') {
     return Number.isFinite(value) ? value : null;
@@ -1390,6 +1414,7 @@ const determineBattlePreview = (levelsData, playerData) => {
     levelUpRequirement
   );
   const progressText = experienceProgress.text;
+  const playerGems = readPlayerGemCount(player);
 
   return {
     levels,
@@ -1408,6 +1433,7 @@ const determineBattlePreview = (levelsData, playerData) => {
       progressExperienceEarned: experienceProgress.earned,
       progressExperienceTotal: experienceProgress.total,
       progressExperienceText: progressText,
+      playerGems,
     },
   };
 };
@@ -1420,6 +1446,7 @@ const applyBattlePreview = (previewData = {}, levels = []) => {
   const progressElement = document.querySelector('[data-battle-progress]');
   const heroNameElements = document.querySelectorAll('[data-hero-name]');
   const heroLevelElements = document.querySelectorAll('[data-hero-level]');
+  const gemCountElements = document.querySelectorAll('[data-hero-gems]');
   const heroInfoElement = document.querySelector('.landing__hero-info');
   const actionsElement = document.querySelector('.landing__actions');
   const landingRoot = document.body;
@@ -1510,30 +1537,58 @@ const applyBattlePreview = (previewData = {}, levels = []) => {
     element.textContent = resolvedLevelLabel;
   });
 
+  const resolvedGemCount = (() => {
+    const fromPreview = Number(previewData?.playerGems);
+    if (Number.isFinite(fromPreview)) {
+      return Math.max(0, Math.round(fromPreview));
+    }
+    const fromHero = Number(previewData?.hero?.gems);
+    if (Number.isFinite(fromHero)) {
+      return Math.max(0, Math.round(fromHero));
+    }
+    return 0;
+  })();
+
+  gemCountElements.forEach((element) => {
+    if (!element) {
+      return;
+    }
+    element.textContent = `${resolvedGemCount}`;
+  });
+
   if (progressElement) {
     const progressValue = Number.isFinite(previewData?.progressExperience)
       ? Math.min(Math.max(previewData.progressExperience, 0), 1)
       : 0;
-    const progressText =
+    const progressTextRaw =
       typeof previewData?.progressExperienceText === 'string' &&
       previewData.progressExperienceText.trim()
         ? previewData.progressExperienceText.trim()
         : '0 of 0';
+    const normalizedProgressText =
+      typeof progressTextRaw === 'string' ? progressTextRaw.trim() : '';
     const earnedCount = Number(previewData?.progressExperienceEarned);
     const totalCount = Number(previewData?.progressExperienceTotal);
     progressElement.style.setProperty('--progress-value', progressValue);
     progressElement.setAttribute('aria-valuemin', '0');
+    let resolvedProgressLabel = '';
+
     if (Number.isFinite(earnedCount) && Number.isFinite(totalCount) && totalCount > 0) {
-      const clampedEarned = Math.max(0, Math.min(earnedCount, totalCount));
-      progressElement.setAttribute('aria-valuemax', `${Math.round(totalCount)}`);
-      progressElement.setAttribute('aria-valuenow', `${Math.round(clampedEarned)}`);
+      const roundedTotal = Math.max(0, Math.round(totalCount));
+      const clampedEarned = Math.max(0, Math.min(Math.round(earnedCount), roundedTotal));
+      progressElement.setAttribute('aria-valuemax', `${roundedTotal}`);
+      progressElement.setAttribute('aria-valuenow', `${clampedEarned}`);
+      resolvedProgressLabel = `${clampedEarned} / ${roundedTotal} Battles Won`;
     } else {
       progressElement.setAttribute('aria-valuemax', '100');
       progressElement.setAttribute('aria-valuenow', `${Math.round(progressValue * 100)}`);
+      if (normalizedProgressText.includes(' of ')) {
+        resolvedProgressLabel = `${normalizedProgressText.replace(' of ', ' / ')} Battles Won`;
+      } else if (normalizedProgressText) {
+        resolvedProgressLabel = normalizedProgressText;
+      }
     }
-    const ariaText = progressText.includes(' of ')
-      ? `${progressText} experience`
-      : progressText;
+    const ariaText = resolvedProgressLabel || normalizedProgressText || 'Battles Won';
     progressElement.setAttribute('aria-valuetext', ariaText);
   }
 


### PR DESCRIPTION
## Summary
- point the home gem counter to the existing gem artwork instead of the new binary
- remove the added `images/home/gem.png` file from the repository to keep the PR binary-free

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e493b2531083299832e46ab07507ef