### PR TITLE
Prevent battle screen flash when leaving reward overlay

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -517,6 +517,10 @@ body.is-reward-active > *:not(.reward-overlay) {
   display: none !important;
 }
 
+body.is-reward-transitioning > *:not(.reward-overlay) {
+  visibility: hidden;
+}
+
 body.is-reward-active .reward-overlay {
   visibility: visible;
   pointer-events: auto;

--- a/js/battle.js
+++ b/js/battle.js
@@ -1823,6 +1823,9 @@ document.addEventListener('DOMContentLoaded', () => {
         if (isFirstGemReward) {
           markGemRewardIntroSeen();
         }
+        if (document.body) {
+          document.body.classList.add('is-reward-transitioning');
+        }
         if (battleGoalsMet && shouldAdvanceBattleLevel && !battleLevelAdvanced) {
           advanceBattleLevel();
         }


### PR DESCRIPTION
## Summary
- add a reward transition style that hides the battle interface before navigating away
- apply the transition class when the reward "Continue" button sends players home

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e5ded3f8b08329beaa7b6d16c90905