### PR TITLE
Fix registration redirect to standard landing

### DIFF
--- a/js/register.js
+++ b/js/register.js
@@ -2,7 +2,7 @@ const GUEST_SESSION_KEY = 'mathmonstersGuestSession';
 const PROGRESS_STORAGE_KEY = 'mathmonstersProgress';
 const DEFAULT_PLAYER_DATA_PATH = '../data/player.json';
 const STARTING_BATTLE_LEVEL = 2;
-const HOME_PAGE_PATH = '../html/home.html';
+const HOME_PAGE_PATH = '../index.html';
 
 const isPlainObject = (value) =>
   Boolean(value) && typeof value === 'object' && !Array.isArray(value);


### PR DESCRIPTION
## Summary
- redirect newly registered players to the standard index landing page so the level 2 experience matches sign-in

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5c6dcb520832987331a20696d098f