### PR TITLE
Ensure defeat reward flow matches design

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -495,7 +495,7 @@ body.is-post-evolution-active #complete-message {
   align-items: center;
   justify-content: center;
   gap: 32px;
-  background: url('../images/background/background.png') no-repeat center/cover;
+  background: rgba(0, 0, 0, 0.3);
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
@@ -523,7 +523,7 @@ body.is-reward-active .reward-overlay {
   inset: 0;
   display: grid;
   place-items: center;
-  background: url('../images/background/background.png') no-repeat center/cover;
+  background: rgba(0, 0, 0, 0.3);
   pointer-events: none;
   opacity: 0;
   visibility: hidden;
@@ -570,7 +570,7 @@ body.is-reward-active .reward-overlay {
   align-items: center;
   justify-content: center;
   padding: clamp(24px, 5vmin, 48px);
-  background: url('../images/background/background.png') no-repeat center/cover;
+  background: rgba(0, 0, 0, 0.3);
   backdrop-filter: none;
   opacity: 0;
   visibility: hidden;
@@ -644,10 +644,10 @@ body.is-reward-active .reward-overlay {
 
 .reward-overlay__image--chest-pulse {
   animation: reward-overlay-chest-pulse
-    var(--reward-chest-pulse-duration, 650ms)
+    var(--reward-chest-pulse-duration, 2100ms)
     cubic-bezier(0.32, 0.75, 0.16, 1)
     0s
-    var(--reward-chest-pulse-count, 3);
+    var(--reward-chest-pulse-count, 1);
   animation-fill-mode: forwards;
 }
 
@@ -677,6 +677,8 @@ body.is-reward-active .reward-overlay {
   width: min(420px, 90vw);
   align-items: flex-start;
   text-align: left;
+  background: #ffffff;
+  color: var(--text-color-dark);
 }
 
 .reward-overlay__card[hidden] {
@@ -692,6 +694,11 @@ body.is-reward-active .reward-overlay {
 
 .reward-overlay__card-text {
   margin: 0;
+  color: inherit;
+}
+
+.reward-overlay__card .text-dark {
+  color: var(--text-color-dark);
 }
 
 .reward-overlay__card-button {
@@ -755,22 +762,42 @@ body.is-reward-active .reward-overlay {
 @keyframes reward-overlay-chest-pulse {
   0% {
     transform: scaleX(var(--reward-direction)) scale(1);
+    opacity: 1;
   }
 
-  25% {
-    transform: scaleX(var(--reward-direction)) scale(1.12);
+  24% {
+    transform: scaleX(var(--reward-direction)) scale(1.14);
+    opacity: 1;
   }
 
-  50% {
-    transform: scaleX(var(--reward-direction)) scale(0.96);
+  44% {
+    transform: scaleX(var(--reward-direction)) scale(1.03);
+    opacity: 1;
   }
 
-  75% {
-    transform: scaleX(var(--reward-direction)) scale(1.2);
+  68% {
+    transform: scaleX(var(--reward-direction)) scale(1.24);
+    opacity: 1;
+  }
+
+  82% {
+    transform: scaleX(var(--reward-direction)) scale(1.15);
+    opacity: 1;
+  }
+
+  92% {
+    transform: scaleX(var(--reward-direction)) scale(1.32);
+    opacity: 1;
+  }
+
+  98% {
+    transform: scaleX(var(--reward-direction)) scale(1.34);
+    opacity: 1;
   }
 
   100% {
-    transform: scaleX(var(--reward-direction)) scale(1);
+    transform: scaleX(var(--reward-direction)) scale(0.5);
+    opacity: 0;
   }
 }
 

--- a/js/battle.js
+++ b/js/battle.js
@@ -21,8 +21,8 @@ const GEM_REWARD_WIN_AMOUNT = 5;
 const GEM_REWARD_LOSS_AMOUNT = 1;
 const GEM_REWARD_INITIAL_PAUSE_MS = 500;
 const GEM_REWARD_CARD_DELAY_MS = 400;
-const GEM_REWARD_PULSE_DURATION_MS = 650;
-const GEM_REWARD_PULSE_COUNT = 3;
+const GEM_REWARD_PULSE_DURATION_MS = 2100;
+const GEM_REWARD_PULSE_COUNT = 1;
 const GEM_REWARD_CHEST_SRC = '../images/complete/chest.png';
 const GEM_REWARD_GEM_SRC = '../images/complete/gem.png';
 const REGISTER_PAGE_URL = './register.html';
@@ -1913,13 +1913,16 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
 
-    if (!win) {
+    const hasPendingReward = Boolean(pendingGemReward);
+
+    if (!win && !hasPendingReward) {
       nextMissionBtn.textContent = 'Try Again';
       nextMissionBtn.dataset.action = 'retry';
       return;
     }
 
-    const useClaimLabel = !pendingGemReward || pendingGemReward.useClaimLabel === true;
+    const useClaimLabel =
+      !hasPendingReward || pendingGemReward.useClaimLabel === true;
     nextMissionBtn.textContent = useClaimLabel ? 'Claim Reward' : 'Continue';
     nextMissionBtn.dataset.action = 'next';
   };
@@ -3679,7 +3682,12 @@ document.addEventListener('DOMContentLoaded', () => {
         pendingGemReward = null;
       }
     } else {
-      pendingGemReward = null;
+      pendingGemReward = {
+        amount: gemRewardAmount,
+        totalAfter: updatedGemTotal,
+        useClaimLabel: true,
+        isFirstGemReward: false,
+      };
     }
 
     if (win && !hasPendingLevelUpReward) {


### PR DESCRIPTION
## Summary
- show the Claim Reward button after a loss and trigger the 1-gem reward overlay
- present the reward card on a white surface and tint all overlay backgrounds to rgba(0, 0, 0, 0.3)
- update the chest pulse animation to mirror the egg timing from the landing page

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e58cd636348329882f2951495ab19f