### PR TITLE
Add dev battle controls for hero, monster, and skipping

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -12,10 +12,8 @@ body {
   box-sizing: border-box;
 }
 
-.dev-damage-button {
+.dev-button {
   position: fixed;
-  top: 8px;
-  right: 8px;
   width: 56px;
   height: 56px;
   border: none;
@@ -26,10 +24,25 @@ body {
   z-index: 1000;
 }
 
-.dev-damage-button:focus-visible {
+.dev-button:focus-visible {
   opacity: 1;
   border-radius: 8px;
   outline: 2px dashed rgba(255, 255, 255, 0.6);
+}
+
+.dev-button--top-left {
+  top: 8px;
+  left: 8px;
+}
+
+.dev-button--top-right {
+  top: 8px;
+  right: 8px;
+}
+
+.dev-button--bottom-left {
+  bottom: 8px;
+  left: 8px;
 }
 
 :root {

--- a/html/battle.html
+++ b/html/battle.html
@@ -16,9 +16,21 @@
   <body>
     <button
       type="button"
-      id="dev-damage-button"
-      class="dev-damage-button"
-      aria-label="Deal 100 damage to the enemy"
+      id="dev-hero-damage-button"
+      class="dev-button dev-button--top-left"
+      aria-label="Deal 100 damage to the hero"
+    ></button>
+    <button
+      type="button"
+      id="dev-monster-damage-button"
+      class="dev-button dev-button--top-right"
+      aria-label="Deal 100 damage to the monster"
+    ></button>
+    <button
+      type="button"
+      id="dev-skip-battle-button"
+      class="dev-button dev-button--bottom-left"
+      aria-label="Skip to Battle 4 of the current level"
     ></button>
     <section
       class="card medal"


### PR DESCRIPTION
## Summary
- position the invisible developer controls in the top corners for quick hero and monster damage access
- keep the hero damage helper and add an equivalent monster damage helper
- add a bottom-left developer shortcut to skip to battle 4 of the current level

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e5690e1cc08329a2eae48504c03022