### PR TITLE
Ensure gem rewards accumulate across sessions

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -812,6 +812,32 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     }
 
+    try {
+      const storage = window.localStorage;
+      if (storage) {
+        const raw = storage.getItem(PROGRESS_STORAGE_KEY);
+        if (raw) {
+          const parsed = JSON.parse(raw);
+          if (parsed && typeof parsed === 'object') {
+            const storedGemValue = Number(parsed.gems);
+            if (Number.isFinite(storedGemValue)) {
+              return Math.max(0, Math.round(storedGemValue));
+            }
+
+            const nestedProgress = parsed.progress;
+            if (nestedProgress && typeof nestedProgress === 'object') {
+              const nestedGemValue = Number(nestedProgress.gems);
+              if (Number.isFinite(nestedGemValue)) {
+                return Math.max(0, Math.round(nestedGemValue));
+              }
+            }
+          }
+        }
+      }
+    } catch (error) {
+      console.warn('Stored progress unavailable.', error);
+    }
+
     return 0;
   };
 


### PR DESCRIPTION
## Summary
- ensure the gem total calculation falls back to stored progress so new rewards stack on previous earnings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5dd597ce48329a210f38c690ce4df