### PR TITLE
Preselect battle sprites on home page to prevent flicker

### DIFF
--- a/html/battle.html
+++ b/html/battle.html
@@ -55,11 +55,15 @@
     />
   </section>
   <div id="battle">
-    <img id="battle-monster" src="../images/monster/addition_mini_1.png" alt="Monster" />
+    <img
+      id="battle-monster"
+      src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=="
+      alt="Monster ready for battle"
+    />
     <img
       id="battle-shellfin"
-      src="../images/hero/shellfin_evolution_1.png"
-      alt="Shellfin"
+      src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=="
+      alt="Hero ready for battle"
     />
     <img
       id="monster-attack-effect"
@@ -106,6 +110,127 @@
       </div>
     </div>
   </div>
+    <script>
+      (() => {
+        const STORAGE_KEY = 'mathmonstersNextBattleSnapshot';
+        const globalScope = typeof window !== 'undefined' ? window : {};
+
+        const sanitizeEntry = (entry) => {
+          if (!entry || typeof entry !== 'object') {
+            return null;
+          }
+
+          const name = typeof entry.name === 'string' ? entry.name.trim() : '';
+          const sprite = typeof entry.sprite === 'string' ? entry.sprite.trim() : '';
+
+          if (!name && !sprite) {
+            return null;
+          }
+
+          return {
+            name: name || null,
+            sprite: sprite || null,
+          };
+        };
+
+        const readSnapshot = () => {
+          if (
+            globalScope.mathMonstersBattleSnapshot &&
+            typeof globalScope.mathMonstersBattleSnapshot === 'object'
+          ) {
+            return globalScope.mathMonstersBattleSnapshot;
+          }
+
+          if (typeof sessionStorage === 'undefined') {
+            return null;
+          }
+
+          try {
+            const raw = sessionStorage.getItem(STORAGE_KEY);
+            if (!raw) {
+              return null;
+            }
+
+            const parsed = JSON.parse(raw);
+            if (!parsed || typeof parsed !== 'object') {
+              return null;
+            }
+
+            const snapshot = {
+              battleLevel: Number.isFinite(parsed.battleLevel) ? parsed.battleLevel : null,
+              hero: sanitizeEntry(parsed.hero),
+              monster: sanitizeEntry(parsed.monster),
+              timestamp: Number.isFinite(parsed.timestamp) ? parsed.timestamp : Date.now(),
+            };
+
+            globalScope.mathMonstersBattleSnapshot = snapshot;
+            return snapshot;
+          } catch (error) {
+            console.warn('Unable to read stored battle snapshot before battle.', error);
+            return null;
+          }
+        };
+
+        const snapshot = readSnapshot();
+
+        const applyImage = (selector, entry, fallbackSrc, fallbackAlt) => {
+          const img = typeof selector === 'string' ? document.querySelector(selector) : null;
+          if (!img) {
+            return;
+          }
+
+          const sprite =
+            entry && typeof entry === 'object' && typeof entry.sprite === 'string'
+              ? entry.sprite.trim()
+              : '';
+          const name =
+            entry && typeof entry === 'object' && typeof entry.name === 'string'
+              ? entry.name.trim()
+              : '';
+
+          const resolvedSrc = sprite || fallbackSrc;
+          if (resolvedSrc) {
+            img.src = resolvedSrc;
+          }
+
+          const resolvedAlt = name ? `${name} ready for battle` : fallbackAlt;
+          if (resolvedAlt) {
+            img.alt = resolvedAlt;
+          }
+        };
+
+        const monsterFallback = '../images/monster/addition_mini_1.png';
+        const heroFallback = '../images/hero/shellfin_evolution_1.png';
+
+        applyImage(
+          '#battle-monster',
+          snapshot ? snapshot.monster : null,
+          monsterFallback,
+          'Monster ready for battle'
+        );
+        applyImage(
+          '#battle-shellfin',
+          snapshot ? snapshot.hero : null,
+          heroFallback,
+          'Hero ready for battle'
+        );
+
+        const applyCompleteSprite = () => {
+          applyImage(
+            '#complete-message .monster-image',
+            snapshot ? snapshot.monster : null,
+            monsterFallback,
+            'Monster ready for battle'
+          );
+        };
+
+        if (document.readyState === 'loading') {
+          document.addEventListener('DOMContentLoaded', applyCompleteSprite);
+        } else {
+          applyCompleteSprite();
+        }
+      })();
+    </script>
     <div id="question">
       <div class="question__content">
         <section class="card card--question">

