### PR TITLE
Add invisible Level 2 Battle 1 reset dev control

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -12,6 +12,25 @@ body {
   overflow-y: auto;
 }
 
+.dev-reset-level {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 56px;
+  height: 56px;
+  padding: 0;
+  margin: 0;
+  border: none;
+  background: transparent;
+  opacity: 0;
+  cursor: pointer;
+  z-index: 1000;
+}
+
+.dev-reset-level:focus {
+  outline: none;
+}
+
 body.is-level-one-landing {
   margin: 0;
 }

--- a/index.html
+++ b/index.html
@@ -18,6 +18,12 @@
   <link rel="stylesheet" href="css/home.css" />
 </head>
 <body class="is-preloading">
+  <button
+    class="dev-reset-level"
+    type="button"
+    data-dev-reset-level
+    aria-label="Reset progress to Level 2 Battle 1"
+  ></button>
   <div
     class="preloader app-safe-area"
     data-preloader


### PR DESCRIPTION
## Summary
- add an invisible top-right developer button on the landing page that resets progress to Level 2 Battle 1
- update landing logic to store the reset progress, clear cached profile data, and reload the page
- add styling for the hidden control so it remains clickable without affecting the layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5e0fd27f88329b41cac98a2b06bdf