### PR TITLE
Implement tutorial highlights and reward copy updates

### DIFF
--- a/css/home.css
+++ b/css/home.css
@@ -136,6 +136,9 @@ body.home-page {
 
 .home__action {
   display: inline-flex;
+  position: relative;
+  align-items: center;
+  justify-content: center;
 }
 
 .home__action-image {
@@ -143,6 +146,29 @@ body.home-page {
   width: 120px;
   height: 120px;
   object-fit: contain;
+  position: relative;
+  z-index: 1;
+}
+
+.home__actions--single {
+  justify-content: center;
+}
+
+.home__action--glow {
+  --pulsating-glow-spread: 28px;
+  --pulsating-glow-opacity: 0.7;
+  --pulsating-glow-opacity-peak: 0.95;
+  --pulsating-glow-scale-start: 0.88;
+  --pulsating-glow-scale-peak: 1.06;
+  --pulsating-glow-duration: 2600ms;
+}
+
+.home__action--glow-sword {
+  --pulsating-glow-color: rgba(255, 255, 255, 0.75);
+}
+
+.home__action--glow-shop {
+  --pulsating-glow-color: rgba(255, 214, 120, 0.85);
 }
 
 @keyframes hero-swim {


### PR DESCRIPTION
## Summary
- highlight the home battle button and hide/show the shop action for the level 2 tutorial battles
- style the home actions with reusable glow utilities to support the tutorial guidance
- refresh gem reward card messaging with context-aware copy that references the shop

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5e0614b488329968ab2f418657f2d