--- a/html/home.html
+++ b/html/home.html
@@ -87,6 +87,9 @@
     </script>
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2" defer></script>
     <script src="../js/supabaseClient.js" defer></script>
+    <script src="../js/utils/progress.js" defer></script>
+    <script src="../js/utils/playerProfile.js" defer></script>
+    <script src="../js/loader.js" defer></script>
     <script src="../js/home.js" defer></script>
   </body>
 </html>

--- a/js/home.js
+++ b/js/home.js
@@ -1,4 +1,5 @@
 const GUEST_SESSION_KEY = 'mathmonstersGuestSession';
+const NEXT_BATTLE_SNAPSHOT_STORAGE_KEY = 'mathmonstersNextBattleSnapshot';
 
 const redirectToWelcome = () => {
   window.location.replace('welcome.html');
@@ -81,6 +82,198 @@ const attachInteractiveHandler = (element, handler) => {
   });
 };
 
+const sanitizeSnapshotEntry = (entry) => {
+  if (!entry || typeof entry !== 'object') {
+    return null;
+  }
+
+  const sanitized = {};
+  if (typeof entry.name === 'string' && entry.name.trim()) {
+    sanitized.name = entry.name.trim();
+  }
+  if (typeof entry.sprite === 'string' && entry.sprite.trim()) {
+    sanitized.sprite = entry.sprite.trim();
+  }
+
+  return Object.keys(sanitized).length > 0 ? sanitized : null;
+};
+
+const storeBattleSnapshot = (snapshot) => {
+  const sanitizedSnapshot = snapshot && typeof snapshot === 'object'
+    ? {
+        battleLevel: Number.isFinite(snapshot.battleLevel)
+          ? snapshot.battleLevel
+          : null,
+        hero: sanitizeSnapshotEntry(snapshot.hero),
+        monster: sanitizeSnapshotEntry(snapshot.monster),
+        timestamp: Date.now(),
+      }
+    : null;
+
+  if (typeof window !== 'undefined') {
+    window.mathMonstersBattleSnapshot = sanitizedSnapshot;
+  }
+
+  if (typeof sessionStorage === 'undefined') {
+    return;
+  }
+
+  try {
+    if (!sanitizedSnapshot) {
+      sessionStorage.removeItem(NEXT_BATTLE_SNAPSHOT_STORAGE_KEY);
+      return;
+    }
+
+    sessionStorage.setItem(
+      NEXT_BATTLE_SNAPSHOT_STORAGE_KEY,
+      JSON.stringify(sanitizedSnapshot)
+    );
+  } catch (error) {
+    console.warn('Unable to persist next battle snapshot from home.', error);
+  }
+};
+
+const readBattleSnapshot = () => {
+  if (typeof window !== 'undefined' && window.mathMonstersBattleSnapshot) {
+    const existing = window.mathMonstersBattleSnapshot;
+    if (existing && typeof existing === 'object') {
+      return existing;
+    }
+  }
+
+  if (typeof sessionStorage === 'undefined') {
+    return null;
+  }
+
+  try {
+    const raw = sessionStorage.getItem(NEXT_BATTLE_SNAPSHOT_STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') {
+      return null;
+    }
+
+    const snapshot = {
+      battleLevel: Number.isFinite(parsed.battleLevel) ? parsed.battleLevel : null,
+      hero: sanitizeSnapshotEntry(parsed.hero),
+      monster: sanitizeSnapshotEntry(parsed.monster),
+      timestamp: Number.isFinite(parsed.timestamp) ? parsed.timestamp : Date.now(),
+    };
+
+    if (typeof window !== 'undefined') {
+      window.mathMonstersBattleSnapshot = snapshot;
+    }
+
+    return snapshot;
+  } catch (error) {
+    console.warn('Unable to read stored battle snapshot on home.', error);
+    return null;
+  }
+};
+
+const applySnapshotToHome = (snapshot) => {
+  if (!snapshot || typeof snapshot !== 'object') {
+    return;
+  }
+
+  const hero = sanitizeSnapshotEntry(snapshot.hero);
+  const heroImg = document.querySelector('[data-hero-sprite]');
+  const heroNameEl = document.querySelector('[data-hero-name]');
+
+  if (hero && heroImg) {
+    if (hero.sprite) {
+      heroImg.src = hero.sprite;
+    }
+    if (hero.name) {
+      heroImg.alt = `${hero.name} ready for the next adventure`;
+    }
+  }
+
+  if (hero && hero.name && heroNameEl) {
+    heroNameEl.textContent = hero.name;
+  }
+};
+
+const updateHomeFromPreloadedData = () => {
+  const data = window.preloadedData;
+  if (!data || typeof data !== 'object') {
+    return;
+  }
+
+  const heroSource =
+    (data.hero && typeof data.hero === 'object' ? data.hero : null) ||
+    (data.player?.hero && typeof data.player.hero === 'object' ? data.player.hero : null);
+  const hero = heroSource ? { ...heroSource } : null;
+  const monster = data.monster && typeof data.monster === 'object' ? { ...data.monster } : null;
+
+  const heroImg = document.querySelector('[data-hero-sprite]');
+  const heroNameEl = document.querySelector('[data-hero-name]');
+  if (heroImg && hero?.sprite) {
+    heroImg.src = hero.sprite;
+  }
+  if (heroImg && hero?.name) {
+    heroImg.alt = `${hero.name} ready for the next adventure`;
+  }
+  if (heroNameEl && hero?.name) {
+    heroNameEl.textContent = hero.name;
+  }
+
+  const gemValueEl = document.querySelector('[data-hero-gems]');
+  const gemCandidates = [
+    data.progress?.gems,
+    data.player?.gems,
+    data.player?.progress?.gems,
+  ];
+  const gemCount = gemCandidates
+    .map((value) => Number(value))
+    .find((value) => Number.isFinite(value));
+  if (gemValueEl && Number.isFinite(gemCount)) {
+    gemValueEl.textContent = gemCount;
+  }
+
+  const levelCandidates = [
+    data.progress?.battleLevel,
+    data.level?.battleLevel,
+    data.player?.progress?.battleLevel,
+  ];
+  const battleLevel = levelCandidates
+    .map((value) => Number(value))
+    .find((value) => Number.isFinite(value) && value > 0);
+  const heroLevelEl = document.querySelector('[data-hero-level]');
+  if (heroLevelEl && Number.isFinite(battleLevel)) {
+    heroLevelEl.textContent = `Level ${battleLevel}`;
+  }
+
+  const progressElement = document.querySelector('[data-battle-progress]');
+  const progressUtils = window.mathMonstersProgress;
+  if (progressElement && progressUtils && Number.isFinite(battleLevel)) {
+    const experienceMap = progressUtils.normalizeExperienceMap(data.progress?.experience);
+    const requirementValue = Number(data.battle?.levelUp);
+    const earned = progressUtils.readExperienceForLevel(experienceMap, battleLevel);
+    const progressInfo = progressUtils.computeExperienceProgress(earned, requirementValue);
+
+    progressElement.setAttribute('aria-valuemax', `${progressInfo.totalDisplay}`);
+    progressElement.setAttribute('aria-valuenow', `${progressInfo.earnedDisplay}`);
+    progressElement.setAttribute(
+      'aria-valuetext',
+      `${progressInfo.earnedDisplay} of ${progressInfo.totalDisplay}`
+    );
+    progressElement.style.setProperty(
+      '--progress-value',
+      progressInfo.totalDisplay > 0 ? `${progressInfo.ratio}` : '0'
+    );
+  }
+
+  storeBattleSnapshot({
+    battleLevel: Number.isFinite(battleLevel) ? battleLevel : null,
+    hero,
+    monster,
+  });
+};
+
 const logoutAndRedirect = async () => {
   const supabase = window.supabaseClient;
   if (supabase?.auth?.signOut) {
@@ -127,8 +320,19 @@ const setupHomeLogout = () => {
   attachInteractiveHandler(logoutTrigger, handleLogout);
 };
 
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', setupHomeLogout);
-} else {
+const initializeHomePage = () => {
   setupHomeLogout();
+  applySnapshotToHome(readBattleSnapshot());
+  updateHomeFromPreloadedData();
+};
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initializeHomePage);
+} else {
+  initializeHomePage();
 }
+
+document.addEventListener('data-loaded', () => {
+  applySnapshotToHome(readBattleSnapshot());
+  updateHomeFromPreloadedData();
+});


### PR DESCRIPTION
## Summary
- load the shared loader on the home page so the next battle hero and monster sprites are prepared and persisted
- update the home experience to read the preloaded data, refresh the hero display, and store a sanitized battle snapshot
- have battle.html read the stored snapshot on load to set hero and monster sprites immediately, preventing the visible sprite swap

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e5c8127f908329bfb1793ee9025a2d