### PR TITLE
Remove background overlay from evolution flow

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -527,7 +527,6 @@ body.is-reward-active .reward-overlay {
   inset: 0;
   display: grid;
   place-items: center;
-  background: rgba(0, 0, 0, 0.3);
   pointer-events: none;
   opacity: 0;
   visibility: hidden;
@@ -574,7 +573,6 @@ body.is-reward-active .reward-overlay {
   align-items: center;
   justify-content: center;
   padding: clamp(24px, 5vmin, 48px);
-  background: rgba(0, 0, 0, 0.3);
   backdrop-filter: none;
   opacity: 0;
   visibility: hidden;


### PR DESCRIPTION
## Summary
- remove the dark background from the evolution overlay during the flow
- remove the dimming backdrop from the post-evolution overlay

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5c8a12aac8329b342c8ac142a954e