### PR TITLE
Add overlay when level one intro cards are shown

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -310,6 +310,20 @@ body:not(.is-level-one-landing) .level-one-intro {
   z-index: 4;
 }
 
+.level-one-intro__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.3);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.35s ease;
+  z-index: 1;
+}
+
+.level-one-intro__overlay.is-visible {
+  opacity: 1;
+}
+
 .level-one-intro.is-active {
   opacity: 1;
   visibility: visible;
@@ -401,6 +415,8 @@ body:not(.is-level-one-landing) .level-one-intro {
     var(--card-translate-y, 24px),
     var(--card-translate-z, 0)
   );
+  position: relative;
+  z-index: 5;
 }
 
 .level-one-intro__card.is-visible {

--- a/index.html
+++ b/index.html
@@ -183,6 +183,11 @@
 
   </main>
   <div class="level-one-intro" data-level-one-intro aria-hidden="true">
+    <div
+      class="level-one-intro__overlay"
+      data-level-one-overlay
+      aria-hidden="true"
+    ></div>
     <button
       class="level-one-intro__egg-button"
       type="button"

--- a/js/index.js
+++ b/js/index.js
@@ -615,6 +615,7 @@ const setupLevelOneIntro = ({ heroImage, beginBattle } = {}) => {
   const continueButton = introRoot?.querySelector('[data-level-one-card-continue]');
   const battleCard = introRoot?.querySelector('[data-level-one-card="battle"]');
   const battleButton = introRoot?.querySelector('[data-level-one-card-battle]');
+  const introOverlay = introRoot?.querySelector('[data-level-one-overlay]');
   const wait = (durationMs) =>
     new Promise((resolve) =>
       window.setTimeout(resolve, Math.max(0, Number(durationMs) || 0))
@@ -652,6 +653,10 @@ const setupLevelOneIntro = ({ heroImage, beginBattle } = {}) => {
     if (!card) {
       return;
     }
+    if (introOverlay) {
+      introOverlay.classList.add('is-visible');
+      introOverlay.setAttribute('aria-hidden', 'false');
+    }
     card.classList.remove('is-exiting');
     card.setAttribute('aria-hidden', 'false');
     void card.offsetWidth;
@@ -667,6 +672,18 @@ const setupLevelOneIntro = ({ heroImage, beginBattle } = {}) => {
     await wait(LEVEL_ONE_INTRO_CARD_EXIT_DURATION_MS);
     card.classList.remove('is-exiting');
     card.setAttribute('aria-hidden', 'true');
+    if (introOverlay) {
+      const hasVisibleCard = introRoot?.querySelector(
+        '.level-one-intro__card.is-visible'
+      );
+      const hasExitingCard = introRoot?.querySelector(
+        '.level-one-intro__card.is-exiting'
+      );
+      if (!hasVisibleCard && !hasExitingCard) {
+        introOverlay.classList.remove('is-visible');
+        introOverlay.setAttribute('aria-hidden', 'true');
+      }
+    }
   };
 
   const showEgg = () => {


### PR DESCRIPTION
## Summary
- add a reusable overlay element to the level one intro markup and styles
- toggle the overlay visibility when intro cards appear or disappear so the background dims consistently

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5c87df6fc8329ba1009a487f7e3b5